### PR TITLE
Fix GC deadlock in initial expressions.

### DIFF
--- a/src/runtime/interp.r
+++ b/src/runtime/interp.r
@@ -2054,7 +2054,7 @@ L_agoto:
 
 	 case Op_Init:		/* initial */
 #ifdef Concurrent
-	    MUTEX_LOCKID_ALWAYS(MTX_INITIAL);
+	    MUTEX_LOCKID_CONTROLLED_ALWAYS(MTX_INITIAL);
             if (ipc.op[-1] == Op_Agoto) {
 	       MUTEX_UNLOCKID_ALWAYS(MTX_INITIAL);
 	       goto L_agoto; 


### PR DESCRIPTION
If a thread that is in an initial expression causes a garbage collection
whilst another thread is waiting to execute an initial expression then a
deadlock occurs (because the waiting thread never enters the GC queue,
so the GC thread hangs waiting for all threads to be stopped and
NARthreads to drop to 0).