### PR TITLE
addressbook package fixes

### DIFF
--- a/uni/gui/addressgui.icn
+++ b/uni/gui/addressgui.icn
@@ -86,7 +86,7 @@ class AddressGui : Dialog(newAddress,helpButton,quitButton,addrListArea,miscText
    #  <[param ev event]>
    #</p>
    method handle_miscTextArea(ev)
-       if ev.get_type() = SELECTION_CHANGED_EVENT then
+       if ev.get_type() = CONTENT_CHANGED_EVENT then
            changed()
    end
 
@@ -96,7 +96,7 @@ class AddressGui : Dialog(newAddress,helpButton,quitButton,addrListArea,miscText
    #  <[param ev event]>
    #</p>
    method handle_nameField(ev)
-       if ev.get_type() = SELECTION_CHANGED_EVENT then
+       if ev.get_type() = CONTENT_CHANGED_EVENT then
            changed()
    end
 
@@ -106,7 +106,7 @@ class AddressGui : Dialog(newAddress,helpButton,quitButton,addrListArea,miscText
    #  <[param ev event]>
    #</p>
    method handle_addrField(ev)
-       if ev.get_type() = SELECTION_CHANGED_EVENT then
+       if ev.get_type() = CONTENT_CHANGED_EVENT then
            changed()
    end
 
@@ -116,7 +116,7 @@ class AddressGui : Dialog(newAddress,helpButton,quitButton,addrListArea,miscText
    #  <[param ev event]>
    #</p>
    method handle_emailField(ev)
-       if ev.get_type() = SELECTION_CHANGED_EVENT then
+       if ev.get_type() = CONTENT_CHANGED_EVENT then
            changed()
    end
 
@@ -126,7 +126,7 @@ class AddressGui : Dialog(newAddress,helpButton,quitButton,addrListArea,miscText
    #  <[param ev event]>
    #</p>
    method handle_phoneField(ev)
-       if ev.get_type() = SELECTION_CHANGED_EVENT then
+       if ev.get_type() = CONTENT_CHANGED_EVENT then
            changed()
    end
 

--- a/uni/lib/db_util.icn
+++ b/uni/lib/db_util.icn
@@ -34,7 +34,9 @@ class DButils : Object ()
         local ns := ""
 
         s ? {
-            while ns ||:= tab(upto('\\\'')) || "\\" || move(1)
+            while ns ||:= tab(upto('\\\'')) do {
+                ns ||:= if ="'" then "''" else "\\\\"
+                }
             ns ||:= tab(0)
             }
         return ns


### PR DESCRIPTION
A) Use standard SQL escapes for backslash and single quote (previous version worked with old PostgreSQL, not standard SQL).
B) GUI event handling has changed from the old GUI support code.  This updates the gui to use the new events.