### PR TITLE
GCC 10 Fixes

### DIFF
--- a/src/common/dconsole.c
+++ b/src/common/dconsole.c
@@ -963,8 +963,8 @@ unsigned long ConsoleFlags = 0;	*/
 extern int ConsolePause;
 extern FILE *flog;
 
-char *lognam;
-char tmplognam[128];
+extern char *lognam;
+extern char tmplognam[128];
 
 void closelogfile()
 {

--- a/src/common/filepart.c
+++ b/src/common/filepart.c
@@ -427,6 +427,7 @@ int pathOpenHandle(char *fname, char *mode)
  */
 char *lognam;
 FILE *flog;
+char tmplognam[128];
 
 void openlog(char *p)
 {

--- a/src/h/rexterns.h
+++ b/src/h/rexterns.h
@@ -82,7 +82,7 @@ extern pthread_mutex_t **mutexes;
 extern word nmutexes;
 extern word maxmutexes;
 
-pthread_mutexattr_t rmtx_attr;
+extern pthread_mutexattr_t rmtx_attr;
 
 extern pthread_t GCthread;
 extern int thread_call;

--- a/src/iconc/ctrans.c
+++ b/src/iconc/ctrans.c
@@ -29,8 +29,8 @@ int incol;			/* current input column number */
 int peekc;			/* one-character look ahead */
 struct srcfile *srclst = NULL;	/* list of source files to translate */
 
-char *lpath;			/* LPATH value */
-
+extern char *lpath;			/* LPATH value */
+
 
 /*
  * This routine walks through rec_lst looking for object instance records,

--- a/src/iconc/yyerror.c
+++ b/src/iconc/yyerror.c
@@ -335,7 +335,7 @@ void yyerror_init()
    errtab[220].u.msg = "invalid argument";
 }
 
-int __merr_errors;
+extern int __merr_errors;
 extern int yychar;
 extern int yylineno;
 

--- a/src/icont/tglobals.h
+++ b/src/icont/tglobals.h
@@ -68,7 +68,7 @@ Global int Dflag	Init(0);	/* -L: linker debug (write .ux file) */
 /*
  * Files and related globals.
  */
-Global char *lpath;			/* search path for $include */
+extern char *lpath;			/* search path for $include */
 Global char *ipath;			/* search path for linking */
 extern char patchpath[];
 extern char uniroot[];
@@ -94,6 +94,6 @@ Global int Zflag	Init(1);	/* -Z disables icode-gz compression */
 Global int OVLDflag;   /* defaults to overloaded (so can make idol.u & unigram.u exceptions */
 #endif
 
-Global char *lognam;		/* name of a logfile, from -l logname */
-Global FILE *flog;		/* log file */
+extern  char *lognam;		/* name of a logfile, from -l logname */
+extern FILE *flog;		/* log file */
 


### PR DESCRIPTION
GCC 10 changed the default behavior related to global variables.
These changes break the build when using gcc 10+.

Related: -fno-common flag
         https://gcc.gnu.org/gcc-10/porting_to.html

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>