### PR TITLE
Mismatch in test output for thread test mutexfun.icn

### DIFF
--- a/tests/thread/stand/mutexfun.std
+++ b/tests/thread/stand/mutexfun.std
@@ -1,11 +1,11 @@
 Testing mutex functions..
  calling mutex()...
-mutex() returned x=46 This is OK
+mutex() returned x=45 This is OK
 
  calling lock(x)...
-lock(x) returned y=46
+lock(x) returned y=45
 
  calling unlock(x)...
-unlock(x) returned y=46
+unlock(x) returned y=45
 
 Done! exiting peacefully...


### PR DESCRIPTION
The standard test output file has a slight difference to what is actually
written by the thread test mutexfun.inc. In the standard test output the
value of x is given as 46 whereas the actual output is 45.

If you add into the source code a copy of the line

x := mutex()

then the output matches.

The standard test output file has been unpadted to reflect this change in
value to 45 instead of 46.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>