### PR TITLE
Revert "Adjust Unicon revision to correspond to SVN's revision (take …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,13 +345,13 @@ update_rev:
 	   echo "#include <stdio.h>" > plus4.c; \
 	   echo "int main(void)" >> plus4.c; \
 	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\\\n\"," \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
 	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c; \
+	   rm plus4 plus4.c;\
 	fi
 
 MV=2

--- a/Makefile.in
+++ b/Makefile.in
@@ -345,13 +345,13 @@ update_rev:
 	   echo "#include <stdio.h>" > plus4.c; \
 	   echo "int main(void)" >> plus4.c; \
 	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\\\n\"," \
+	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
 	            $(REPO_REV_COUNT) "+ 4," \
 	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
 	   echo "}" >> plus4.c; \
 	   gcc plus4.c -o plus4; \
 	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c; \
+	   rm plus4 plus4.c;\
 	fi
 
 MV=2

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -159,11 +159,10 @@ rt.a: ../common/rswitch.$(O) ../common/long.$(O) ../common/time.$(O) ../common/m
 	-(test -f ../../NoRanlib) || (ranlib ../../bin/rt.a)
 
 update_rev:
-	@if test ! -f ../h/revision.h ; then \
-		if test ! -z $(REPO_REV); then \
-	        echo "#define REPO_REVISION \"$(REPO_REV)\"" > ../h/revision.h; else \
-	        echo "#define REPO_REVISION \"0\"" > ../h/revision.h; \
-	    fi \
+	@if test ! -z $(REPO_REV) ; then \
+	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > ../h/revision.h; \
+	elif test ! -f ../h/revision.h ; then \
+	   echo "#define REPO_REVISION \"0\"" > ../h/revision.h; \
 	fi
 
 keyword.$(O) : keyword.r $(HDRS) ../h/feature.h ../h/revision.h


### PR DESCRIPTION
…2)."

This reverts commit f0b745f81fca351873ad0f09c9b2aba06f4e104e.

   Reasons:
     1- It breaks the build on some platforms (fedora)
     2- Updating the revision only when building from the top level
        directory runs the risk of having a stale revision number
        when rebuilding the runtime directly from its directory