### PR TITLE
Fix fieldNames().

### DIFF
--- a/uni/lib/object.icn
+++ b/uni/lib/object.icn
@@ -141,7 +141,7 @@ class Object()
    #   <[generates the names of all fields]>
    #</p>
    method fieldNames()
-      every ::name(self[3 to *self]) ? {
+      every ::name(self[1 to *self]) ? {
 	 &pos := upto('.')+1
 	 suspend tab(0)
 	 }


### PR DESCRIPTION
The fieldNames() method was written for original UniLib version.  This updates it to work correctly with uni/lib changes.