### PR TITLE
IB: Prevent em-dashes from interfering with index term matching.

### DIFF
--- a/doc/ib/p1-exprEval.tex
+++ b/doc/ib/p1-exprEval.tex
@@ -1198,7 +1198,7 @@ result. Without this termination condition, an expression such as
 
 \iconline{ \>\ \ |upto(c, s) }
 
-\noindent would never return if \texttt{upto()} failed--expression
+\noindent would never return if \texttt{upto()} failed{---}expression
 evaluation would vanish into a {\textquotedbl}black
 hole.{\textquotedbl} Expressions that produce results at one time but
 not at another also are useful. For example,
@@ -1220,7 +1220,7 @@ L1:\\
 \>\>esusp
 \end{iconcode}
 
-The {\textquotedbl}black hole{\textquotedbl} here is evident---if
+The {\textquotedbl}black hole{\textquotedbl} here is evident{---}if
 \textit{expr} fails, it is evaluated again and there is no way out.
 
 The termination condition is handled by an instruction that changes
@@ -1273,7 +1273,7 @@ In the limitation control structure,
 \ \ \ \ \ \ lsusp}
 
 If \textit{expr2 }succeeds, its result is on the top of the stack. The
-limit instruction checks this result to be sure that it is legal---an
+limit instruction checks this result to be sure that it is legal{---}an
 integer greater than or equal to zero. If it is not an integer, an
 attempt is made to convert it to one. If the limit value is zero,
 limit fails. Otherwise, limit creates an expression frame marker with
@@ -1615,7 +1615,7 @@ exclusive alternation.
 
 \textbf{9.4} The expression \texttt{read(f)} is an example of an expression
 that may produce result at one time and fail at another. This is
-possible because of a side effect of evaluating it---changing the
+possible because of a side effect of evaluating it{---}changing the
 position in the file f. Give an example of an expression that may fail
 at one time and produce a result at a subsequent time.
 

--- a/doc/ib/p1-iconOverview.tex
+++ b/doc/ib/p1-iconOverview.tex
@@ -2078,7 +2078,7 @@ In one sense, the absence of type declarations simplifies the
 implementation: there is not much that can be done about types during
 program translation (compilation), and some of the work that is
 normally performed by conventional compilers can be avoided. The
-problems do not go away, however -- they just move to another part of
+problems do not go away, however --- they just move to another part of
 the implementation, since run-time type checking is
 required. Automatic type conversion according to context goes
 hand-in-hand with type checking.
@@ -2088,7 +2088,7 @@ hand-in-hand with type checking.
 during program execution, rather than being declared, the space for
 them must be allocated as needed at run time. This implies, in turn,
 some mechanism for reclaiming space that has been allocated but which
-is no longer needed--{\textquotedbl}garbage collection.{\textquotedbl}
+is no longer needed{---}{\textquotedbl}garbage collection.{\textquotedbl}
 These issues are complicated by the diversity of types and sizes of
 objects, the lack of any inherent size limitations, and the
 possibility of pointer loops in circular structures.
@@ -2192,7 +2192,7 @@ of string and structure operations. One of Icon's notable
 characteristics is the freedom from translation-time constraints and
 the ability to specify and change the meanings of operations at run
 time. This run-time flexibility is valuable to the programmer, but it
-places substantial burdens on the implementation---and also makes it
+places substantial burdens on the implementation{---}and also makes it
 interesting.
 
 At the top level, there is the question of how actually to carry out

--- a/doc/ib/p1-procs-coexprs.tex
+++ b/doc/ib/p1-procs-coexprs.tex
@@ -697,7 +697,7 @@ the activator indicates the absence of a valid C state.
 
 
 \textbf{Co-Expression Activation.} As mentioned previously,
-\texttt{coact} and \texttt{coret} perform many similar functions--both
+\texttt{coact} and \texttt{coret} perform many similar functions{---}both
 save current state information, establish new state information, and
 activate another co-expression.  The current i-state variables are
 saved in the current co-expression block, and new ones are established

--- a/doc/ib/p1-sets-tables.tex
+++ b/doc/ib/p1-sets-tables.tex
@@ -711,7 +711,7 @@ change, and even its location in memory may change as the result of
 garbage collection. For a list, its only time-invariant attribute is
 its type.
 
-This presents a dilemma--the type of such a value can be used as its
+This presents a dilemma{---}the type of such a value can be used as its
 hash number, but if that is done, all values of that type are in the
 same slot and have the same hash number. Lookup for these values
 degenerates to a linear search.  The alternative is to add some

--- a/doc/ib/p1-strings-csets.tex
+++ b/doc/ib/p1-strings-csets.tex
@@ -9,7 +9,7 @@ strings and the total amount of string data often are
 large. Therefore, it is important to be able to store and access
 strings efficiently.
 
-Icon has many operations on strings---nearly fifty of them. Some
+Icon has many operations on strings{---}nearly fifty of them. Some
 operations, such as determining the size of a string, are performed
 frequently. The efficiency of these operations is an important issue
 and influences, to a considerable extent, how strings are represented.
@@ -33,7 +33,7 @@ strings. Substrings tend to occur frequently, especially in programs
 that analyze (as opposed to synthesize) strings.
 
 
-Strings in Icon are atomic---there are no operations in Icon that
+Strings in Icon are atomic{---} there are no operations in Icon that
 change the characters in existing strings. This aspect of Icon is not
 obvious; in fact, there are operations that appear to change the
 characters in strings. The atomic nature of string operations in Icon
@@ -81,7 +81,7 @@ representation described in the last chapter. The qualifier provides
 information, external to the string itself, that delimits the string
 by the address of its first character and its length. Such a
 representation makes the computation of substrings fast and
-simple---and, of course, determining the length of a string is
+simple{---}and, of course, determining the length of a string is
 fast and independent of its length.
 
 Note that C-style strings serve perfectly well as Icon-style strings;

--- a/doc/ib/p1-values.tex
+++ b/doc/ib/p1-values.tex
@@ -191,7 +191,7 @@ As explained previously, the \texttt{n} flag occurs in this and all other
 descriptors that are not qualifiers so that strings can be easily and
 unambiguously distinguished from all other kinds of values. The value
 in the v-word could be any constant value, but zero is useful and
-easily identified---and suggests
+easily identified{---}and suggests
 {\textquotedbl}null.{\textquotedbl}
 
 In the diagrams that follow, a null block-pointer is represented as
@@ -878,10 +878,10 @@ qualifier originally.
 \textsc{Retrospective}: Descriptors provide a uniform way of
 representing Icon values and variables. Since descriptors for all
 types of data are the same size, there are no problems with assigning
-different types of values to a variable---they all fit.
+different types of values to a variable{---}they all fit.
 
 The importance of strings is reflected in the separation of
-descriptors into two classes---qualifiers and nonqualifiers---by the \texttt{n}
+descriptors into two classes{---}qualifiers and nonqualifiers{---}by the \texttt{n}
 flag. The advantages of the qualifier representation for strings are
 discussed in Chapter 5.
 


### PR DESCRIPTION
IdxGen allows minuses as part of a word (so "virtual-machine" is
treated as a single word). But a naked em-dash without a space
separating the two words effectively concatenates the words, so in
    Strings in Icon are atomic---there are no operations ...
the 5th word in the sentence is "atomic---there" from idxGen's
point of view, thus defeating a match like
    "(S|s)tring(|s)+5+(A|a)tomic(|ity)".
The solution is to change "atomic---there" into "atomic{---}there".