### PR TITLE
Remove code handling Icon v8.5 and earlier.

### DIFF
--- a/uni/unicon/unix.icn
+++ b/uni/unicon/unix.icn
@@ -12,13 +12,7 @@ end
 
 
 procedure sysinitialize()
-  &version ? {
-     tab(find("Version ")+ *"Version ")
-     if numeric(tab(many(&digits))) * 100 +
-	(move(1) & numeric(tab(many(&digits)))) >= 806 then icontopt := " "
-     else # older versions of icont required lots of -S options
-        icontopt := " -Sc500 -Sf600 -Sg600 -Si1200 -Sl400 -Sn3000 -Sr2000 -Ss30000 -St20000 -SC30000 -SF60 -SL1000 "
-  }
+  icontopt := " "
   env := getenv("IDOLENV") | "uniclass"
   sysok := 0
 end


### PR DESCRIPTION
The (old) -S options that were passed along if the version was before 8.6
are no longer understood (and, if used, break the build): it's best to remove them.