### PR TITLE
IB: Correct previous list-element ptr in list diagrams.

### DIFF
--- a/doc/ib/appA.tex
+++ b/doc/ib/appA.tex
@@ -167,13 +167,15 @@ circular queues. See Chapter 6 for details. An example is the list
 \put(-10,136){\parbox{100pt}{Unicon replaces the null pointer used by Icon
 with a pointer to the list header block.}}
 \multiput(100,136)(4,0){23}{\line(1,0){2}}
+\multiput(100,152)(4,0){24}{\line(1,0){2}}
 \put(370,136){\line(1,0){50}}
+\put(380,152){\line(1,0){40}}
 \put(420,136){\line(0,1){324}}
 \put(420,460){\vector(-1,0){150}}
 \put(270,460){\line(-1,0){154}}
 \put(116,460){\vector(0,-1){20}}
 }
-\put(130,144){\nullptrbox{previous list-element block}}
+\put(130,144){\hdrnullptrbox{previous list-element block}}
 \begin{picture}(0,0)(0,32)
 \put(130,192){\blkbox{0}{3}}
 \put(130,192){\rightboxlabels{first slot used}{number of slots used}}

--- a/doc/ib/p1-lists.tex
+++ b/doc/ib/p1-lists.tex
@@ -190,13 +190,15 @@ of evaluating
 \put(-10,136){\parbox{100pt}{Unicon replaces the null pointer used by Icon
     with a pointer to the list header block.}}
 \multiput(100,136)(4,0){24}{\line(1,0){2}}
+\multiput(100,152)(4,0){24}{\line(1,0){2}}
 \put(370,136){\line(1,0){50}}
+\put(380,152){\line(1,0){40}}
 \put(420,136){\line(0,1){214}}
 \put(420,350){\vector(-1,0){150}}
 \put(270,350){\line(-1,0){154}}
 \put(116,350){\vector(0,-1){22}}
 }
-\put(130,144){\nullptrbox{previous list-element block}}
+\put(130,144){\hdrnullptrbox{previous list-element block}}
 \begin{picture}(0,0)(0,32)
 \put(130,192){\blkbox{0}{1}}
 \put(130,192){\rightboxlabels{first slot used}{number of slots used}}
@@ -313,7 +315,7 @@ The effect on the list-header block and list-element block is:
 \put(130,96){\trboxlabel{slot 0}}
 \end{picture}
 \put(130,160){\hdrnullptrbox{next list-element block}}
-\put(130,176){\nullptrbox{previous list-element block}}
+\put(130,176){\hdrnullptrbox{previous list-element block}}
 \put(130,192){\blkbox{0}{2}}
 \put(130,192){\rightboxlabels{first slot used}{number of slots used}}
 \put(130,224){\blkbox{60}{4}}
@@ -329,6 +331,7 @@ The effect on the list-header block and list-element block is:
 \put(0,288){\brboxlabel{number of elements in the list}}
 {\color{blue}
 \put(366,168){\line(1,0){60}}
+\put(376,184){\line(1,0){50}}
 \put(426,168){\line(0,1){160}}
 \put(426,328){\vector(-1,0){130}}
 \put(296,328){\line(-1,0){316}}
@@ -366,7 +369,7 @@ list-element block. The result is
 \put(130,96){\trboxlabel{slot 0}}
 \end{picture}
 \put(130,160){\hdrnullptrbox{next list-element block}}
-\put(130,176){\nullptrbox{previous list-element block}}
+\put(130,176){\hdrnullptrbox{previous list-element block}}
 \put(130,192){\blkbox{3}{3}}
 \put(130,192){\rightboxlabels{first slot used}{number of slots used}}
 \put(130,224){\blkbox{60}{4}}
@@ -382,6 +385,7 @@ list-element block. The result is
 \put(0,288){\brboxlabel{number of elements in the list}}
 {\color{blue}
 \put(366,168){\line(1,0){60}}
+\put(376,184){\line(1,0){50}}
 \put(426,168){\line(0,1){160}}
 \put(426,328){\vector(-1,0){130}}
 \put(296,328){\line(-1,0){316}}
@@ -680,7 +684,7 @@ block is removed from the chain:
 \put(130,96){\dvbox{integer}{n}{4}}
 \put(130,96){\trboxlabel{slot 0}}
 \put(130,128){\hdrnullptrbox{next list-element block}}
-\put(130,144){\nullptrbox{previous list-element block}}
+\put(130,144){\hdrnullptrbox{previous list-element block}}
 %% \put(130,128){\dvbox{null}{n}{0}}
 %% \put(130,128){\trboxlabel{next list-element block}}
 %% \put(130,160){\dvbox{null}{n}{0}}
@@ -794,7 +798,7 @@ points indirectly to the descriptor for the value 5:
 \put(140,96){\dvbox{integer}{n}{4}}
 \put(140,96){\trboxlabel{slot 0}}
 \put(140,128){\hdrnullptrbox{next list-element block}}
-\put(140,144){\nullptrbox{previous list-element block}}
+\put(140,144){\hdrnullptrbox{previous list-element block}}
 \put(140,160){\blkbox{3}{3}}
 \put(140,160){\rightboxlabels{first slot used}{number of slots used}}
 \put(140,192){\blkbox{60}{4}}


### PR DESCRIPTION
The previous list-element ptr was drawn with a null terminator.
In Unicon, it terminates with a ptr to the list header block.