### PR TITLE
Replace file contents with link to datetime.icn

### DIFF
--- a/ipl/procs/calendat.icn
+++ b/ipl/procs/calendat.icn
@@ -8,6 +8,10 @@
 #
 #	Date:     September 6, 1992
 #
+#	Modified: Bruce Rennie
+#
+#	Date:     August 7, 2020
+#
 ############################################################################
 #
 #   This file is in the public domain.
@@ -16,6 +20,12 @@
 #
 #  calendat(j) return a record with the month, day, and year corresponding
 #  to the Julian Date Number j.
+#
+#  As the former contents of this file were a direct extract from the IPL
+#  file datetime.icn, replace the code with a link to datetime.
+#
+#  record date1(month, day, year)
+#  procedure calendat(julian)
 #
 ############################################################################
 #
@@ -26,31 +36,4 @@
 #
 ############################################################################
 
-record date1(month, day, year)
-
-procedure calendat(julian)
-   local ja, jalpha, jb, jc, jd, je, gregorian
-   local month, day, year
-
-   gregorian := 2299161
-
-   if julian >= gregorian then {
-      jalpha := integer(((julian - 1867216) - 0.25) / 36524.25)
-      ja := julian + 1 + jalpha - integer(0.25 * jalpha)
-      }
-   else ja := julian
-
-   jb := ja + 1524
-   jc := integer(6680.0 + ((jb - 2439870) - 122.1) / 365.25)
-   jd := 365 * jc + integer(0.25 * jc)
-   je := integer((jb - jd) / 30.6001)
-   day := jb - jd - integer(30.6001 * je)
-   month := je - 1
-   if month > 12 then month -:= 12
-   year := jc - 4715
-   if month > 2 then year -:= 1
-   if year <= 0 then year -:= 1
-
-   return date1(month, day, year)
-
-end
+link datetime


### PR DESCRIPTION
As the contents of calendat.icn were a direct extract from datetime.icn,
change the file to link to the datetime IPL file. This will allow any
future changes that may be made to datetime.icn to be propagated to any
usage of this file.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>