### PR TITLE
Revert "Adjust Unicon revision to correspond to what SVN's revision w…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 #  configuration parameters
 VERSION=13.1
 name=unspecified
-REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
+
+REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
@@ -337,6 +338,8 @@ distclean2: clean
 update_rev:
 	@if test ! -z $(REPO_REV) ; then \
 	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
+	elif test ! -f ../h/revision.h ; then \
+	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
 
 MV=2

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ VERSION=13.1
 name=unspecified
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
+REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -333,25 +334,9 @@ distclean2: clean
 #config.status: $(srcdir)/configure 
 #	$(SHELL) ./config.status --recheck
 
-#--------------------------------------------------------------------------------
-# Calculate the revision and store it in src/h/revision.h
-#
-# git's REV count is adjusted to correspond to what the revision number
-# would have been under SVN (SVN revisions 1,2,4 and 1497 don't exist,
-# so git's revision count is 4 less than SVN's revision number).
-# The easiest portable way to add 4 is to write a small C program (!) to do it.
 update_rev:
-	@if test ! -z $(REPO_REV_COUNT) ; then \
-	   echo "#include <stdio.h>" > plus4.c; \
-	   echo "int main(void)" >> plus4.c; \
-	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
-	            $(REPO_REV_COUNT) "+ 4," \
-	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
-	   echo "}" >> plus4.c; \
-	   gcc plus4.c -o plus4; \
-	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c;\
+	@if test ! -z $(REPO_REV) ; then \
+	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
 	fi
 
 MV=2

--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,8 @@
 #  configuration parameters
 VERSION=13.1
 name=unspecified
-REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
+
+REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
@@ -337,6 +338,8 @@ distclean2: clean
 update_rev:
 	@if test ! -z $(REPO_REV) ; then \
 	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
+	elif test ! -f ../h/revision.h ; then \
+	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
 
 MV=2

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,7 @@ VERSION=13.1
 name=unspecified
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
+REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -333,25 +334,9 @@ distclean2: clean
 #config.status: $(srcdir)/configure 
 #	$(SHELL) ./config.status --recheck
 
-#--------------------------------------------------------------------------------
-# Calculate the revision and store it in src/h/revision.h
-#
-# git's REV count is adjusted to correspond to what the revision number
-# would have been under SVN (SVN revisions 1,2,4 and 1497 don't exist,
-# so git's revision count is 4 less than SVN's revision number).
-# The easiest portable way to add 4 is to write a small C program (!) to do it.
 update_rev:
-	@if test ! -z $(REPO_REV_COUNT) ; then \
-	   echo "#include <stdio.h>" > plus4.c; \
-	   echo "int main(void)" >> plus4.c; \
-	   echo "{" >> plus4.c; \
-	   echo "   printf(\"#define REPO_REVISION \\\"%d-%s\\\"\"," \
-	            $(REPO_REV_COUNT) "+ 4," \
-	            \"$(REPO_REV_HASH)\" ");" >> plus4.c; \
-	   echo "}" >> plus4.c; \
-	   gcc plus4.c -o plus4; \
-	   ./plus4 > src/h/revision.h; \
-	   rm plus4 plus4.c;\
+	@if test ! -z $(REPO_REV) ; then \
+	   echo "#define REPO_REVISION \"$(REPO_REV)\"" > src/h/revision.h; \
 	fi
 
 MV=2

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -5,10 +5,10 @@ include ../../Makedefs
 
 #REPO_REV="$(shell LC_ALL=C svnversion -cn ../../ | sed -e "s/.*://" -e "s/\([0-9]*\).*/\1/" | grep "[0-9]" )"
 
-REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --count HEAD )"
+
+REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
-
 
 HDRS = ../h/define.h ../h/config.h ../h/typedefs.h ../h/monitor.h\
 	  ../h/proto.h ../h/cstructs.h ../h/cpuconf.h ../h/grttin.h\


### PR DESCRIPTION
…ould have been."

This reverts commit 7295925164b18d83d6a4f0e0ba3c01dd7f710e3a.

There is no need to align with svn revision numbers. All commits are within git context now.
The revision number should reflect git's history, not svn history.