### PR TITLE
Fix escape() method.

### DIFF
--- a/uni/lib/db_util.icn
+++ b/uni/lib/db_util.icn
@@ -34,8 +34,8 @@ class DButils : Object ()
         local ns := ""
 
         s ? {
-            while ns ||:= tab(upto('\\\'')) do {
-                ns ||:= if ="'" then "''" else "\\\\"
+            while ns ||:= tab(upto('\e\'')) do {
+                ns ||:= if ="'" then "''" else "\e\e"
                 }
             ns ||:= tab(0)
             }


### PR DESCRIPTION
The escape() method mishandles backslashes.  This fixes it.