### PR TITLE
Add src/runtime/devmode.r

### DIFF
--- a/src/h/fdefs.h
+++ b/src/h/fdefs.h
@@ -31,6 +31,9 @@ FncDefV(constructor)
 FncDef(copy,1)
 FncDef(cos,1)
 FncDef(cset,1)
+#ifdef DEVMODE
+FncDef(dbgbrk,0)
+#endif /* DEVMODE */
 FncDef(delay,1)
 FncDefV(delete)
 FncDefV(detab)

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -34,7 +34,7 @@ XOBJS=	xcnv.$(O) xdata.$(O) xdef.$(O) xerrmsg.$(O) xextcall.$(O) xfconv.$(O) xfl
 	xomisc.$(O) xoref.$(O) xoset.$(O) xovalue.$(O) xralc.$(O) xrcoexpr.$(O) xrcomp.$(O) xrdb.$(O)\
 	xrdebug.$(O) xrlocal.$(O) xrlrgint.$(O) xrmemmgt.$(O) xrmisc.$(O) xrstruct.$(O) xrsys.$(O)\
 	xrgfxsys.$(O) xrwinsys.$(O) xrwindow.$(O) xfxtra.$(O) xrwinrsc.$(O) xrposix.$(O) xrmsg.$(O)\
-	xraudio.$(O)
+	xraudio.$(O) xdevmode.$(O)
 
 # These files are affected by NTConsole on Windows
 CONSOLEOBJS=  xrwindow.$(O) xrsys.$(O) xinit.$(O) xfwindow.$(O) xfsys.$(O) xrwinsys.$(O) xkeyword.$(O)
@@ -129,7 +129,7 @@ RTLSRC= cnv.r data.r def.r errmsg.r fconv.r fdb.r fload.r fmath.r\
 	oref.r oset.r ovalue.r ralc.r rcoexpr.r rcomp.r\
 	rdb.r rdebug.r rlrgint.r rlocal.r rmemmgt.r rmisc.r rstruct.r\
 	rsys.r rwinrsc.r rgfxsys.r rwinsys.r rwindow.r fxtra.r raudio.r\
-	rposix.r rmsg.r
+	rposix.r rmsg.r devmode.r
 
 comp_all comp_all_uniconc: update_rev
 	$(MAKE) db_lib
@@ -151,7 +151,7 @@ rt.a: ../common/rswitch.$(O) ../common/long.$(O) ../common/time.$(O) ../common/m
       keyword.$(O) lmisc.$(O) oarith.$(O) oasgn.$(O) ocat.$(O) ocomp.$(O) omisc.$(O) oref.$(O) oset.$(O)\
       ovalue.$(O) ralc.$(O) rcoexpr.$(O) rcomp.$(O) rdebug.$(O) rlrgint.$(O) rlocal.$(O) rmemmgt.$(O)\
       rmisc.$(O) rstruct.$(O) rsys.$(O) rwinrsc.$(O) rgfxsys.$(O) rwinsys.$(O) fxtra.$(O) raudio.$(O)\
-      rmsg.$(O) rposix.$(O) rwindow.$(O) rdb.$(O)\
+      rmsg.$(O) rposix.$(O) rwindow.$(O) rdb.$(O) devmode.$(O)\
       ../common/xwindow.$(O) ../common/alloc.$(O) $(COMMONDRAWSTRING)
 	$(CMNT) @echo [ICONC RTT] "-A -O ... # rt.a: "
 	$(RTT) $(DASHS) -A -O "../common/rswitch.$(O) ../common/long.$(O) ../common/time.$(O) ../common/mlocal.$(O) ../common/xwindow.$(O) ../common/alloc.$(O) $(COMMONDRAWSTRING)"

--- a/src/runtime/devmode.r
+++ b/src/runtime/devmode.r
@@ -1,0 +1,29 @@
+/*
+ * File: devmode.r
+ *
+ * This file is a home for code that is only intended to be present
+ * when the --enable-devmode option has been supplied to configure.
+ *
+ * If any function is thought to be useful enough to be present in
+ * the standard (non-developer) configuration, we'll probably change
+ * its name and move it somewhere else.
+ */
+
+#ifdef DEVMODE
+
+/* Used in test code where the criterion for a break point is complicated.   */
+/* Easier to write code and call dbgbrkpoint() with a break on this function */
+int dbgbrkpoint()
+{
+  return 0;
+}
+
+"dbgbrk() - allow a convenient debugger break point called from Unicon code"
+function{1} dbgbrk()
+abstract {  return null }
+body {
+  return nulldesc;  /* Set a break point on this line or use "-n Zdbgbrk" */
+}
+end
+
+#endif /* DEVMODE */


### PR DESCRIPTION
devmode.r is a file to store code used during development that is not
intended to be available if the system is configured  without the
--enable-devmode option.