### PR TITLE
Adjust Unicon revision to correspond to SVN's revision (take 2).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,13 +345,13 @@ update_rev:
 	   echo "#include <stdio.h>" > plus4.c; \
 	   echo "int main(void)" >> plus4.c; \
 	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\\\n\"," \
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
 	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c;\
+	   rm plus4 plus4.c; \
 	fi
 
 MV=2

--- a/Makefile.in
+++ b/Makefile.in
@@ -345,13 +345,13 @@ update_rev:
 	   echo "#include <stdio.h>" > plus4.c; \
 	   echo "int main(void)" >> plus4.c; \
 	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\\\n\"," \
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
 	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c;\
+	   rm plus4 plus4.c; \
 	fi
 
 MV=2

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -159,10 +159,11 @@ rt.a: ../common/rswitch.$(O) ../common/long.$(O) ../common/time.$(O) ../common/m
 	-(test -f ../../NoRanlib) || (ranlib ../../bin/rt.a)
 
 update_rev:
-	@if test ! -z $(REPO_REV) ; then \
-	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > ../h/revision.h; \
-	elif test ! -f ../h/revision.h ; then \
-	   echo "#define REPO_REVISION \"0\"" > ../h/revision.h; \
+	@if test ! -f ../h/revision.h ; then \
+		if test ! -z $(REPO_REV); then \
+	        echo "#define REPO_REVISION \"$(REPO_REV)\"" > ../h/revision.h; else \
+	        echo "#define REPO_REVISION \"0\"" > ../h/revision.h; \
+	    fi \
 	fi
 
 keyword.$(O) : keyword.r $(HDRS) ../h/feature.h ../h/revision.h


### PR DESCRIPTION
The calculation of the SVN revision number (stored in src/h/revision.h)
was being overridden by the update_rev target in src/runtime/Makefile.
That target is now active only if the file src/h/revision.h does not exist.
A missing newline has been added to src/h/revision.h. and the file is now
removed by the Pure target (since it's a configured file).