### PR TITLE
Fix iconc C compiler driver to pass the correct linker option on MacOS.

### DIFF
--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -328,8 +328,13 @@ Deliberate Syntax Error
 #endif					/* NTGCC */
 
 #if UNIX
+#ifdef MacOS
+   /* needs to be more precise, add a HAVE_LIBDL or some such */
+   buf = growcat(buf, &buflen, 1, " -ldl -Wl,-export_dynamic ");
+#else
    /* needs to be more precise, add a HAVE_LIBDL or some such */
    buf = growcat(buf, &buflen, 1, " -ldl -export-dynamic ");
+#endif					/* MacOS */
 #endif					/* UNIX */
 
 #endif					/* UNIX || NTGCC */


### PR DESCRIPTION
The --export-dynamic linker option (used everywhere else) is
called -export_dynamic on macOS. No, I don't know why either.