### PR TITLE
Squashed commit of the following:

### DIFF
--- a/uni/lib/fcn_util.icn
+++ b/uni/lib/fcn_util.icn
@@ -11,6 +11,7 @@
 #</p>
 
 package lang
+invocable all
 
 #<p>
 # Compose multiple single-argument functions into a
@@ -123,15 +124,15 @@ class Closure : Object (fcn)
    # Merges the argument list into the Closure object and then
    #  invokes it.  Missing arguments are mapped to &null.
    #</p>
-   method doInvocation(fcn, args)
+   method doInvocation(flist, args)
       local i
 
-      fcn := copy(fcn)
+      flist := copy(flist)
       /args := list()
-      every i := 2 to *fcn do
-	 if fcn[i] === Arg then
-	    fcn[i] := pop(args) | &null
-      suspend invoke ! (fcn ||| args)
+      every i := 2 to *flist do
+	 if flist[i] === Arg then
+	    flist[i] := pop(args) | &null
+      suspend invokeFcn ! (flist ||| args)
    end
 
 #<p>
@@ -220,12 +221,13 @@ procedure invokeFcn(fcn, args[])
 	 }
       "list" : {
 	 fcn := copy(fcn)
-	 every i := 2 to *fcn do {
+         f := pull(fcn)
+	 every i := 1 to *fcn do {
 	    if fcn[i] === Arg then {
 	       fcn[i] := pop(args) | &null
 	       }
 	    }
-	 suspend invoke!(fcn ||| args)
+	 suspend f!(fcn ||| args)
 	 }
       "co-expression" : {
 	 while suspend args@fcn


### PR DESCRIPTION
commit 4a0e260f5ca83ad5be56793a2ff44c06fdef0d0e
Author: swampler <av_13@tapestry.tucson.az.us>
Date:   Wed Aug 26 17:37:20 2020 -0700

    Avoid name collision in Closure call

    This is a minor change to avoid a name collision between a local variable and an object field.

commit 03af501fb2a91efbab62c7e5f5b374e202fe3c0c
Author: swampler <av_13@tapestry.tucson.az.us>
Date:   Tue Aug 25 08:59:22 2020 -0700

    Allow string invocation of functions

    Allows fcn_util to use string invocation.
    Bug fix to invoking a list.
