### PR TITLE
Correcting Makefile install "docs and mans"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ install Install:
 #	docs and man
 	@echo "Installing $(DESTDIR)$(mandir)/man1/unicon.1 ..."
 	@$(INST) -m 644 doc/unicon/unicon.1 $(DESTDIR)$(mandir)/man1/
-	@$(INST) -m 644 README $(DESTDIR)$(docdir)/unicon
+	@$(INST) -m 644 README.md $(DESTDIR)$(docdir)/unicon
 	@echo "Installing $(DESTDIR)$(docdir)/unicon ..."
 	@$(INST) -m 644 doc/unicon/*.* $(DESTDIR)$(docdir)/unicon
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -310,7 +310,7 @@ install Install:
 #	docs and man
 	@echo "Installing $(DESTDIR)$(mandir)/man1/unicon.1 ..."
 	@$(INST) -m 644 doc/unicon/unicon.1 $(DESTDIR)$(mandir)/man1/
-	@$(INST) -m 644 README $(DESTDIR)$(docdir)/unicon
+	@$(INST) -m 644 README.md $(DESTDIR)$(docdir)/unicon
 	@echo "Installing $(DESTDIR)$(docdir)/unicon ..."
 	@$(INST) -m 644 doc/unicon/*.* $(DESTDIR)$(docdir)/unicon
 


### PR DESCRIPTION
The Makefile references README in the Install section instead of README.md.

This fails to copy the README.md document to the documentation directory
when installing.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>