### PR TITLE
Add _DEVMODE unicon preprocessor predefined symbol

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -4747,7 +4747,8 @@ platforms. These symbols include:
 \_MS\_WINDOWS\ \ \ \ \ \ MS Windows\\
 \_WIN32\ \ \ \ \ \ \ \ \ \ \ Win32\\
 \_PRESENTATION\_MGR\ \ \ \ Presentation Manager\\
-\_DOS\_FUNCTIONS\ \ \ \ \ \ MS-DOS extensions
+\_DOS\_FUNCTIONS\ \ \ \ \ \ MS-DOS extensions\\
+\_DEVMODE\ \ \ \ \ \ \ \ developer mode
 
 \section{Execution Errors}
 

--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -190,3 +190,7 @@
 #ifdef OVLD
    Feature(1, "_OVLD", "operator overloading")
 #endif					/* OVLD */
+
+#ifdef DEVMODE
+   Feature(1, "_DEVMODE", "developer mode")
+#endif					/* DEVMODE */

--- a/uni/unicon/preproce.icn
+++ b/uni/unicon/preproce.icn
@@ -85,6 +85,7 @@ procedure predefs()
 	    "Audio":"_AUDIO"
 	    "Voice Over IP":"_VOIP"
 	    "operator overloading":"_OVLD"
+	    "developer mode":"_DEVMODE"
 	}] := "1"
     }
 


### PR DESCRIPTION
_DEVMODE is defined by the preprocessor when unicon is configured with
--enable-devmode. It enables unicon programs to use $ifdef _DEVMODE to
do different things if the system has been built in developer mode
(e.g. call built-in functions that are not available normally).