### PR TITLE
Fix a problem with non alphanumeric options.

### DIFF
--- a/ipl/procs/options.icn
+++ b/ipl/procs/options.icn
@@ -182,9 +182,9 @@ procedure options(arg,optstring,errproc)
                optname := (tab(many(optcs)) | break)
                if \stripm & \opttable["-" || optname] then {
                   return errproc("duplicate option -" || optname)
-               }               
-            }
-         } else { optname := move(1) }
+               }
+            } else { optname := move(1) | break }
+         } else { optname := move(1) | break }
 
          tab(many(' '))
          opttype := tab(any('!:+.')) | "!"


### PR DESCRIPTION
The code used to overwrite the value of the _previous_ option
to a non alphanumeric option. (So an option string like
"-wait+ -?" ended up being parsed as "-wait! -?").