### PR TITLE
Define missing global variable "iconc" in paths.icn.

### DIFF
--- a/ipl/procs/paths.icn
+++ b/ipl/procs/paths.icn
@@ -8,6 +8,14 @@
 link getpaths
 
 #
+# the global variable "iconc" needs to be defined here for all uses other
+# than in the unicon compiler. Defining this global here will not affect any
+# other global definition in the unicon compiler sources and will prevent
+# any undefined variable messages in other applications that use this IPl file.
+#
+global iconc
+
+#
 # pathsep() returns the sentinel value that separates elements of the path.
 # extra care is needed (on non-Windows systems) when space appears in a
 # pathname, since space is the path separator for many shells.
@@ -67,13 +75,13 @@ local sep, prefix
       prefix := ulibprefix()
 
       pathstr := ulibpaths()
-      
+
       pathstr ||:=
          prefix || "/ipl/incl"  || sep ||
          prefix || "/ipl/gincl" || sep ||
          prefix || "/ipl/mincl" || sep
 
-      if \iconc then 
+      if \iconc then
          pathstr ||:=
             prefix || "/ipl/procs"  || sep ||
             prefix || "/ipl/gprocs" || sep ||
@@ -113,14 +121,14 @@ end
 
 procedure ipaths_get()
    static rslt
-   initial 
+   initial
       rslt := paths_get(ipaths())
    return rslt
 end
 
 procedure lpaths_get()
    static rslt
-   initial 
+   initial
       rslt := paths_get(lpaths())
    return rslt
 end


### PR DESCRIPTION
When the procedure lpaths() is used in the unicon compiler, the global
variable "iconc" is defined. However, when the lpaths() procedure is used
in other applications, this global will not be defined.

We define it here to prevent the undefined variable message from occurrig.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>