### PR TITLE
Add vbuttons to vidgets.icn

### DIFF
--- a/ipl/gprocs/vidgets.icn
+++ b/ipl/gprocs/vidgets.icn
@@ -25,4 +25,5 @@ link viface
 link vlist
 link vmenu
 link vpane
+link vbuttons
 link vstd


### PR DESCRIPTION
Without this change, importing both 'gui' and ''util' packages as in:

    ->cat Test1.icn
    import util
    import gui

    procedure main()
    end
    ->

 results in the linking warnings:

    ->unicon Test1.icn
    Parsing Test1.icn: ...
    /opt/unicon/bin/icont -c   -O Test1.icn 
    /tmp/uni30124935
   Translating:
   Test1.icn:
      main
    No errors
    /opt/unicon/bin/icont  Test1.u
    Linking:
    viface.icn: "erase_Vline": undeclared identifier, procedure VErase
    viface.icn: "event_Vtoggle": undeclared identifier, procedure VGetState
    ->

Note that both imports are needed to produce the warnings.  Go figure.