### PR TITLE
Remove a fossil reference to chapter 18 from the book

### DIFF
--- a/doc/book/string.tex
+++ b/doc/book/string.tex
@@ -820,11 +820,14 @@ Parsers for any CFG can be written in this way. However, this is an
 expensive way to do it! Unicon's
 expression evaluation will try all possible derivations
 trying to match a string. This is not a good way to parse, especially
-if the grammar is amenable to lookahead methods. A more efficient
-method is given in the next section. For serious parsing jobs, Chapter
-18 shows how to use the Unicon versions of the standard
-industrial-strength lexical analyzer and parser generation tools, lex
-and yacc.
+if the grammar is amenable to lookahead methods.
+%% The chapter 18 referred to here is lexyacc.tex (which was removed
+%% in January 2013).
+%% A more efficient
+%% method is given in the next section. For serious parsing jobs, Chapter
+%% 18 shows how to use the Unicon versions of the standard
+%% industrial-strength lexical analyzer and parser generation tools, lex
+%% and yacc.
 
 \subsection*{Doing It Better}
 


### PR DESCRIPTION
The chapter referred to is in lexyacc.tex, which was removed from
the Unicon book in Jan 2013 (commit 86fb4aad). It is still in the
distribution and will be incorporated into a new document.