### PR TITLE
Reorder build sequence in Makefile

### DIFF
--- a/uni/lib/Makefile
+++ b/uni/lib/Makefile
@@ -10,14 +10,15 @@ UFILES=gui.u file_dlg.u db.u \
  fcn_util.u group.u httpclient.u json.u langprocs.u listener.u \
  mailbox.u mailmisc.u mapbytes.u message.u messagehandler.u method.u \
  money.u msg.u multipart.u multiparthandler.u netclient.u noophandler.u object.u \
- popclient.u predicat.u process.u property.u pushback.u qsort.u quotedprintablehandler.u \
+ popclient.u predicat.u process.u pushback.u qsort.u quotedprintablehandler.u \
  rfc822parser.u runnable.u args.u blockread.u notifier.u \
- selectiveclasscoding.u sem.u setfields.u shm.u smtpclient.u str_util.u \
- stringbuff.u misc_util.u heap.u scan_util.u str_replacer.u \
+ selectiveclasscoding.u sem.u setfields.u shm.u smtpclient.u scan_util.u \
+ stringbuff.u misc_util.u heap.u str_util.u str_replacer.u \
  texthandler.u time.u timezone.u typehandler.u \
  undoableedit.u undomanager.u url.u webup.u \
  notification.u md5.u httprequest.u httpresponse.u exception.u \
- thread.u matrix_util.u struct.u db_util.u database.u addressdb.u
+ thread.u matrix_util.u struct.u db_util.u database.u addressdb.u \
+ property.u
 
 # COPYINS are library files copied in from other directories for
 # organizational purposes. Inspired by ipl/lib.  They have to be


### PR DESCRIPTION
Switch positions of scan_util.u and and str_util.u to fix dependency issue.  Move property.u to the end.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>
