### PR TITLE
Remove traces of MacOSX, replace with MacOS

### DIFF
--- a/doc/ib/appH.tex
+++ b/doc/ib/appH.tex
@@ -272,7 +272,7 @@ M\_PI & IU & constant value of Pi \\
 MacGraph & U & build graphics using (legacy pre OSX) Mac graphics (should delete)  \\
 MACGRAPH\_H & IU & macgraph.h has been included \\
 MACINTOSH & all & build on legacy Mac platform (delete?)  \\
-MacOSX & U & build on modern UNIX-based Mac platform \\
+MacOS & U & build on modern UNIX-based Mac platform \\
 max & all & compute maximum of x and y \\
 MaxAbrSize & all & maximum allocated block region size \\
 MAXADDRS & U & maximum number of IP addresses associated with a host

--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -26,9 +26,9 @@
    Feature(1, "_MACINTOSH", "Macintosh")
 #endif					/* MACINTOSH */
 
-#ifdef MacOSX
-   Feature(1, "_MACOSX", "MacOSX")
-#endif					/* MacOSX */
+#ifdef MacOS
+   Feature(1, "_MACOS", "MacOS")
+#endif					/* MacOS */
 
 #if MSDOS
 #if NT

--- a/src/h/posix.h
+++ b/src/h/posix.h
@@ -83,7 +83,7 @@ extern char *sys_errlist[];
 #include <sys/param.h>
 #endif
 
-#if (defined(BSD) || defined(BSD_4_4_LITE)) && !defined(MacOSX)
+#if (defined(BSD) || defined(BSD_4_4_LITE)) && !defined(MacOS)
 #define Setpgrp() setpgrp(0, 0)
 #else
 #define Setpgrp() setpgrp()

--- a/src/h/sys.h
+++ b/src/h/sys.h
@@ -166,7 +166,7 @@
    #include <sys/time.h>
    #include <sys/times.h>
    #include <sys/types.h>
-#ifdef MacOSX
+#ifdef MacOS
    #include <sys/sysctl.h>
 #endif
 #ifdef HAVE_SYS_RESOURCE_H
@@ -332,7 +332,7 @@
 #ifdef ISQL
 #ifndef BOOL
   /* to prevent double-typedef of BOOL on some platforms */
-#ifdef MacOSX
+#ifdef MacOS
   #define BOOL rumplemacskin
 #else
   #define BOOL int

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -315,9 +315,9 @@ Deliberate Syntax Error
 
    buf = growcat(buf, &buflen, 2, " ", LinkLibs);
 
-#if defined(MacOSX) || defined(HAVE_LIBFTGL)
+#if defined(MacOS) || defined(HAVE_LIBFTGL)
    buf = growcat(buf, &buflen, 1, " -lstdc++");
-#endif					/* MacOSX || HAVE_LIBFTGL */
+#endif					/* MacOS || HAVE_LIBFTGL */
 
 #if HAVE_LIBSSL
    buf = growcat(buf, &buflen, 1, " -lssl -lcrypto");

--- a/tests/bench/auxiliary.icn
+++ b/tests/bench/auxiliary.icn
@@ -246,7 +246,7 @@ procedure get_CPU()
        result := read(f) # read the actual name
        close(f)
        }
-   else if &features == ("MacOSX"|"MacOS") then {
+   else if &features == "MacOS" then {
        if f := open("sysctl -n machdep.cpu.brand_string", "p") then {
        read(f) ? result := tab(find("CPU"))
        close(f)
@@ -303,7 +303,7 @@ procedure get_clockspeed()
              close(f)
              }
           }
-      else if &features == ("MacOSX"|"MacOS") then {
+      else if &features == "MacOS" then {
          if f := open("sysctl -n machdep.cpu.brand_string", "p") then {
             read(f) ? (tab(find("@") + 2) & result := tab(0))
             close(f)

--- a/tests/general/prepro.icn
+++ b/tests/general/prepro.icn
@@ -53,7 +53,7 @@ $endif
    precheck(_ACORN,		"Acorn Archimedes")
    precheck(_CMS,		"CMS")
    precheck(_MACINTOSH,		"Macintosh")
-   precheck(_MACOSX,		"MacOSX")
+   precheck(_MACOS,		"MacOS")
    precheck(_MSDOS_386,		"MS-DOS/386")
    precheck(_MSDOS,		"MS-DOS")
    precheck(_MVS,		"MVS")

--- a/uni/gui/dialog.icn
+++ b/uni/gui/dialog.icn
@@ -386,7 +386,7 @@ class Dialog : Component(
          fire(CLOSE_BUTTON_EVENT, e)
       }
 
-$ifdef _MACOSX
+$ifdef _MACOS
       #
       # On Macs, substitute control-click for right-click and shift-click
       # for middle-click.  Should we do this everywhere, for consistency?

--- a/uni/unicon/preproce.icn
+++ b/uni/unicon/preproce.icn
@@ -42,7 +42,7 @@ procedure predefs()
 # _CMS # gone
 	    "CMS": "_CMS"
 	    "Macintosh":"_MACINTOSH"
-	    "MacOSX":"_MACOSX"
+	    "MacOS":"_MACOS"
 	    "MS Windows NT":"_MS_WINDOWS_NT"
 	    "MS-DOS":"_MSDOS"
 	    "MVS":"_MVS"


### PR DESCRIPTION
Apart from the config directory (which also contains other fossils)
all instances of the MacOSX definition -- including in &features --
have been replaced by MacOS. The stimulus for this change is to fix an
error reported by clang v12 in rmemmgt.r. Clang v11 warned about the
implicit declaration of sysctlbyname, but let it go. Clang v12 is less
forgiving.