### PR TITLE
Uni lib

### DIFF
--- a/doc/ib/appH.tex
+++ b/doc/ib/appH.tex
@@ -534,85 +534,100 @@ ZPIPE & 9 & uncompress .Z files via a piped process (libXpm) \\
 
 \newpage
 \section{A Bestiary of Unicon Releases}
-The criterion used here for identifying which revision constitutes a release,
-rather than merely being an incremental update, is that the version or the
-version date reported by the Unicon compiler changed. This may or may not
-identify the actual revision which was thought, at the time, to be the release
--- but it should be close enough.
+The table below identifies the points at which the version details changed
+and also (as far as is practicable) the points at which a binary release was
+made. The table also contains suggestions to tag the historical releases.
+Windows Date is the Version Date reported by the Windows binary.
 
 \vspace{0.5cm}
+{\small
+{\renewcommand{\arraystretch}{1.05} % Reduce line spacing to fit on two pages
 %
 % Define the table furniture.
 %
 \tablefirsthead{\hline%
-  {\bf SVN rev} & {\bf git hash} & {\bf Version}%
-  & {\bf Version Date} & {\bf git tag}~~~~~~\\\hline}
-\tablehead{%
-  {\bf SVN rev} & {\bf git hash} & {\bf Version} &%
-  {\bf Version Date} & {\bf git tag}~~~~~\\\hline}
+  {\bf SVN} & {\bf git} & {\bf Version}%
+  & {\bf Version} & {\bf Windows} & {\bf git}~~~~~~\\
+  {\bf rev} & {\bf hash} &
+  & {\bf Date} & {\bf Date} & {\bf tag}~~~~~~\\\hline}
+\tablehead{\hline%
+  {\bf SVN} & {\bf git} & {\bf Version}%
+  & {\bf Version} & {\bf Windows} & {\bf git}~~~~~~\\
+  {\bf rev} & {\bf hash} &
+  & {\bf Date} & {\bf Date} & {\bf tag}~~~~~~\\\hline}
 \tabletail{\multicolumn{5}{r}{\small continued \ldots}\\}
 \tablelasttail{\hline}
 % the default value (of 0.1) gives very short pages: this works better for this table.
 \xentrystretch{-0.15}
 %
+\definecolor{lightgrey}{RGB}{180,180,180}
 \newcommand{\gr}[1]{\color{lightgrey}#1}
-\noindent
-\begin{xtabular}{|cc@{\hspace{1cm}}ll@{\hspace{1cm}}l|}
+\begin{xtabular}{|c@{\hspace{1cm}}c@{\hspace{1cm}}lll@{\hspace{1cm}}l|}
 %%
 %% In reverse chronological order ----------------------------------------
 %%
-%%SVN& git hash & Version            & Version Date      & git tag\\
-     & a37d2288 & \gr{13.1}          & November 6, 2019  &\\
-     & f22d949a & \gr{13.1}          & August 19, 2019   &\\
-5920 & 283f5909 & \gr{13.1}          & March 2, 2019     & \\
-5888 & c27495fd & 13.1               & January 19, 2019  & V13.1\\
-5854 & 5eb096f4 & \gr{13.0}          & December 6, 2018  &\\
-5599 & a6a53187 & \gr{13.0}          & August 10, 2017   &\\
-5076 & 2f471f57 & \gr{13.0}          & April 16, 2017    &\\
-5039 & 8ddc1399 & \gr{13.0}          & April 10, 2017    &\\
-4777 & 37b670df & \gr{13.0}          & Feb 1, 2017       &\\
-4768 & fad1e049 & \gr{13.0}          & Jan 30, 2017      &\\
-4500 & 3de78ac1 & 13.0               & Aug 30, 2016      & V13.0\\
-4232 & 8cb66e3a & \gr{12.3}          & Feb 29, 2016      & \\
-4166 & e717f130 & 12.3               & Sep 12, 2015      & V12.3\\
-3976 & 2edead79 & 12.2               & \gr{Dec 2, 2014}  & V12.2\\
-3975 & 2b1344d4 & 12.3               & Dec 2, 2014       &\\
-3883 & 250626b8 & \gr{12.1}          & July 17, 2014     &\\
-3420 & eee39677 & \gr{12.1}          & April 13, 2013    &\\
-3312 & a89fd52c & \gr{12.1}          & November 19, 2012 &\\
-3211 & 7f7f54e6 & \gr{12.1}          & August 06, 2012   &\\
-3101 & 3dc88528 & \gr{12.1}          & May 31, 2012      &\\
-3090 & 509e849d & 12.1               & May 21, 2012      & V12.1\\
-2857 & 6c12273b & \gr{12.0 or 11.9}  & November 2, 2011  &\\
-2787 & 7e02b299 & 12.0 or 11.9       & July 15, 2011     & V12.0 and V11.9\\
-2623 & 39a3e916 & \gr{11.7}          & January 14, 2011  &\\
-2237 & 7465a6d4 & 11.7               & January 22, 2010  & V11.7\\
-2094 & 14bf54ab & 11.6               & October 12, 2009  & V11.6\\
-1932 & 5ee2eb2f & \gr{11.5}          & March 22, 2009    &\\
-1636 & a683b0ad & 11.5               & April 27, 2008    & V11.5\\
-1362 & 5b279165 & 11.4               & January 10, 2007  & V11.4\\
-1273 & 018bbb2a & 11.3               & March 20, 2006    & V11.3\\
-1213 & 5c306bdc & \gr{11.3 (beta)}   & November 30, 2005 &\\
-1117 & 85d2d3f2 & \gr{11.3 (beta)}   & June 23, 2005     &\\
-1078 & 95d17114 & 11.3 (beta)        & April 28, 2005    & V11.3-B1\\
-1051 & 1eb51620 & \gr{11.2 (beta)}   & February 18, 2005 &\\
-1018 & 4e83fa58 & 11.2 (beta)        & January 4, 2005   & V11.2-B1\\
-922  & c73adaed & \gr{11.1 (beta)}   & October 18, 2004  &\\
-882  & 0df3e550 & 11.1 (beta)        & July 6, 2004      & V11.1-B1\\
-810  & 794f8018 & \gr{11.0 (beta)}   & May 15, 2004      &\\
-672  & 520e9aea & \gr{11.0 (beta)}   & February 1, 2004  &\\
-548  & 63b5dcc1 & \gr{11.0 (beta)}   & July 8, 2003      &\\
-520  & 175cc419 & \gr{11.0 (beta)}   & June 2, 2003      &\\
-492  & d7388853 & \gr{11.0 (beta)}   & May 24, 2003      &\\
-484  & 11eea964 & 11.0 (beta)        & May 23, 2003      & V11.0-B1\\
-411  & bf6174b2 & \gr{10.0 (beta-3)} & November 25, 2002 &\\
-395  & f7804ff1 & \gr{10.0 (beta-3)} & October 25, 2002  &\\
-369  & a5cadd88 & \gr{10.0 (beta-3)} & August 24, 2002   &\\
-274  & 4ea85e6f & \gr{10.0 (beta-3)} & April 27, 2002    &\\
-244  & 441aad90 & 10.0 (beta-3)      & February 14, 2002 & V10.0-B3\\
-58   & be738a6a & 10.0 (beta-2)      & August 1, 2001    & V10.0-B2\\
-3    & 984fa078 & 10.0 beta          & January 18, 2001  & V10.0-B1\\
+%%SVN& git hash & Version            & Version Date         & Win Date & git tag\\
+     & a37d2288 & \gr{13.1}          & November 6, 2019     &&\\
+     & f22d949a & \gr{13.1}          & August 19, 2019      &&\\
+5965 & dce80670 & \gr{13.1}          & \gr{March 2, 2019}   & March 24, 2019 & {13.1}\\
+5920 & 283f5909 & \gr{13.1}          & March 2, 2019        &&\\
+5888 & c27495fd & 13.1               & January 19, 2019     &&\\
+5854 & 5eb096f4 & \gr{13.0}          & December 6, 2018     &&\\
+5599 & a6a53187 & \gr{13.0}          & August 10, 2017      &&\\
+5080 & 380c9ec5 & \gr{13.0}          & \gr{April 16, 2017}  & April 16, 2017 & {13.0.1}\\
+5076 & 2f471f57 & \gr{13.0}          & April 16, 2017       &&\\
+5039 & 8ddc1399 & \gr{13.0}          & April 10, 2017       &&\\
+4777 & 37b670df & \gr{13.0}          & Feb 1, 2017          & Feb 1, 2017 & {13.0}\\
+4768 & fad1e049 & \gr{13.0}          & Jan 30, 2017         &&\\
+4500 & 3de78ac1 & 13.0               & Aug 30, 2016         &&\\
+4237 & e9bb5587 & \gr{12.3}          & Feb 29, 2016         & Feb 29, 2016 & {12.3}\\
+4232 & 8cb66e3a & \gr{12.3}          & Feb 29, 2016         &&\\
+4166 & e717f130 & 12.3               & Sep 12, 2015         && \\
+3976 & 2edead79 & 12.2               & \gr{Dec 2, 2014}     & Dec 2, 2014 & {12.2}\\
+3975 & 2b1344d4 & 12.3               & Dec 2, 2014          &&\\
+3883 & 250626b8 & \gr{12.1}          & July 17, 2014        &&\\
+3420 & eee39677 & \gr{12.1}          & April 13, 2013       & April 13, 2013 & {12.1.2}\\
+3312 & a89fd52c & \gr{12.1}          & November 19, 2012    &&\\
+3231 & 4ae6595f &\gr{12.1}           &\gr{August 06, 2012}  & August 12, 2012 & {12.1.1}\\
+3211 & 7f7f54e6 & \gr{12.1}          & August 06, 2012      & August 6, 2012 & {12.1}\\
+3101 & 3dc88528 & \gr{12.1}          & May 31, 2012         &&\\
+3090 & 509e849d & 12.1               & May 21, 2012         &&\\
+2983 & 9db42528 & \gr{12.0 or 11.9}  &\gr{November 2, 2011} & November 2, 2011 & {12.0.3}\\
+2857 & 6c12273b & \gr{12.0 or 11.9}  & November 2, 2011     & November 2, 2011 & {12.0.2}\\
+2788 & bdffe5e7 & 12.0 or 11.9       & July 15, 2011        & July 15, 2011 & {11.9.1}\\
+2786 & 39258419 & \gr{11.7}          &\gr{January 14, 2011} & July 13, 2011 & {12.0.1}\\
+2708 & 547d0670 & \gr{11.7}          &\gr{January 14, 2011} & March 10, 2011 & {12.0} {11.9}\\
+2675 & 11466f2e & \gr{11.7}          &\gr{January 14, 2011} & February 22, 2011 & {11.8}\\
+2623 & 39a3e916 & \gr{11.7}          & January 14, 2011     &&\\
+2535 & 268a2a6a & \gr{11.7}          &\gr{January 22, 2010} & January 22, 2010 & {11.7.1}\\
+2237 & 7465a6d4 & 11.7               & January 22, 2010     & January 22, 2010 & {11.7}\\
+2094 & 14bf54ab & 11.6               & October 12, 2009     &&\\
+1932 & 5ee2eb2f & \gr{11.5}          & March 22, 2009       &&\\
+1636 & a683b0ad & 11.5               & April 27, 2008       &&\\
+1362 & 5b279165 & 11.4               & January 10, 2007     &&\\
+1273 & 018bbb2a & 11.3               & March 20, 2006       &&\\
+1213 & 5c306bdc & \gr{11.3 (beta)}   & November 30, 2005    &&\\
+1117 & 85d2d3f2 & \gr{11.3 (beta)}   & June 23, 2005        &&\\
+1078 & 95d17114 & 11.3 (beta)        & April 28, 2005       &&\\
+1051 & 1eb51620 & \gr{11.2 (beta)}   & February 18, 2005    &&\\
+1018 & 4e83fa58 & 11.2 (beta)        & January 4, 2005      &&\\
+922  & c73adaed & \gr{11.1 (beta)}   & October 18, 2004     &&\\
+882  & 0df3e550 & 11.1 (beta)        & July 6, 2004         &&\\
+810  & 794f8018 & \gr{11.0 (beta)}   & May 15, 2004         &&\\
+672  & 520e9aea & \gr{11.0 (beta)}   & February 1, 2004     &&\\
+548  & 63b5dcc1 & \gr{11.0 (beta)}   & July 8, 2003         &&\\
+520  & 175cc419 & \gr{11.0 (beta)}   & June 2, 2003         &&\\
+492  & d7388853 & \gr{11.0 (beta)}   & May 24, 2003         &&\\
+484  & 11eea964 & 11.0 (beta)        & May 23, 2003         &&\\
+411  & bf6174b2 & \gr{10.0 (beta-3)} & November 25, 2002    &&\\
+395  & f7804ff1 & \gr{10.0 (beta-3)} & October 25, 2002     &&\\
+369  & a5cadd88 & \gr{10.0 (beta-3)} & August 24, 2002      &&\\
+274  & 4ea85e6f & \gr{10.0 (beta-3)} & April 27, 2002       &&\\
+244  & 441aad90 & 10.0 (beta-3)      & February 14, 2002    &&\\
+58   & be738a6a & 10.0 (beta-2)      & August 1, 2001       &&\\
+3    & 984fa078 & 10.0 beta          & January 18, 2001     &&\\
 \end{xtabular}
+} % \arraystretch is back to its previous value
 %
 % Remove the table furniture.
 % (without this, the next table is typeset with these definitions!)
@@ -623,3 +638,4 @@ identify the actual revision which was thought, at the time, to be the release
 \tablelasttail{}
 \xentrystretch{0.1}
 %
+}% end /small

--- a/uni/lib/complex.icn
+++ b/uni/lib/complex.icn
@@ -12,7 +12,7 @@ import lang
 #<p>
 #  A complex number representation that supports overloading the
 #  basic numeric operators ("<tt>+</tt>","<tt>-</tt>",
-#  "<tt>*</tt>","<tt>/<tt>") to work with complex numbers.
+#  "<tt>*</tt>","<tt>/</tt>") to work with complex numbers.
 #  Note that Unicon's operator overloading implementation requires
 #  that the <i>left</i> operand be of the overloaded type.
 #  That is, <tt>Complex(1,2)+3</tt> works but <tt>3+Complex(1,2)</tt>
@@ -23,28 +23,28 @@ import lang
 #</p>
 class Complex:Object(r:0,i:0)
 
-    #<p>Add a scaler or Complex to this complex number.
+    #<p>Add a scalar or Complex to this complex number.
     #   Fails if right operator cannot be converted to Complex.
     #</p>
     method add(x)
        if x := convert(x) then return Complex(r+x.r,i+x.i)
     end
 
-    #<p>Subtract a scaler or Complex from this complex number.
+    #<p>Subtract a scalar or Complex from this complex number.
     #   Fails if right operator cannot be converted to Complex.
     #</p>
     method minus(x)
        if x := convert(x) then return Complex(r-x.r,i-x.i)
     end
 
-    #<p>Multiply this complex number by a scaler or Complex.
+    #<p>Multiply this complex number by a scalar or Complex.
     #   Fails if right operator cannot be converted to Complex.
     #</p>
     method mult(x)
        if x := convert(x) then return Complex(r*x.r-i*x.i, r*x.i+i*x.r)
     end
 
-    #<p>Divide this complex number by a scaler or Complex.
+    #<p>Divide this complex number by a scalar or Complex.
     #   In the result, both the real and imaginary parts are
     #   represented as floating point values.
     #   Fails if right operator cannot be converted to Complex.
@@ -98,7 +98,8 @@ class Complex:Object(r:0,i:0)
 
     #<p>
     #  Produce the additive inverse of this complex number.
-    #  <i>Note: no support for operator overloading for this operation.</i>
+    #  <i>Note: no support for operator overloading for this operation
+    #  because there is no such operator in Unicon.</i>
     #</p>
     method addInverse()
        return Complex(-r, -i)
@@ -106,7 +107,8 @@ class Complex:Object(r:0,i:0)
 
     #<p>
     #  Produce the multiplicative inverse of this complex number.
-    #  <i>Note: no support for operator overloading for this operation.</i>
+    #  <i>Note: no support for operator overloading for this operatio
+    #  because there is no such operator in Unicon.</i>
     #</p>
     method multInverse()
        n := conjugate()

--- a/uni/lib/complex.icn
+++ b/uni/lib/complex.icn
@@ -1,0 +1,133 @@
+#<p>
+#  This file is in the public domain.
+#</p>
+#<p>
+#  Author: Steve Wampler (sbw@tapestry.tucson.az.us)
+#</p>
+
+package math
+
+import lang
+
+#<p>
+#  A complex number representation that supports overloading the
+#  basic numeric operators ("<tt>+</tt>","<tt>-</tt>",
+#  "<tt>*</tt>","<tt>/<tt>") to work with complex numbers.
+#  Note that Unicon's operator overloading implementation requires
+#  that the <i>left</i> operand be of the overloaded type.
+#  That is, <tt>Complex(1,2)+3</tt> works but <tt>3+Complex(1,2)</tt>
+#  doesn't.
+#  <b>Operator overloading only works with Unicon configured with
+#  the <tt>--enable-ovld</tt> flag.  However, this class provides
+#  methods that can be invoked directly, as in: <tt>Complex(3,1).add(4)</tt></b>
+#</p>
+class Complex:Object(r:0,i:0)
+
+    #<p>Add a scaler or Complex to this complex number.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method add(x)
+       if x := convert(x) then return Complex(r+x.r,i+x.i)
+    end
+
+    #<p>Subtract a scaler or Complex from this complex number.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method minus(x)
+       if x := convert(x) then return Complex(r-x.r,i-x.i)
+    end
+
+    #<p>Multiply this complex number by a scaler or Complex.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method mult(x)
+       if x := convert(x) then return Complex(r*x.r-i*x.i, r*x.i+i*x.r)
+    end
+
+    #<p>Divide this complex number by a scaler or Complex.
+    #   In the result, both the real and imaginary parts are
+    #   represented as floating point values.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method div(x)
+       if x := convert(x) then {
+          c := x.conjugate()
+          n := self.mult(c)
+          d := real((x.mult(c)).r)
+          return Complex(n.r/d,n.i/d)
+          }
+    end
+
+    #<p>Overload the "+" binary operator.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method __add__(x)
+       return add(x)
+    end
+
+    #<p>Overload the "-" binary operator.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method __minus__(x)
+       return minus(x)
+    end
+
+    #<p>Overload the "*" binary operator.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method __mult__(x)
+       return mult(x)
+    end
+
+    #<p>Overload the "/" binary operator.
+    #   In the result, both the real and imaginary parts are
+    #   represented as floating point values.
+    #   Fails if right operator cannot be converted to Complex.
+    #</p>
+    method __div__(x)
+       return div(x)
+    end
+
+    #<p>
+    #  Produce the complex conjugate of this complex number.
+    #  <i>Note: no support for operator overloading for this operation.</i>
+    #</p>
+    method conjugate()
+       return Complex(r, -i)
+    end
+
+    #<p>
+    #  Produce the additive inverse of this complex number.
+    #  <i>Note: no support for operator overloading for this operation.</i>
+    #</p>
+    method addInverse()
+       return Complex(-r, -i)
+    end
+
+    #<p>
+    #  Produce the multiplicative inverse of this complex number.
+    #  <i>Note: no support for operator overloading for this operation.</i>
+    #</p>
+    method multInverse()
+       n := conjugate()
+       d := real(r^2 + i^2)
+       return Complex(n.r/d, n.i/d)
+    end
+
+    #<p>
+    #  Produce a string representation of this complex number.
+    #</p>
+    method toString()
+       return "("||r||","||i||"i)"
+    end
+
+    #<p>
+    #  Convert x into a complex number, if possible.
+    #  <i>Used internally.</i>
+    #</p>
+    method convert(x)
+       if type(x) == "math__Complex__state" then return x
+       return Complex(numeric(x),0)
+    end
+
+end

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -62,10 +62,13 @@ end
 #<p>
 # Is className an ancestor of class x?
 #   Any class is considered as an ancestor of itself.
+#   <[param x -- class to test]>
+#   <[param className -- name of potential ancestor or actual potential ancestor.
+#        For example, <tt>instanceof(X,"lang::Object")</tt> and
+#        <tt>instanceof(X,Object())</tt> are equivalent.]>
 #   <[returns <tt>x</tt> if <tt>x</tt> is an instance of <tt>className</tt>]>
 #</p>
-procedure instanceof(x,         # Object to examine
-                     className) # Classname to check against
+procedure instanceof(x, className)
    # The call to isClass is just to ensure x is a class, since
    #   istype(...) doesn't care.
    return (isClass(x) & istype(x, className))
@@ -73,19 +76,27 @@ end
 
 #<p>
 # Is the type of x s?  Works even if s is "class" or "record".
-#   Also, will accept s as "numeric" to check if x is either
+# Also works if s is an actual class instead of a string, as in:
+# </p>
+# <pre>
+#   if istype(x,Object())
+# </pre>
+#<p>
+#   Will accept s as "numeric" to check if x is either
 #      a real or an integer.
 #   <[returns <tt>x</tt> if it's of type <tt>s</tt>]>
 #   <[fails if <tt>x</tt> is not of type <tt>s</tt>]>
 #</p>
 procedure istype(x,         # Object to examine
-                 s)          # Type to check against
+                 s)         # Type to check against
    case string(s) of {
       "class"  : return isClass(x)
       "record" : return isRecord(x)
       "numeric": return 2(numeric(x), x)
       default  : return 2(string(s) == Type(x), x )
       }
+   # Last gasp, maybe s is really a class instead of a classname
+   return 2(Type(s)\1 == Type(x), x )
 end
 
 #<p>


### PR DESCRIPTION
Two changes to uni/lib:
   -- complex.icn  -- fixed typos in comments ("scaler" -> "scalar") as caught by Don
   -- predicat.icn -- extend istype so 2nd argument can be a class instance as well as a class name.  This affects
               instanceof() [same file] and instanceOf() [object.icn] to test against the class instance, as in:

            if X.instanceOf(Object()) then ...

      complementing the existing equivalent:

           if X.instanceOf("lang::Object")

     