### PR TITLE
Adjust Unicon revision to correspond to what SVN's revision would hav…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ update_rev:
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
-	   $(CC) plus4.c -o plus4; \
+	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
 	   rm plus4 plus4.c;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ VERSION=13.1
 name=unspecified
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
-REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -334,9 +333,25 @@ distclean2: clean
 #config.status: $(srcdir)/configure 
 #	$(SHELL) ./config.status --recheck
 
+#--------------------------------------------------------------------------------
+# Calculate the revision and store it in src/h/revision.h
+#
+# git's REV count is adjusted to correspond to what the revision number
+# would have been under SVN (SVN revisions 1,2,4 and 1497 don't exist,
+# so git's revision count is 4 less than SVN's revision number).
+# The easiest portable way to add 4 is to write a small C program (!) to do it.
 update_rev:
-	@if test ! -z $(REPO_REV) ; then \
-	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
+	@if test ! -z $(REPO_REV_COUNT) ; then \
+	   echo "#include <stdio.h>" > plus4.c; \
+	   echo "int main(void)" >> plus4.c; \
+	   echo "{" >> plus4.c; \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
+	            $(REPO_REV_COUNT) "+ 4," \
+	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
+	   echo "}" >> plus4.c; \
+	   $(CC) plus4.c -o plus4; \
+	   ./plus4 > src/h/revision.h; \
+	   rm plus4 plus4.c;\
 	fi
 
 MV=2

--- a/Makefile.in
+++ b/Makefile.in
@@ -349,7 +349,7 @@ update_rev:
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
-	   $(CC) plus4.c -o plus4; \
+	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
 	   rm plus4 plus4.c;\
 	fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,6 @@ VERSION=13.1
 name=unspecified
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
-REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -334,9 +333,25 @@ distclean2: clean
 #config.status: $(srcdir)/configure 
 #	$(SHELL) ./config.status --recheck
 
+#--------------------------------------------------------------------------------
+# Calculate the revision and store it in src/h/revision.h
+#
+# git's REV count is adjusted to correspond to what the revision number
+# would have been under SVN (SVN revisions 1,2,4 and 1497 don't exist,
+# so git's revision count is 4 less than SVN's revision number).
+# The easiest portable way to add 4 is to write a small C program (!) to do it.
 update_rev:
-	@if test ! -z $(REPO_REV) ; then \
-	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
+	@if test ! -z $(REPO_REV_COUNT) ; then \
+	   echo "#include <stdio.h>" > plus4.c; \
+	   echo "int main(void)" >> plus4.c; \
+	   echo "{" >> plus4.c; \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
+	            $(REPO_REV_COUNT) "+ 4," \
+	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
+	   echo "}" >> plus4.c; \
+	   $(CC) plus4.c -o plus4; \
+	   ./plus4 > src/h/revision.h; \
+	   rm plus4 plus4.c;\
 	fi
 
 MV=2


### PR DESCRIPTION
…e been.

SVN revisions 1,2,4, and 1497 don't exist, so the revision number calculated
by "git rev-list --count" is 4 less than what the SVN revision would have been.