### PR TITLE
Supply the required include definitions to appease clang v12.

### DIFF
--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -30,6 +30,10 @@
    Feature(1, "_MACOSX", "MacOSX")
 #endif					/* MacOSX */
 
+#ifdef MacOS
+   Feature(1, "_MACOS", "MacOS")
+#endif					/* MacOS */
+
 #if MSDOS
 #if NT
    Feature(1, "_MS_WINDOWS_NT", "MS Windows NT")

--- a/src/h/posix.h
+++ b/src/h/posix.h
@@ -83,7 +83,7 @@ extern char *sys_errlist[];
 #include <sys/param.h>
 #endif
 
-#if (defined(BSD) || defined(BSD_4_4_LITE)) && !defined(MacOSX)
+#if (defined(BSD) || defined(BSD_4_4_LITE)) && !(defined(MacOSX) || defined(MacOS))
 #define Setpgrp() setpgrp(0, 0)
 #else
 #define Setpgrp() setpgrp()

--- a/src/h/sys.h
+++ b/src/h/sys.h
@@ -166,7 +166,7 @@
    #include <sys/time.h>
    #include <sys/times.h>
    #include <sys/types.h>
-#ifdef MacOSX
+#if defined(MacOSX) || defined(MacOS)
    #include <sys/sysctl.h>
 #endif
 #ifdef HAVE_SYS_RESOURCE_H

--- a/src/runtime/rmemmgt.r
+++ b/src/runtime/rmemmgt.r
@@ -8,6 +8,8 @@
 #include <malloc.h>
 #endif					/* CRAY */
 
+
+
 /*
  * Prototypes
  */


### PR DESCRIPTION
On macOS the function sysctlbyname() is used in rmemmgt.r.
Clang v11 warned of an implicit definition (because the
needed includes were not present). Clang v12 raises an error.