### PR TITLE
Fix compile error in 32 bit code.

### DIFF
--- a/src/runtime/rstruct.r
+++ b/src/runtime/rstruct.r
@@ -1714,7 +1714,7 @@ struct descrip listtoarray(dptr l)
 #ifdef DescriptorDouble
                *rp++ = bp->Lelem.lslots[j].vword.realval;
 #else
-               *rp++ = (struct b_real *)(bp->Lelem.lslots[j].vword.bptr)->realval;
+               *rp++ = ((struct b_real *)(bp->Lelem.lslots[j].vword.bptr))->realval;
 #endif /* DescriptorDouble */
              }
            }


### PR DESCRIPTION
rstruct.r had an error (brackets missing around a cast) that caused
a compilation failure.