### PR TITLE
Updated UniDoc for use with uni/lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ uni/xml/testinvalid
 uni/xml/testnotwf
 uni/xml/testvalid
 
+# Auto-generated API documents
+doc/uni-api/*
+doc/ipl-api/*
 
 # http://www.gnu.org/software/autoconf
 

--- a/uni/unidoc/Makefile
+++ b/uni/unidoc/Makefile
@@ -1,4 +1,6 @@
 SHELL=/bin/sh
+BASE=../..
+include $(BASE)/Makedefs.uni
 
 ########################################################
 # Manage the construction of the UniDoc program        #
@@ -26,14 +28,14 @@ help:
 #    commonly used suffixes.
 #
 %.u:	%.icn
-	unicon -c $?
+	$(UNICON) $(UFLAGS) -c $?
 
 UniDoc: $(UFILES) UniDoc.icn
-	unicon UniDoc
+	$(UNICON) UniDoc
 	@date >.lastbuild        # remembers when things were last built.
 
 ufiles: $(SRCS)
-	unicon -c $?
+	$(UNICON) $(UFLAGS) -c $?
 
 doc docs:	UniDoc
 	./buildDocs.sh

--- a/uni/unidoc/Makefile
+++ b/uni/unidoc/Makefile
@@ -1,5 +1,4 @@
-BASE=../..
-include $(BASE)/Makedefs.uni
+SHELL=/bin/sh
 
 ########################################################
 # Manage the construction of the UniDoc program        #
@@ -9,9 +8,6 @@ include $(BASE)/Makedefs.uni
 #
 SRCS   := $(wildcard ./*.icn)
 UFILES := $(filter-out ./UniDoc.u,$(patsubst %.icn, %.u, $(SRCS)))
-CLIB   := ../../Classes
-
-all: ufiles UniDoc
 
 # The first target is the default target.
 #    The "@"'s tell make to suppress printing the command before
@@ -30,15 +26,14 @@ help:
 #    commonly used suffixes.
 #
 %.u:	%.icn
-	$(UNICON) $(UFLAGS) -c $?
+	unicon -c $?
 
 UniDoc: $(UFILES) UniDoc.icn
-	$(UNICON) $(UFLAGS) UniDoc
-	$(CP) UniDoc$(EXE) ../../bin/
+	unicon UniDoc
 	@date >.lastbuild        # remembers when things were last built.
 
 ufiles: $(SRCS)
-	$(UNICON) $(UFLAGS) -c $?
+	unicon -c $?
 
 doc docs:	UniDoc
 	./buildDocs.sh
@@ -48,8 +43,9 @@ deps depends:
 
 # Clean up the directory.
 #
-Clean clean:
-	$(RM) uniclass.dir uniclass.pag uniclass.db UniDoc$(EXE) *.u .lastbuild *~
+clean:
+	@-rm -f *.u
+	@-rm -f *~
 
 # List all source files that have been modified since the last build.
 #

--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -189,13 +189,13 @@ class UniAll : Object (files, packages,
     end
 
     #<p>
-    # Given a string of space-separated directories, generates the
+    # Given a string of comma-separated directories, generates the
     # individual directories from that string.  Guarantees that
     # each directory produced ends with "/".
     #</p>
     # <i>This is intended for internal use only!</i>
     method genDirs(s)
-        suspend trim(genFields(s),"/\\")||"/"
+        suspend trim(genFields(s,','),"/\\")||"/"
     end
 
     #<p>
@@ -943,6 +943,23 @@ class UniAll : Object (files, packages,
         return clist
     end
 
+    method locatePack(pName)
+        every dir := !linkPath do {
+            d := open(dir) | next
+            every cf := !d do {
+                #  Note that this is a best guess effort: it may fail, or
+                #   worse find wrong package!
+                fName := "pack_"||pName||".html"
+                if fName == cf then {
+                   return (close(d), dir||"/"||fName)
+                   }
+                }
+            close(d)
+            }
+        # Give up
+        return "pack_"||fixName(pName)||".html"  # Placeholder code
+    end
+
     # <p>
     # Given the name of a class, attempts to find an existing
     # html page for that class, by searching the <b>linkPath</b>.
@@ -951,20 +968,29 @@ class UniAll : Object (files, packages,
     method classOnLinkPath(bClass, cName)
         local pName
 
-        # great idea, but generates wrong name (need source file
-        #   for class, not the package name!)  Leave in for
-        #   now because it's no worse than anything else.
-        #
-        cName ? {
-            if pName := tabSkip("::"|"__") then {
-                if pName == "" then pName := "0main"
-                cName := tab(0)
-                return "class_"||pName||"_"||cName
-                }
-            }
+        imps := curFile.getImportNames()
+        every dir := !linkPath do {
+            d := open(dir) | next
+            every cf := !d do {
+                # Start by hoping it's a full class name (with package)
+                cName ? {
+                    if pName := tabSkip("::"|"__") then {
+                        if pName == (""|"(main)") then pName := "0main"
+                        cName := tab(0)
+                        return dir||"/class_"||pName||"_"||cName||".html"
+                        }
+                    }
 
-        # Don't know how to write the rest because can't determine
-        #   the package for a class from the class name yet!
+                #  Have to check imports next.
+                #  Note that this is a best guess effort: it may fail, or
+                #   worse find the class in the wrong package!
+                every pName := ("0main" | !\imps) do {
+                    fName := "class_"||pName||"_"||cName||".html"
+                    if fName == cf then return (close(d), dir||"/"||fName)
+                    }
+                }
+            close(d)
+            }
     end
 
     # <p>
@@ -977,7 +1003,7 @@ class UniAll : Object (files, packages,
         # If the superclass name tells us the package, use that.
         scName ? {
             if pName := tabSkip("::"|"__") then {
-                if pName := "" then pName := "(main)"
+                if pName == (""|"(main)") then pName := "0main"
                 scName := tab(0)
                 if \(p := packages[pName]) then {
                     sc := p.getClass(scName)

--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -20,1022 +20,1034 @@
 package UniDoc
 
 import util
-import parser
 import lang
+import parser
 
 #<p>
 #  The UniAll class holds the entire internal form of a Unicon
 #    documentation set.
 #</p>
-class UniAll : Object (files, packages,
-		       curFile, curClass, curPackage, curComments, fileHead,
-		       uniFile, resolveFlag, targetDir, saveSrcFlag,
-		       importSet, linkSet, badFiles, sourcePath)
-
-   # <p>
-   # Set the level of entity resolution.  If <b>flag</b> is <b>&null</b>,
-   # then references to entities <i>not</i> contained in files passed
-   # to <b>processFile()</b> are not expanded.  If <b>flag</b> is non-null,
-   # then the current sourcePath is used to locate these entities.
-   # </p>
-   method fullyResolve(flag)
-      if map(flag[1]) == "n" then flag := &null
-      resolveFlag := flag
-   end
-
-   # <p>
-   # Set the source path to be used when attempting to resolve
-   # unknown entities.
-   # </p>
-   method setSourcePath(p)
-      sourcePath := p
-   end
-
-   # <p>
-   # Decide whether or not to save a copy of source code to link to.
-   # </p>
-   method setSaveSrc(flag)
-      if map(flag[1]) == "n" then flag := &null
-      saveSrcFlag := flag
-   end
-
-   # <p>
-   # Remember the target directory (needed if we're output source
-   # code for later linking.)
-   # </p>
-   method setTargetDir(tDir)
-      targetDir := tDir
-   end
-
-   # <p>
-   # Remember <b>fName</b> as a file that has been processed.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   #
-   method addFile(fName)
-      if curFile := /files[fName] := UFile(fName) then {
-         if \saveSrcFlag then
-            curFile.setSrcFile(uniFile.getFilename())
-         return curFile
-         }
-   end
-
-   # <p>
-   # Insert a tag for an entirty into the saved source code, if any.
-   # </p>
-   method addTag(obj)
-      if uniFile.hasSource() then {
-	 if \saveSrcFlag then
-	    obj.setSrcFile(uniFile.getFilename())
-	 tag := obj.getFormType()||"_"||obj.getName()
-	 uniFile.setTag(tag)
-	 }
-   end
-
-   # <p>
-   #  Remove any files that have already been processed from the
-   #    import and link sets.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   #
-   method cleanSets()
-      local fName, pName, fList
-
-      # for now, just be satisfied with the link set, since
-      #     imports are *not* file names!
-      #
-      every fName := !linkSet do {
-	 if \files[fName] then {     # Already processed, remove
-	    delete(linkSet, fName)
-	    }
-	 }
-      every pName := !importSet do {
-	 every fName := genPackageFiles(pName) do {
-	    if /fName | (*fName == 0) then next
-	    if /files[fName] then {     # Need to process
-	       insert(linkSet, \fName)
-	       }
-	    }
-	 }
-      every delete(linkSet, !badFiles)
-   end
-
-   # <p>
-   # This is the main entry point to the <b>UniAll</b> class.  When
-   # invoked, the file <b>fName</b> is parsed and added to an
-   # internal representation for the Unicon source code being
-   # handled by this class instance.  May be called repeatedly to
-   # process multiple files.
-   # </p>
-   method processFile(fName)
-
-      if /fName | (*fName = 0) then fail
-      fName := delSuffix(fName,".icn")||".icn"
-      uniFile := UniFile(fName) |
-	 UniFile(fName, genDirs(\sourcePath)) | {
-	    insert(badFiles, fName)
-	    fail
-	    }
-      if f := addFile(fName) then {
-	 uniFile.setSaveSrc(saveSrcFlag)
-	 fileHead := "yes"
-	 curClass := &null
-	 curComments := Comments()
-
-	 # Start by assuming this file is not part of a package
-	 curPackage := packages["(main)"]
-	 curFile.setPackage(curPackage)
-	 packages["(main)"].addFile(f)
-	 classifyLines(uniFile)
-	 if uniFile.hasSource() then {
-	    UniDoc::writeSrcFile(targetDir, uniFile)
-	    }
-	 uniFile.close()
-	 }
-
-      # See if we need to resolve imports and links...
-
-      if \resolveFlag then {     # Yep...
-
-	 cleanSets()
-
-	 # Have added package files from imports to linkSet, since
-	 #     imports are *not* file names!
-	 #
-	 while *linkSet > 0 do {
-	    every fName := !linkSet do {
-	       processFile(fName)
-	       }
-	    cleanSets()
-	    }
-	 }
-   end
-
-   #<p>
-   #  Given the name of a package, generates all the files associated with
-   #    that package.  (Uses <b>parser</b> package from <i>Robert Parlett</i>
-   #    and requires that the package has been compiled and exists on IPATH.)
-   #</p>
-   method genPackageFiles(pName)
-      local pi
-
-      pi := parser::load_package_info(pName) | fail
-      suspend !pi.get_files()
-   end
-
-   #<p>
-   # Given a string of space-separated directories, generates the
-   # individual directories from that string.  Guarantees that
-   # each directory produced ends with "/".
-   #</p>
-   # <i>This is intended for internal use only!</i>
-   method genDirs(s)
-      suspend trim(genFields(s),"/\\")||"/"
-   end
-
-   #<p>
-   # Output some simple statistics on the amount of processing
-   #  that has been performed.  Give more detail if <b>detail</b>
-   #  is non-null.
-   #</p>
-   method dumpStatistics(detail)
-      local p
-
-      write()
-      write()
-      write("UniDoc processing:")
-      write()
-
-      write("Files:         ",*files)
-      if \detail then dumpNames("\t",files)
-      write("Packages:      ",*packages)
-      if \detail then {
-	 every p := (!sort(packages))[2] do {
-	    write("\t",p.getName(),":")
-	    write("\t\tfiles:",      p.files.size())
-	    write("\t\tpackages:",   p.imports.size())
-	    write("\t\tclasses:",    p.classes.size())
-	    write("\t\tprocedures:", p.procs.size())
-	    write("\t\trecords:",    p.records.size())
-	    write("\t\tglobals:",    p.globals.size())
-	    write()
-	    }
-	 }
-
-      write("\n")
-      write("Unprocessed files: ",*badFiles)
-      if \detail then dumpNames("\t", badFiles)
-   end
-
-   # <p>
-   # Outputs a list of entity names.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method dumpNames(prefix, data)
-      if Utils::istype(data, "table") then {
-	 every write(prefix, key(data))
-	 }
-      else if Utils::istype(data, "UniDoc::Sequence") then {
-	 every write(prefix, data.get().getName())
-	 }
-      else if Utils::istype(data, "UniDoc::Set") then {
-	 every write(prefix, data.get().getName())
-	 }
-      else {
-	 every write(prefix, !sort(data))
-	 }
-   end
-
-   # <p>
-   # Parse a file, building an internal representation.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method classifyLines(f)
-      while classify(f)
-   end
-
-   # <p>
-   #  Classify the type of an input line based on tokens produced
-   #  during parsing of the file <b>f</b>.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method classify(f)
-      local token
-
-      token := f.nextToken() | fail
-
-      case token.Type() of {
-	 "UniDoc::BlankLine" : processBlank(f)
-	 "UniDoc::Comment"   : processComment(f, token.value)
-	 "UniDoc::Keyword"   : processKeyword(f, token.value)
-	 }
-
-      f.clearLine()
-      return
-   end
-
-   # <p>
-   #   Process a blank line.  Blank lines are only interesting
-   #   in that they serve to distinguish comment blocks.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processBlank(f)
-      if \fileHead then {     # File-level comments
-	 fileHead := &null
-	 curFile.setComments(curComments)
-	 }
-      curComments := Comments()    # discard current comment block
-   end
-
-   # <p>
-   #   Process a comment.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processComment(f, s)
-      curComments.add(s)
-   end
-
-   # <p>
-   # Process a keyword.  Not all keywords are interesting.  Many
-   # are simply ignored.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processKeyword(f, word)
-      case word of {
-	 "package"   : processPackage(f)
-	 "import"    : processImport(f)
-	 "link"      : processLink(f)
-	 "class"     : processClass(f)
-	 "initially" : processInitially(f)
-	 "method"    : processMethod(f)
-	 "procedure" : processProcedure(f)
-	 "global"    : processGlobal(f)
-	 "record"    : processRecord(f)
-	 }
-   end
-
-   # <p>
-   # There are places in a Unicon program where an entity may be
-   # represented by either a <i>name</i> or a <i>string</i>.
-   # This guarentees that it's represented by a name.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method getName(token)
-      if token.Type() == "UniDoc::String" then {
-	 return token.value[2:-1]
-	 }
-      return token.value
-   end
-
-   # <p>
-   # Process a package header.  Note that this implies that
-   # the current file isn't part of the <i>default</i> package.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processPackage(f)
-      local pName
-
-      pName := getName(f.nextToken())
-      /packages[pName] := UPackage(pName, curFile)
-      curPackage := packages[pName]
-      curPackage.mergeComments(curComments)
-      curComments := Comments()
-      curFile.setPackage(curPackage)
-      curPackage.addFile(curFile)
-      packages["(main)"].delFile(curFile.getName())
-   end
-
-   # <p>
-   # Process an import statement.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processImport(f)
-      local iName, iList, imp, token, sawComma
-
-      iName := getName(f.nextToken())
-      iList := iName
-      insert(importSet, iName)           # Remember for later processing
-      imp := UImport(iName, curFile, curComments)
-      curComments := Comments()
-      curFile.addImport(imp)
-      curPackage.addImport(imp)
-      while not f.EOS() do {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comma" then {
-	    token := f.nextToken()
-	    sawComma := "yes"
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    imp.addComment(token.value)
-	    if \sawComma then {
-	       f.pushback(Comma())
-	       }
-	    }
-	 else if token.Type() == ("UniDoc::Name" | "UniDoc::String") then {
-	    iName := getName(token)
-	    insert(importSet, iName)   # Remember for later processing
-	    imp := UImport(iName, curFile)
-	    iList ||:= " " || iName
-	    curFile.addImport(imp)
-	    curPackage.addImport(imp)
-	    sawComma := &null
-	    }
-	 }
-   end
-
-   # <p>
-   # Process a link statement.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processLink(f)
-      local lName, lList, lnk, token, sawComma
-
-      lName := getName(f.nextToken())
-      lList := lName
-      lName := delSuffix(lName, ".icn")||".icn"
-      insert(linkSet, lName)             # Remember for later processing
-      lName := delSuffix(lName,".icn")||".icn"
-      lnk := ULink(lName, curFile, curComments)
-      curComments := Comments()
-      curFile.addLink(lnk)
-      while not f.EOS() do {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comma" then {
-	    token := f.nextToken()
-	    sawComma := "yes"
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    lnk.addComment(token.value)
-	    if \sawComma then {
-	       f.pushback(Comma())
-	       }
-	    }
-	 else if token.Type() == ("UniDoc_Name" | "UniDoc_String") then {
-	    lName := getName(token)
-	    insert(linkSet, lName)     # Remember for later processing
-	    lList ||:= " " || lName
-	    lName := delSuffix(lName,".icn")||".icn"
-	    lnk := ULink(lName, curFile)
-	    curFile.addLink(lnk)
-	    sawComma := &null
-	    }
-	 }
-   end
-
-   # <p>
-   # Process a class header.  If there's an <b>initially</b> clause that
-   # will get tacked on later.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processClass(f)
-      local cName, const, scList, token, scName, pList, field
-
-      cName := getName(f.nextToken())
-      curClass := UClass(cName, curFile, curComments)
-      addTag(curClass)
-
-      const := UConstructor(curClass.getName(), curClass, Comments())
-      curClass.setConstructor(const)
-      curComments := Comments()
-
-      curClass.setFile(curFile)
-      curClass.setPackage(curPackage)
-      curFile.addClass(curClass)
-      curPackage.addClass(curClass)
-      scList := ""
-
-      while (token := f.nextToken()).className() ~== "UniDoc::LParen" do {
-	 if token.Type() == "UniDoc::Colon" then {
-	    next
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    if /scName then {   # attach to class
-	       curClass.addComment(token.value)
-	       }
-	    else {
-	       sClass.addComment(token.value)
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    scName := getName(token)
-	    sClass := UName(scName, curClass)
-	    sClass.setCategory("class")
-	    curClass.addSuperClass(sClass)
-	    scList ||:= ": " || scName
-	    }
-	 }
-      f.pushback(token)
-      pList := ""
-      while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
-	 if token.Type() == "UniDoc::Comma" then {
-	    next
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    if /field then {        # apply to class itself
-	       curClass.addComment(token.value)
-	       }
-	    else {                # apply to field name
-	       field.addComment(token.value)
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    field := getParam(f, token, "field", curClass)
-	    pList ||:= " " || field.getName()
-	    curClass.addField(field)
-	    }
-	 }
-
-      if not f.EOS() then {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comment" then {
-	    curClass.addComment(token.value)
-	    }
-	 else f.pushback(token)
-	 }
-
-      curClass.getConstructor().setParams(curClass.getParams())
-   end
-
-   # <p>
-   # Get a parameter.
-   # </p>
-   method getParam(f, token, category, parent)
-      fName := getName(token)
-      param := UName(fName, parent)
-      param.setCategory(category)
-
-      # Look for default value and or type. (Note: if
-      #   only one or the other, can't distinquish so assume default value
-      #
-      if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
-	 token := f.nextToken()      # initializer
-	 param.setDefValue(token.get())
-	 if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
-	    # oops, had a type earlier!
-	    param.setTypeValue(param.getDefValue())
-	    token := f.nextToken()      # initializer
-	    param.setDefValue(token.get())
-	    }
-	 else f.pushback(token)
-	 }
-      else f.pushback(token)
-
-      return param
-   end
-
-   # <p>
-   # Get a global.
-   # </p>
-   method getGlobal(f, token, parent, comments)
-      gName := getName(token)
-      glob := UGlobal(gName, parent, comments)
-      addTag(glob)
-
-      # Look for default value and or type. (Note: if
-      #   only one or the other, can't distinquish so assume default
-      #   value
-      if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
-	 token := f.nextToken()      # initializer
-	 glob.setDefValue(token.get())
-	 if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
-	    # oops, had a type earlier!
-	    glob.setTypeValue(glob.getDefValue())
-	    token := f.nextToken()      # initializer
-	    glob.setDefValue(token.get())
-	    }
-	 else f.pushback(token)
-	 }
-      else f.pushback(token)
-
-      curFile.addGlobal(glob)
-      curPackage.addGlobal(glob)
-
-      return glob
-   end
-
-   # <p>
-   # Process an initially clause, treating it as a class
-   # constructor.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processInitially(f)
-      local const, token, pList, param
-
-      const := UConstructor(curClass.getName(), curClass, curComments)
-      addTag(const)
-      curComments := Comments()
-      curClass.setConstructor(const)
-      token := f.nextToken()
-      if token.Type() == "UniDoc::LParen" then {
-	 const.setParams(Sequence())
-	 pList := ""
-	 while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
-	    if token.Type() == "UniDoc::Comma" then {
-	       next
-	       }
-	    if token.Type() == "UniDoc::Comment" then {
-	       if /param then {        # apply to constructor itself
-		  const.addComment(token.value)
-		  }
-	       else {                # apply to parameter name
-		  param.addComment(token.value)
-		  }
-	       }
-	    else if token.Type() == "UniDoc::Name" then {
-	       param := getParam(f, token, "param", curClass)
-	       pList ||:= " " || param.getName()
-	       const.addParam(param)
-	       }
-	    }
-	 }
-      else {
-	 f.pushback(token)
-	 }
-
-      if not f.EOS() then {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comment" then {
-	    const.addComment(token.value)
-	    }
-	 else f.pushback(token)
-	 }
-
-      # No param list on constructor, so assume all fields!
-      if /const.getParams() then {
-	 const.setParams(curClass.getParams())
-	 }
-   end
-
-   # <p>
-   # Process a method definition.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processMethod(f)
-      local mName, pList, met, token, param
-
-      mName := getName(f.nextToken())
-      pList := ""
-      met := UMethod(mName, curClass, curComments)
-      addTag(met)
-      curClass.addMethod(met)
-      curComments := Comments()
-      token := f.nextToken()
-      if token.Type() == "UniDoc::LParen" then {
-	 token := f.nextToken()
-	 }
-      if token.Type() == "UniDoc::Comment" then {
-	 met.addComment(token.value)
-	 }
-      else if token.Type() ~== "UniDoc::LParen" then {
-	 f.pushback(token)
-	 }
-
-      while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
-	 if token.Type() == "UniDoc::Comma" then {
-	    next
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    if /param then {        # apply to method itself
-	       met.addComment(token.value)
-	       }
-	    else {                # apply to parameter name
-	       param.addComment(token.value)
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    param := getParam(f, token, "param", curClass)
-	    pList ||:= " " || param.getName()
-	    met.addParam(param)
-	    }
-	 }
-
-      if not f.EOS() then {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comment" then {
-	    met.addComment(token.value)
-	    }
-	 else f.pushback(token)
-	 }
-   end
-
-   # <p>
-   # Process a procedure definition.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processProcedure(f)
-      local pName, pList, proced, token, param
-
-      pName := getName(f.nextToken())
-      pList := ""
-      proced := UProc(pName, curFile, curComments)
-      addTag(proced)
-      curFile.addProcedure(proced)
-      curPackage.addProcedure(proced)
-      curComments := Comments()
-      token := f.nextToken()
-      if token.Type() == "UniDoc::LParen" then {
-	 token := f.nextToken()
-	 }
-      if token.Type() == "UniDoc::Comment" then {
-	 proced.addComment(token.value)
-	 }
-      else if token.Type() ~== "UniDoc::LParen" then {
-	 f.pushback(token)
-	 }
-
-      while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
-	 if token.Type() == "UniDoc::Comma" then {
-	    next
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    if /param then {        # apply to record itself
-	       proced.addComment(token.value)
-	       }
-	    else {                # apply to field name
-	       param.addComment(token.value)
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    param := getParam(f, token, "param", proced)
-	    pList ||:= " " || param.getName()
-	    proced.addParam(param)
-	    }
-	 }
-
-      if not f.EOS() then {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comment" then {
-	    proced.addComment(token.value)
-	    }
-	 else f.pushback(token)
-	 }
-   end
-
-   # <p>
-   # Process a global statement.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processGlobal(f)
-      local gName, gList, glob, token, sawComma
-      gList := ""
-
-      glob := getGlobal(f, f.nextToken(), curFile, curComments)
-      gList ||:= " " || glob.getName()
-      curComments := Comments()
-      while not f.EOS() do {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comma" then {
-	    token := f.nextToken()
-	    sawComma := "yes"
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    glob.addComment(token.value)
-	    if \sawComma then {
-	       f.pushback(Comma())
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    glob := getGlobal(f, token, curFile)
-	    gList ||:= " " || glob.getName()
-	    sawComma := &null
-	    }
-	 }
-      uniFile.setInside()                # re-enable Unicon keywords
-   end
-
-   # <p>
-   # Process a record definition.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method processRecord(f)
-      local rName, pList, rec, token, field
-
-      rName := getName(f.nextToken())
-      pList := ""
-      rec := URecord(rName, curFile, curComments)
-      addTag(rec)
-      curFile.addRecord(rec)
-      curPackage.addRecord(rec)
-      curComments := Comments()
-      token := f.nextToken()
-      if token.Type() == "UniDoc::LParen" then {
-	 token := f.nextToken()
-	 }
-      if token.Type() == "UniDoc::Comment" then {
-	 rec.addComment(token.value)
-	 }
-      else if token.Type() ~== "UniDoc::LParen" then {
-	 f.pushback(token)
-	 }
-
-      while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
-	 if token.Type() == "UniDoc::Comma" then {
-	    next
-	    }
-	 if token.Type() == "UniDoc::Comment" then {
-	    if /field then {        # apply to record itself
-	       rec.addComment(token.value)
-	       }
-	    else {                # apply to field name
-	       field.addComment(token.value)
-	       }
-	    }
-	 else if token.Type() == "UniDoc::Name" then {
-	    field := getParam(f, token, "field", rec)
-	    pList ||:= " " || field.getName()
-	    rec.addField(field)
-	    }
-	 }
-
-      if not f.EOS() then {
-	 token := f.nextToken()
-	 if token.Type() == "UniDoc::Comment" then {
-	    rec.addComment(token.value)
-	    }
-	 else f.pushback(token)
-	 }
-
-      uniFile.setInside()                # re-enable Unicon keywords
-   end
-
-   # <p>
-   # Produce a table of all methods that are inherited by
-   #   a class.  Keys are superclasses, entries are
-   #   UniDoc::Set()s of methods.
-   # </p>
-   method inherited(aClass)
-      local iSet, mSet, sc, metd, mName
-
-      # Start with all the methods in the current class
-      every insert(mSet := ::set(), aClass.getMethods().get().getName())
-
-      iSet := table()
-      #mSet := set()
-      every sc := genAllSuperClasses(aClass) do {
-	 every metd := sc.getMethods().get() do {
-	    mName := metd.getName()
-	    if not member(mSet, mName) then {
-	       insert(mSet, mName)
-	       /iSet[sc] := Set()
-	       iSet[sc].add(mName, metd)
-	       }
-	    }
-	 }
-
-      return iSet
-   end
-
-   # <p>
-   # Produce a sorted list (by name) of superclasses,
-   #    given a table whose keys are superclasses.
-   # </p>
-   method makeNameTab(aTab)
-
-      nTab := table()
-      every sc := key(aTab) do {
-	 nTab[sc.getName()] := sc
-	 }
-      every put(nList := [], (!sort(nTab))[2])
-      return nList
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> packages.
-   # </p>
-   method getAllPackages()
-      local ptab, p, plist
-
-      ptab := table()
-      every p := !packages do {
-	 ptab[p] := p.getName()
-	 }
-      every put(plist := [], (!sort(ptab, 2))[1])
-      return plist
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> classes.
-   # </p>
-   method getAllClasses()
-      local ctab, p, g, clist
-
-      ctab := table()
-      every p := !files do {
-	 every g := p.getClasses().get() do {
-	    ctab[g] := g.getName()
-	    }
-	 }
-      every put(clist := [], (!sort(ctab, 2))[1])
-      return clist
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> procedures.
-   # </p>
-   method getAllProcedures()
-      local ctab, p, g, clist
-
-      ctab := table()
-      every p := !files do {
-	 every g := p.getProcedures().get() do {
-	    ctab[g] := g.getName()
-	    }
-	 }
-      every put(clist := [], (!sort(ctab, 2))[1])
-      return clist
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> records.
-   # </p>
-   method getAllRecords()
-      local ctab, p, g, clist
-
-      ctab := table()
-      every p := !files do {
-	 every g := p.getRecords().get() do {
-	    ctab[g] := g.getName()
-	    }
-	 }
-      every put(clist := [], (!sort(ctab, 2))[1])
-      return clist
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> globals.
-   # </p>
-   method getAllGlobals()
-      local ctab, p, g, clist
-
-      ctab := table()
-      every p := !files do {
-	 every g := p.getGlobals().get() do {
-	    ctab[g] := g.getName()
-	    }
-	 }
-      every put(clist := [], (!sort(ctab, 2))[1])
-      return clist
-   end
-
-   # <p>
-   # Produce a list of <i>all</i> files that have been processed,
-   # whether by explicit reference <b>processFile()</b> or during
-   # entity resolution.
-   # </p>
-   method getAllFiles()
-      local ctab, f, clist
-
-      ctab := table()
-      every f := \!files do {
-	 ctab[f.getName()] := f
-	 }
-      every put(clist := [], (!sort(ctab))[2])
-      return clist
-   end
-
-   # <p>
-   # Given the name of a class, attempts to find an existing
-   # html page for that class, by searching the <b>linkPath</b>.
-   # </p>
-   # <p><b>This method is currently broken!</b></p>
-   method classOnLinkPath(bClass, cName)
-      local pName
-
-      # great idea, but generates wrong name (need source file
-      #   for class, not the package name!)  Leave in for
-      #   now because it's no worse than anything else.
-      #
-      cName ? {
-	 if pName := tabSkip("::"|"__") then {
-	    if pName == "" then pName := "0main"
-	    cName := tab(0)
-	    return "class_"||pName||"_"||cName
-	    }
-	 }
-
-      # Don't know how to write the rest because can't determine
-      #   the package for a class from the class name yet!
-   end
-
-   # <p>
-   # Given a class and the name of a superclass of that class,
-   #   return that superclass.
-   # </p>
-   method locateSuperClass(aClass, scName)
-      local pName, p, f, sc
-
-      # If the superclass name tells us the package, use that.
-      scName ? {
-	 if pName := tabSkip("::"|"__") then {
-	    if pName := "" then pName := "(main)"
-	    scName := tab(0)
-	    if \(p := packages[pName]) then {
-	       sc := p.getClass(scName)
-	       return \sc
-	       }
-	 fail                # No hope of finding it!
-	 }
-      }
-
-      # Have to look for it.  Go file, package, imports, links...
-      f := aClass.getFile()
-      p := f.getPackage()
-      if \(sc := (f|p).getClass(scName)) then return sc
-      every pName := f.getImports().get().getName() do {
-	 if \(p := packages[pName]) then {
-	    if \(sc := p.getClass(scName)) then return sc
+class UniAll : Object (files, packages, 
+                      curFile, curClass, curPackage, curComments, fileHead,
+                      uniFile, resolveFlag, targetDir, saveSrcFlag,
+                      importSet, linkSet, badFiles, sourcePath)
+
+    # <p>
+    # Set the level of entity resolution.  If <b>flag</b> is <b>&null</b>,
+    # then references to entities <i>not</i> contained in files passed
+    # to <b>processFile()</b> are not expanded.  If <b>flag</b> is non-null,
+    # then the current sourcePath is used to locate these entities.
+    # </p>
+    method fullyResolve(flag)
+        if map(flag[1]) == "n" then flag := &null
+        resolveFlag := flag
+    end
+
+    # <p>
+    # Set the source path to be used when attempting to resolve
+    # unknown entities.
+    # </p>
+    method setSourcePath(p)
+        sourcePath := p
+    end
+
+    # <p>
+    # Decide whether or not to save a copy of source code to link to.
+    # </p>
+    method setSaveSrc(flag)
+        if map(flag[1]) == "n" then flag := &null
+        saveSrcFlag := flag
+    end
+
+    # <p>
+    # Remember the target directory (needed if we're output source
+    # code for later linking.)
+    # </p>
+    method setTargetDir(tDir)
+        targetDir := tDir
+    end
+
+    # <p>
+    # Remember <b>fName</b> as a file that has been processed.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    #
+    method addFile(fName)
+        if curFile := /files[fName] := UFile(fName) then {
+            if \saveSrcFlag then 
+                curFile.setSrcFile(uniFile.getFilename())
+            return curFile
             }
-         }
-      every fName := f.getLinks().get().getName() do {
-	 if \(p := files[pName]) then {
-	    if \(sc := p.getClass(scName)) then return sc
+    end
+
+    # <p>
+    # Insert a tag for an entirty into the saved source code, if any.
+    # </p>
+    method addTag(obj)
+        if uniFile.hasSource() then {
+            if \saveSrcFlag then 
+                obj.setSrcFile(uniFile.getFilename())
+            tag := obj.getFormType()||"_"||obj.getName()
+            uniFile.setTag(tag)
             }
-         }
+    end
 
-      # Last chance - check the (main) package.
-      sc := packages["(main)"].getClass(scName)
-      return \sc
-   end
+    # <p>
+    #  Remove any files that have already been processed from the
+    #    import and link sets.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    #
+    method cleanSets()
+        local fName, pName, fList
 
-   # <p>
-   # Generate (in order) all the superclasses of a class
-   # </p>
-   method genAllSuperClasses(aClass, scSet)
-      /scSet := ::set()
-      insert(scSet, aClass)
-      scSeq := aClass.getSuperClasses()
-      every scName := scSeq.get().getName() do {
-	 if sc := locateSuperClass(aClass, scName) then {
-	    if not member(scSet, sc) then {   # Haven't seen it yet
-	       suspend sc | genAllSuperClasses(sc, scSet)
-	       }
-	    }
-	 }
-   end
+        # for now, just be satisfied with the link set, since
+        #     imports are *not* file names!
+        #
+        every fName := !linkSet do {
+            if \files[fName] then {     # Already processed, remove
+                delete(linkSet, fName)
+                }
+            }
+        every pName := !importSet do {
+            every fName := genPackageFiles(pName) do {
+                if /fName | (*fName == 0) then next
+                if /files[fName] then {     # Need to process
+                    insert(linkSet, \fName)
+                    }
+                }
+            }
+        every delete(linkSet, !badFiles)
 
-   # <p>
-   # Given a class and a method name from that class, does this method
-   #   override any method from a superclass?
-   # </p><p>
-   # Returns the superclass of the overridden method, if any.
-   # </p>
-   method overrides(aClass, mName)
-      every sc := genAllSuperClasses(aClass) do {
-	 if sc.hasMethod(mName) then {
-	    return sc
-	    }
-	 }
-   end
+    end
+            
 
-initially ()
-   every (files|packages) := table()
-   packages["(main)"]     := UPackage("(main)")
-   resolveFlag            := &null
-   sourcePath             := &null
-   importSet              := ::set()
-   linkSet                := ::set()
-   lName                  := delSuffix(lName, ".icn")||".icn"
-   badFiles               := ::set()
+    # <p>
+    # This is the main entry point to the <b>UniAll</b> class.  When
+    # invoked, the file <b>fName</b> is parsed and added to an
+    # internal representation for the Unicon source code being
+    # handled by this class instance.  May be called repeatedly to
+    # process multiple files.
+    # </p>
+    method processFile(fName)
+
+        if /fName | (*fName = 0) then fail
+        fName := delSuffix(fName,".icn")||".icn"
+        uniFile := UniFile(fName) |
+                   UniFile(fName, genDirs(\sourcePath)) | {
+                   insert(badFiles, fName)
+                   fail
+                   }
+        if f := addFile(fName) then {
+            uniFile.setSaveSrc(saveSrcFlag)
+            fileHead := "yes"
+            curClass := &null
+            curComments := Comments()
+
+            # Start by assuming this file is not part of a package
+            curPackage := packages["(main)"]
+            curFile.setPackage(curPackage)
+            packages["(main)"].addFile(f)
+            classifyLines(uniFile)
+            if uniFile.hasSource() then {
+                UniDoc::writeSrcFile(targetDir, uniFile)
+                }
+            uniFile.close()
+            }
+
+        # See if we need to resolve imports and links...
+        
+        if \resolveFlag then {     # Yep...
+
+            cleanSets()
+
+            # Have added package files from imports to linkSet, since
+            #     imports are *not* file names!
+            #
+            while *linkSet > 0 do {
+                every fName := !linkSet do {
+                    processFile(fName)
+                    }
+                cleanSets()
+                }
+
+            }
+            
+
+    end
+
+    #<p>
+    #  Given the name of a package, generates all the files associated with
+    #    that package.  (Uses <b>parser</b> package from <i>Robert Parlett</i>
+    #    and requires that the package has been compiled and exists on IPATH.)
+    #</p>
+    method genPackageFiles(pName)
+        local pi
+
+        pi := parser::load_package_info(pName) | fail
+        suspend !pi.get_files()
+    end
+
+    #<p>
+    # Given a string of space-separated directories, generates the
+    # individual directories from that string.  Guarantees that
+    # each directory produced ends with "/".
+    #</p>
+    # <i>This is intended for internal use only!</i>
+    method genDirs(s)
+        suspend trim(genFields(s),"/\\")||"/"
+    end
+
+    #<p>
+    # Output some simple statistics on the amount of processing
+    #  that has been performed.  Give more detail if <b>detail</b>
+    #  is non-null.
+    #</p>
+    method dumpStatistics(detail)
+        local p
+
+        write()
+        write()
+        write("UniDoc processing:")
+        write()
+
+        write("Files:         ",*files)
+        if \detail then dumpNames("\t",files)
+        write("Packages:      ",*packages)
+        if \detail then {
+            every p := (!sort(packages))[2] do {
+                write("\t",p.getName(),":")
+                write("\t\tfiles:",      p.files.size())
+                write("\t\tpackages:",   p.imports.size())
+                write("\t\tclasses:",    p.classes.size())
+                write("\t\tprocedures:", p.procs.size())
+                write("\t\trecords:",    p.records.size())
+                write("\t\tglobals:",    p.globals.size())
+                write()
+                }
+            }
+
+        write("\n")
+        write("Unprocessed files: ",*badFiles)
+        if \detail then dumpNames("\t", badFiles)
+    end
+
+    # <p>
+    # Outputs a list of entity names.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method dumpNames(prefix, data)
+        if lang::istype(data, "table") then {
+            every write(prefix, key(data))
+            }
+        else if lang::istype(data, "UniDoc::Sequence") then {
+            every write(prefix, data.get().getName())
+            }
+        else if lang::istype(data, "UniDoc::Set") then {
+            every write(prefix, data.get().getName())
+            }
+        else {
+            every write(prefix, !sort(data))
+            }
+    end
+
+    # <p>
+    # Parse a file, building an internal representation.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method classifyLines(f)
+        while classify(f)
+    end
+
+    # <p>
+    #  Classify the type of an input line based on tokens produced
+    #  during parsing of the file <b>f</b>.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method classify(f)
+        local token
+
+        token := f.nextToken() | fail
+    
+        case token.Type() of {
+            "UniDoc::BlankLine" : processBlank(f)
+            "UniDoc::Comment"   : processComment(f, token.value)
+            "UniDoc::Keyword"   : processKeyword(f, token.value)
+            }
+    
+        f.clearLine()
+        return
+    end
+    
+    # <p>
+    #   Process a blank line.  Blank lines are only interesting
+    #   in that they serve to distinguish comment blocks.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processBlank(f)
+        if \fileHead then {     # File-level comments
+            fileHead := &null
+            curFile.setComments(curComments)
+            }
+        curComments := Comments()    # discard current comment block
+    end
+    
+    # <p>
+    #   Process a comment.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processComment(f, s)
+        curComments.add(s)
+    end
+    
+    # <p>
+    # Process a keyword.  Not all keywords are interesting.  Many
+    # are simply ignored.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processKeyword(f, word)
+        case word of {
+            "package"   : processPackage(f)
+            "import"    : processImport(f)
+            "link"      : processLink(f)
+            "class"     : processClass(f)
+            "initially" : processInitially(f)
+            "method"    : processMethod(f)
+            "procedure" : processProcedure(f)
+            "global"    : processGlobal(f)
+            "record"    : processRecord(f)
+            }
+    end
+    
+    # <p>
+    # There are places in a Unicon program where an entity may be
+    # represented by either a <i>name</i> or a <i>string</i>.
+    # This guarentees that it's represented by a name.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method getName(token)
+        if token.Type() == "UniDoc::String" then {
+            return token.value[2:-1]
+            }
+        return token.value
+    end
+
+    # <p>
+    # Process a package header.  Note that this implies that
+    # the current file isn't part of the <i>default</i> package.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processPackage(f)
+        local pName
+
+        pName := getName(f.nextToken())
+        /packages[pName] := UPackage(pName, curFile)
+        curPackage := packages[pName]
+        curPackage.mergeComments(curComments)
+        curComments := Comments()
+        curFile.setPackage(curPackage)
+        curPackage.addFile(curFile)
+        packages["(main)"].delFile(curFile.getName())
+    end
+    
+    # <p>
+    # Process an import statement.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processImport(f)
+        local iName, iList, imp, token, sawComma
+
+        iName := getName(f.nextToken())
+        iList := iName
+        insert(importSet, iName)           # Remember for later processing
+        imp := UImport(iName, curFile, curComments)
+        curComments := Comments()
+        curFile.addImport(imp)
+        curPackage.addImport(imp)
+        while not f.EOS() do {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comma" then {
+                token := f.nextToken()
+                sawComma := "yes"
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                imp.addComment(token.value)
+                if \sawComma then {
+                    f.pushback(Comma())
+                    }
+                }
+            else if token.Type() == ("UniDoc::Name" | "UniDoc::String") then {
+                iName := getName(token)
+                insert(importSet, iName)   # Remember for later processing
+                imp := UImport(iName, curFile)
+                iList ||:= " " || iName
+                curFile.addImport(imp)
+                curPackage.addImport(imp)
+                sawComma := &null
+                }
+            }
+    
+    end
+    
+    # <p>
+    # Process a link statement.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processLink(f)
+        local lName, lList, lnk, token, sawComma
+
+        lName := getName(f.nextToken())
+        lList := lName
+        lName := delSuffix(lName, ".icn")||".icn"
+        insert(linkSet, lName)             # Remember for later processing
+        lName := delSuffix(lName,".icn")||".icn"
+        lnk := ULink(lName, curFile, curComments)
+        curComments := Comments()
+        curFile.addLink(lnk)
+        while not f.EOS() do {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comma" then {
+                token := f.nextToken()
+                sawComma := "yes"
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                lnk.addComment(token.value)
+                if \sawComma then {
+                    f.pushback(Comma())
+                    }
+                }
+            else if token.Type() == ("UniDoc_Name" | "UniDoc_String") then {
+                lName := getName(token)
+                insert(linkSet, lName)     # Remember for later processing
+                lList ||:= " " || lName
+                lName := delSuffix(lName,".icn")||".icn"
+                lnk := ULink(lName, curFile)
+                curFile.addLink(lnk)
+                sawComma := &null
+                }
+            }
+    
+    end
+    
+    # <p>
+    # Process a class header.  If there's an <b>initially</b> clause that
+    # will get tacked on later.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processClass(f)
+        local cName, const, scList, token, scName, pList, field
+
+        cName := getName(f.nextToken())
+        curClass := UClass(cName, curFile, curComments)
+        addTag(curClass)
+
+        const := UConstructor(curClass.getName(), curClass, Comments())
+        curClass.setConstructor(const)
+        curComments := Comments()
+
+        curClass.setFile(curFile)
+        curClass.setPackage(curPackage)
+        curFile.addClass(curClass)
+        curPackage.addClass(curClass)
+        scList := ""
+
+        while (token := f.nextToken()).className() ~== "UniDoc::LParen" do {
+            if token.Type() == "UniDoc::Colon" then {
+                next
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                if /scName then {   # attach to class
+                    curClass.addComment(token.value)
+                    }
+                else {
+                    sClass.addComment(token.value)
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                scName := getName(token)
+                sClass := UName(scName, curClass)
+                sClass.setCategory("class")
+                curClass.addSuperClass(sClass)
+                scList ||:= ": " || scName
+                }
+            }
+        f.pushback(token)
+        pList := ""
+        while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
+            if token.Type() == "UniDoc::Comma" then {
+                next
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                if /field then {        # apply to class itself
+                    curClass.addComment(token.value)
+                    }
+                else {                # apply to field name
+                    field.addComment(token.value)
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                field := getParam(f, token, "field", curClass)
+                pList ||:= " " || field.getName()
+                curClass.addField(field)
+                }
+            }
+    
+        if not f.EOS() then {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comment" then {
+                curClass.addComment(token.value)
+                }
+            else f.pushback(token)
+            }
+
+        curClass.getConstructor().setParams(curClass.getParams())
+    end
+
+    # <p>
+    # Get a parameter.
+    # </p>
+    method getParam(f, token, category, parent)
+        fName := getName(token)
+        param := UName(fName, parent)
+        param.setCategory(category)
+
+        # Look for default value and or type. (Note: if
+        #   only one or the other, can't distinquish so assume default value
+        #
+        if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
+            token := f.nextToken()      # initializer
+            param.setDefValue(token.get())
+            if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
+                # oops, had a type earlier!
+                param.setTypeValue(param.getDefValue())
+                token := f.nextToken()      # initializer
+                param.setDefValue(token.get())
+                }
+            else f.pushback(token)
+            }
+        else f.pushback(token)
+
+        return param
+    end
+
+    # <p>
+    # Get a global.
+    # </p>
+    method getGlobal(f, token, parent, comments)
+        gName := getName(token)
+        glob := UGlobal(gName, parent, comments)
+        addTag(glob)
+
+        # Look for default value and or type. (Note: if
+        #   only one or the other, can't distinquish so assume default
+        #   value
+        if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
+            token := f.nextToken()      # initializer
+            glob.setDefValue(token.get())
+            if (token := f.nextToken()).Type() == "UniDoc::Colon" then {
+                # oops, had a type earlier!
+                glob.setTypeValue(glob.getDefValue())
+                token := f.nextToken()      # initializer
+                glob.setDefValue(token.get())
+                }
+            else f.pushback(token)
+            }
+        else f.pushback(token)
+
+        curFile.addGlobal(glob)
+        curPackage.addGlobal(glob)
+
+        return glob
+    end
+    
+    # <p>
+    # Process an initially clause, treating it as a class
+    # constructor.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processInitially(f)
+        local const, token, pList, param
+
+        const := UConstructor(curClass.getName(), curClass, curComments)
+        addTag(const)
+        curComments := Comments()
+        curClass.setConstructor(const)
+        token := f.nextToken()
+        if token.Type() == "UniDoc::LParen" then {
+            const.setParams(Sequence())
+            pList := ""
+            while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
+                if token.Type() == "UniDoc::Comma" then {
+                    next
+                    }
+                if token.Type() == "UniDoc::Comment" then {
+                    if /param then {        # apply to constructor itself
+                        const.addComment(token.value)
+                        }
+                    else {                # apply to parameter name
+                        param.addComment(token.value)
+                        }
+                    }
+                else if token.Type() == "UniDoc::Name" then {
+                    param := getParam(f, token, "param", curClass)
+                    pList ||:= " " || param.getName()
+                    const.addParam(param)
+                    }
+                }
+            }
+        else {
+            f.pushback(token)
+            }
+    
+        if not f.EOS() then {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comment" then {
+                const.addComment(token.value)
+                }
+            else f.pushback(token)
+            }
+        
+        # No param list on constructor, so assume all fields!
+        if /const.getParams() then {
+            const.setParams(curClass.getParams())
+            }
+    end
+    
+    # <p>
+    # Process a method definition.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processMethod(f)
+        local mName, pList, met, token, param
+
+        mName := getName(f.nextToken())
+        pList := ""
+        met := UMethod(mName, curClass, curComments)
+        addTag(met)
+        curClass.addMethod(met)
+        curComments := Comments()
+        token := f.nextToken()
+        if token.Type() == "UniDoc::LParen" then {
+            token := f.nextToken()
+            }
+        if token.Type() == "UniDoc::Comment" then {
+            met.addComment(token.value)
+            }
+        else if token.Type() ~== "UniDoc::LParen" then {
+            f.pushback(token)
+            }
+        
+        while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
+            if token.Type() == "UniDoc::Comma" then {
+                next
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                if /param then {        # apply to method itself
+                    met.addComment(token.value)
+                    }
+                else {                # apply to parameter name
+                    param.addComment(token.value)
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                param := getParam(f, token, "param", curClass)
+                pList ||:= " " || param.getName()
+                met.addParam(param)
+                }
+            }
+    
+        if not f.EOS() then {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comment" then {
+                met.addComment(token.value)
+                }
+            else f.pushback(token)
+            }
+        
+    end
+    
+    # <p>
+    # Process a procedure definition.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processProcedure(f)
+        local pName, pList, proced, token, param
+
+        pName := getName(f.nextToken())
+        pList := ""
+        proced := UProc(pName, curFile, curComments)
+        addTag(proced)
+        curFile.addProcedure(proced)
+        curPackage.addProcedure(proced)
+        curComments := Comments()
+        token := f.nextToken()
+        if token.Type() == "UniDoc::LParen" then {
+            token := f.nextToken()
+            }
+        if token.Type() == "UniDoc::Comment" then {
+            proced.addComment(token.value)
+            }
+        else if token.Type() ~== "UniDoc::LParen" then {
+            f.pushback(token)
+            }
+        
+        while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
+            if token.Type() == "UniDoc::Comma" then {
+                next
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                if /param then {        # apply to record itself
+                    proced.addComment(token.value)
+                    }
+                else {                # apply to field name
+                    param.addComment(token.value)
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                param := getParam(f, token, "param", proced)
+                pList ||:= " " || param.getName()
+                proced.addParam(param)
+                }
+            }
+    
+        if not f.EOS() then {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comment" then {
+                proced.addComment(token.value)
+                }
+            else f.pushback(token)
+            }
+    end
+    
+    # <p>
+    # Process a global statement.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processGlobal(f)
+        local gName, gList, glob, token, sawComma
+        gList := ""
+
+        glob := getGlobal(f, f.nextToken(), curFile, curComments)
+        gList ||:= " " || glob.getName()
+        curComments := Comments()
+        while not f.EOS() do {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comma" then {
+                token := f.nextToken()
+                sawComma := "yes"
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                glob.addComment(token.value)
+                if \sawComma then {
+                    f.pushback(Comma())
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                glob := getGlobal(f, token, curFile)
+                gList ||:= " " || glob.getName()
+                sawComma := &null
+                }
+
+            }
+
+            uniFile.setInside()                # re-enable Unicon keywords
+    end
+    
+    # <p>
+    # Process a record definition.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method processRecord(f)
+        local rName, pList, rec, token, field
+
+        rName := getName(f.nextToken())
+        pList := ""
+        rec := URecord(rName, curFile, curComments)
+        addTag(rec)
+        curFile.addRecord(rec)
+        curPackage.addRecord(rec)
+        curComments := Comments()
+        token := f.nextToken()
+        if token.Type() == "UniDoc::LParen" then {
+            token := f.nextToken()
+            }
+        if token.Type() == "UniDoc::Comment" then {
+            rec.addComment(token.value)
+            }
+        else if token.Type() ~== "UniDoc::LParen" then {
+            f.pushback(token)
+            }
+        
+        while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
+            if token.Type() == "UniDoc::Comma" then {
+                next
+                }
+            if token.Type() == "UniDoc::Comment" then {
+                if /field then {        # apply to record itself
+                    rec.addComment(token.value)
+                    }
+                else {                # apply to field name
+                    field.addComment(token.value)
+                    }
+                }
+            else if token.Type() == "UniDoc::Name" then {
+                field := getParam(f, token, "field", rec)
+                pList ||:= " " || field.getName()
+                rec.addField(field)
+                }
+            }
+    
+        if not f.EOS() then {
+            token := f.nextToken()
+            if token.Type() == "UniDoc::Comment" then {
+                rec.addComment(token.value)
+                }
+            else f.pushback(token)
+            }
+        
+            uniFile.setInside()                # re-enable Unicon keywords
+    end
+
+    # <p>
+    # Produce a table of all methods that are inherited by
+    #   a class.  Keys are superclasses, entries are 
+    #   UniDoc::Set()s of methods.
+    # </p>
+    method inherited(aClass)
+        local iSet, mSet, sc, metd, mName
+
+        # Start with all the methods in the current class
+        every insert(mSet := ::set(), aClass.getMethods().get().getName())
+
+        iSet := table()
+        #mSet := set()
+        every sc := genAllSuperClasses(aClass) do {
+            every metd := sc.getMethods().get() do {
+                mName := metd.getName()
+                if not member(mSet, mName) then {
+                    insert(mSet, mName)
+                    /iSet[sc] := Set()
+                    iSet[sc].add(mName, metd)
+                    }
+                }
+            }
+
+        return iSet
+    end
+
+    # <p>
+    # Produce a sorted list (by name) of superclasses,
+    #    given a table whose keys are superclasses.
+    # </p>
+    method makeNameTab(aTab)
+        
+        nTab := table()
+        every sc := key(aTab) do {
+            nTab[sc.getName()] := sc
+            }
+        every put(nList := [], (!sort(nTab))[2])
+        return nList
+    end
+            
+    # <p>
+    # Produce a list of <i>all</i> packages.
+    # </p>
+    method getAllPackages()
+        local ptab, p, plist
+
+        ptab := table()
+        every p := !packages do {
+            ptab[p] := p.getName()
+            }
+        every put(plist := [], (!sort(ptab, 2))[1])
+        return plist
+    end
+
+    # <p>
+    # Produce a list of <i>all</i> classes.
+    # </p>
+    method getAllClasses()
+        local ctab, p, g, clist
+
+        ctab := table()
+        every p := !files do {
+            every g := p.getClasses().get() do {
+                ctab[g] := g.getName()
+                }
+            }
+        every put(clist := [], (!sort(ctab, 2))[1])
+        return clist
+    end
+
+    # <p>
+    # Produce a list of <i>all</i> procedures.
+    # </p>
+    method getAllProcedures()
+        local ctab, p, g, clist
+
+        ctab := table()
+        every p := !files do {
+            every g := p.getProcedures().get() do {
+                ctab[g] := g.getName()
+                }
+            }
+        every put(clist := [], (!sort(ctab, 2))[1])
+        return clist
+    end
+
+    # <p>
+    # Produce a list of <i>all</i> records.
+    # </p>
+    method getAllRecords()
+        local ctab, p, g, clist
+
+        ctab := table()
+        every p := !files do {
+            every g := p.getRecords().get() do {
+                ctab[g] := g.getName()
+                }
+            }
+        every put(clist := [], (!sort(ctab, 2))[1])
+        return clist
+    end
+
+    # <p>
+    # Produce a list of <i>all</i> globals.
+    # </p>
+    method getAllGlobals()
+        local ctab, p, g, clist
+
+        ctab := table()
+        every p := !files do {
+            every g := p.getGlobals().get() do {
+                ctab[g] := g.getName()
+                }
+            }
+        every put(clist := [], (!sort(ctab, 2))[1])
+        return clist
+    end
+
+    # <p>
+    # Produce a list of <i>all</i> files that have been processed,
+    # whether by explicit reference <b>processFile()</b> or during
+    # entity resolution.
+    # </p>
+    method getAllFiles()
+        local ctab, f, clist
+
+        ctab := table()
+        every f := \!files do {
+           ctab[f.getName()] := f
+           }
+        every put(clist := [], (!sort(ctab))[2])
+        return clist
+    end
+
+    # <p>
+    # Given the name of a class, attempts to find an existing
+    # html page for that class, by searching the <b>linkPath</b>.
+    # </p>
+    # <p><b>This method is currently broken!</b></p>
+    method classOnLinkPath(bClass, cName)
+        local pName
+
+        # great idea, but generates wrong name (need source file
+        #   for class, not the package name!)  Leave in for
+        #   now because it's no worse than anything else.
+        #
+        cName ? {
+            if pName := tabSkip("::"|"__") then {
+                if pName == "" then pName := "0main"
+                cName := tab(0)
+                return "class_"||pName||"_"||cName
+                }
+            }
+
+        # Don't know how to write the rest because can't determine
+        #   the package for a class from the class name yet!
+    end
+
+    # <p>
+    # Given a class and the name of a superclass of that class,
+    #   return that superclass.
+    # </p>
+    method locateSuperClass(aClass, scName)
+        local pName, p, f, sc
+
+        # If the superclass name tells us the package, use that.
+        scName ? {
+            if pName := tabSkip("::"|"__") then {
+                if pName := "" then pName := "(main)"
+                scName := tab(0)
+                if \(p := packages[pName]) then {
+                    sc := p.getClass(scName)
+                    return \sc
+                    }
+                fail                # No hope of finding it!
+                }
+            }
+
+        # Have to look for it.  Go file, package, imports, links...
+        f := aClass.getFile()
+        p := f.getPackage()
+        if \(sc := (f|p).getClass(scName)) then return sc
+        every pName := f.getImports().get().getName() do {
+            if \(p := packages[pName]) then {
+                if \(sc := p.getClass(scName)) then return sc
+                }
+            }
+        every fName := f.getLinks().get().getName() do {
+            if \(p := files[pName]) then {
+                if \(sc := p.getClass(scName)) then return sc
+                }
+            }
+
+        # Last chance - check the (main) package.
+        sc := packages["(main)"].getClass(scName)
+        return \sc
+
+    end
+
+    # <p>
+    # Generate (in order) all the superclasses of a class
+    # </p>
+    method genAllSuperClasses(aClass, scSet)
+        /scSet := ::set()
+        insert(scSet, aClass)
+        scSeq := aClass.getSuperClasses()
+        every scName := scSeq.get().getName() do {
+            if sc := locateSuperClass(aClass, scName) then {
+                if not member(scSet, sc) then {   # Haven't seen it yet
+                    suspend sc | genAllSuperClasses(sc, scSet)
+                    }
+                }
+            }
+
+    end
+
+    # <p>
+    # Given a class and a method name from that class, does this method
+    #   override any method from a superclass?
+    # </p><p>
+    # Returns the superclass of the overridden method, if any.
+    # </p>
+    method overrides(aClass, mName)
+        every sc := genAllSuperClasses(aClass) do {
+            if sc.hasMethod(mName) then {
+                return sc
+                }
+            }
+    end
+
+    initially ()
+        every (files|packages) := table()
+        packages["(main)"]     := UPackage("(main)")
+        resolveFlag            := &null
+        sourcePath             := &null
+        importSet              := ::set()
+        linkSet                := ::set()
+        lName                  := delSuffix(lName, ".icn")||".icn"
+        badFiles               := ::set()
 end
 
 # <p>
@@ -1044,14 +1056,14 @@ end
 #   name.
 # </p>
 procedure mkList(aSet)
-   local ctab, obj, clist
+    local ctab, obj, clist
 
-   ctab := table()
-   every obj := \aSet.get() do {
-      ctab[obj] := obj.getName()
-      }
-   every put(clist := [], (!sort(ctab, 2))[1])
-   return clist
+    ctab := table()
+    every obj := \aSet.get() do {
+        ctab[obj] := obj.getName()
+        }
+    every put(clist := [], (!sort(ctab, 2))[1])
+    return clist
 end
 
 # <p>
@@ -1061,18 +1073,18 @@ end
 #   syntax of call.
 # </p>
 procedure mkCallStr(obj)
-   local s
+    local s
 
-   s := obj.getName()
-   case obj.className() of {
-      "UniDoc::UMethod"     |
-	 "UniDoc::UConstructor"|
-	 "UniDoc::UProc"       |
-	 "UniDoc::UClass"      |
-	 "UniDoc::URecord"     :
-	 s ||:= mkParamListStr(obj.getParams())
-      }
-   return s
+    s := obj.getName()
+    case obj.className() of {
+        "UniDoc::UMethod"     |
+        "UniDoc::UConstructor"|
+        "UniDoc::UProc"       |
+        "UniDoc::UClass"      |
+        "UniDoc::URecord"     :
+                              s ||:= mkParamListStr(obj.getParams())
+        }
+    return s
 end
 
 # <p>
@@ -1081,7 +1093,7 @@ end
 #   enclosing parentheses</i>).
 # </p>
 procedure mkParamListStr(sequence)
-   return "("||mkListStr(sequence)||")"
+    return "("||mkListStr(sequence)||")"
 end
 
 # <p>
@@ -1089,18 +1101,18 @@ end
 #   produces a string showing that list.
 # </p>
 procedure mkListStr(sequence)
-   local s, item, n
+    local s, item, n
 
-   s := ""
-   if \sequence then {
-      every item := sequence.get() do {
-	 n := item.getName()
-	 if item.Type() == ("UniDoc::UName"|"UniDoc::UGlob") then {
+    s := ""
+    if \sequence then {
+        every item := sequence.get() do {
+            n := item.getName()
+            if item.Type() == ("UniDoc::UName"|"UniDoc::UGlob") then {
             n ||:= ":"||item.getTypeValue()
-	    n ||:= ":"||item.getDefValue()
-	    }
-	 s ||:= n||", "
-	 }
-      }
-   return (s[1:-2] | "")
+                n ||:= ":"||item.getDefValue()
+                }
+            s ||:= n||", "
+            }
+        }
+    return (s[1:-2] | "")
 end

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -1,9 +1,9 @@
 #<p>
 # Generate HTML documentation from Unicon (<i>or Icon</i>) source files.
 #</p>
-#<p>Syntax:<pre>
+#<p>Syntax:<tt>
 # <b>UniDoc</b> <i>arg...</i>
-# </pre>
+# </tt>
 #</p>
 #<p>
 # where <i>arg</i> may be an option or a Unicon source file name.
@@ -87,11 +87,11 @@
 #As a special case, placing procedure and method parameters on separate
 #lines with a comment describing each parameter on the same line, as in:
 #<pre><code>
-#    # &lt;p>
+#    # <p>
 #    # Invoke a class method by name.
-#    # &lt[returns the outcome of the invocation]>
-#    # &lt[fails if no method exists with that name]>
-#    # &lt;/p>
+#    # <[returns the outcome of the invocation]>
+#    # <[fails if no method exists with that name]>
+#    # </p>
 #    method invoke(mName,    # Name of method to call
 #                  args[]    # Remaining arguments are arguments to call
 #                  )
@@ -100,22 +100,21 @@
 #            }
 #    end
 #</code></pre>
-# is the same as using the <tt>&lt;[param name description]&gt;</tt> tag:
+# is the same as using the <code><[param name description]></code> tag:
 #<pre><code>
-#    # &lt;p>
+#    # <p>
 #    # Invoke a class method by name.
-#    # &lt;[param mName Name of method to call]>
-#    # &lt;[param args[] Remaining arguments are arguments to call]>
-#    # &lt;[returns the outcome of the invocation]>
-#    # &lt;[fails if no method exists with that name]>
-#    # &lt;/p>
+#    # <[param mName Name of method to call]>
+#    # <[param args[] Remaining arguments are arguments to call]>
+#    # <[returns the outcome of the invocation]>
+#    # <[fails if no method exists with that name]>
+#    # </p>
 #    method invoke(mName, args[])
 #        if hasMethod(mName) then {
 #            suspend (self.__m[mName]) ! push(args, self)
 #            }
 #    end
 #</code></pre>
-#
 #
 #<p>
 # <b><i>This version is preliminary and no doubt contains numerous bugs

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -50,7 +50,8 @@
 # <tr>
 # <td valign=top align=left><tt><b>--linkPath=PATH</b>  </tt></td>
 # <td valign=top >-- where to look for existing HTML files for entities that
-#                    can't be found in source files.
+#                    can't be found in source files.  This is a
+#                    <b>comma</b>-separated list of directories.
 #                    <b><i>Not yet implemented</i></b>
 #                    </td>
 # </tr>
@@ -141,9 +142,10 @@ procedure main(args)
     local uniAll, html
 
     if *args = 0 then helpMesg()
+    Args(args)
 
     uniAll := UniAll()
-    processArgs(args, uniAll)
+    processArgs(uniAll)
     uniAll.dumpStatistics("yes")
 
     html := UniHTML(title, uniAll, targetDir, indexFile, linkPath, debug)
@@ -154,39 +156,35 @@ end
 # <p>
 # Process the arguments, passing flags as appropriate to parser.
 # </p>
-procedure processArgs(args, # Command line arguments
-                      uniAll # Unicon parser (instance of <tt>UniAll</tt>)
+procedure processArgs(uniAll # Unicon parser (instance of <tt>UniAll</tt>)
                      )
     local arg
 
     indexFile := "index.html"
     targetDir := "./htmlDoc"
     # Some parameters are global, find them now.
-    linkPath  := zapPrefix(!args, "--linkPath=")
-    indexFile := zapPrefix(!args, "--indexFile=")
-    title     := zapPrefix(!args, "--title=")
+    title     := Args().getOpt("title", "Generated API Docs")
+    indexFile := Args().getOptDef("indexFile","index.html")
+    linkPath  := []	# Default situation (no --linkPath option)
+    linkPath  := [: genFields(\(Args().getOptDef("linkPath")),",") :]
+    uniAll.setSourcePath(Args().getOptDef("sourcePath"))
+    uniAll.setTargetDir(targetDir := Args().getOptDef("targetDir"))
 
-
-    while arg := ::get(args) do {
-        if match("--",arg) then {
-            case arg of {
-                "--help"     : helpMesg()
-                "--resolve"  : uniAll.fullyResolve("yes")
-                "--noresolve": uniAll.fullyResolve("no")
-                "--debug"    : debug := "yes"
-                "--nodebug"  : debug := &null
-                "--linkSrc"  : uniAll.setSaveSrc("yes")
-                "--nolinkSrc": uniAll.setSaveSrc()
-                }
-            uniAll.setSourcePath(zapPrefix(arg, "--sourcePath="))
-            targetDir := zapPrefix(!args, "--targetDir=")
-            uniAll.setTargetDir(targetDir)
-            }
-        else {
-            uniAll.processFile(arg)
+    every opt := Args().genOptNames() do {
+        case opt of {
+            "help"     : helpMesg()
+            "resolve"  : uniAll.fullyResolve("yes")
+            "noresolve": uniAll.fullyResolve("no")
+            "debug"    : debug := "yes"
+            "nodebug"  : debug := &null
+            "linkSrc"  : uniAll.setSaveSrc("yes")
+            "nolinkSrc": uniAll.setSaveSrc()
             }
         }
 
+    every arg := Args().genArgs() do {
+            uniAll.processFile(arg)
+            }
 end
 
 # <p>

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -83,6 +83,40 @@
 # </ul>
 #</p>
 #<p>
+#As a special case, placing procedure and method parameters on separate
+#lines with a comment describing each parameter on the same line, as in:
+#<pre><code>
+#    # &lt;p>
+#    # Invoke a class method by name.
+#    # &lt[returns the outcome of the invocation]>
+#    # &lt[fails if no method exists with that name]>
+#    # &lt;/p>
+#    method invoke(mName,    # Name of method to call
+#                  args[]    # Remaining arguments are arguments to call
+#                  )
+#        if hasMethod(mName) then {
+#            suspend (self.__m[mName]) ! push(args, self)
+#            }
+#    end
+#</code></pre>
+# is the same as using the <tt>&lt;[param name description]&gt;</tt> tag:
+#<pre><code>
+#    # &lt;p>
+#    # Invoke a class method by name.
+#    # &lt;[param mName Name of method to call]>
+#    # &lt;[param args[] Remaining arguments are arguments to call]>
+#    # &lt;[returns the outcome of the invocation]>
+#    # &lt;[fails if no method exists with that name]>
+#    # &lt;/p>
+#    method invoke(mName, args[])
+#        if hasMethod(mName) then {
+#            suspend (self.__m[mName]) ! push(args, self)
+#            }
+#    end
+#</code></pre>
+#
+#
+#<p>
 # <b><i>This version is preliminary and no doubt contains numerous bugs
 #   and omissions.</i></b>
 #</p>
@@ -94,6 +128,7 @@
 #</p>
 
 import util
+import lang
 import UniDoc
 
 global linkPath,  # Path to search when looking for already-generated HTML
@@ -103,86 +138,91 @@ global linkPath,  # Path to search when looking for already-generated HTML
        debug      # Debug flag
 
 procedure main(args)
-   local uniAll, html
+    local uniAll, html
 
-   if *args = 0 then helpMesg()
+    if *args = 0 then helpMesg()
 
-   uniAll := UniAll()
-   processArgs(args, uniAll)
-   uniAll.dumpStatistics("yes")
+    uniAll := UniAll()
+    processArgs(args, uniAll)
+    uniAll.dumpStatistics("yes")
 
-   html := UniHTML(title, uniAll, targetDir, indexFile, linkPath, debug)
-   html.buildPages()
+    html := UniHTML(title, uniAll, targetDir, indexFile, linkPath, debug)
+    html.buildPages()
+
 end
 
 # <p>
 # Process the arguments, passing flags as appropriate to parser.
 # </p>
-procedure processArgs(args,   # Command line arguments
-                      uniAll) # Unicon parser (instance of <tt>UniAll</tt>)
-   local arg
+procedure processArgs(args, # Command line arguments
+                      uniAll # Unicon parser (instance of <tt>UniAll</tt>)
+                     )
+    local arg
 
-   indexFile := "index.html"
-   targetDir := "./htmlDoc"
-   # Some parameters are global, find them now.
-   linkPath  := zapPrefix(!args, "--linkPath=")
-   indexFile := zapPrefix(!args, "--indexFile=")
-   title     := zapPrefix(!args, "--title=")
+    indexFile := "index.html"
+    targetDir := "./htmlDoc"
+    # Some parameters are global, find them now.
+    linkPath  := zapPrefix(!args, "--linkPath=")
+    indexFile := zapPrefix(!args, "--indexFile=")
+    title     := zapPrefix(!args, "--title=")
 
-   while arg := ::get(args) do {
-      if match("--",arg) then {
-	 case arg of {
-	    "--help"     : helpMesg()
-	    "--resolve"  : uniAll.fullyResolve("yes")
-	    "--noresolve": uniAll.fullyResolve("no")
-	    "--debug"    : debug := "yes"
-	    "--nodebug"  : debug := &null
-	    "--linkSrc"  : uniAll.setSaveSrc("yes")
-	    "--nolinkSrc": uniAll.setSaveSrc()
-	    }
-	 uniAll.setSourcePath(zapPrefix(arg, "--sourcePath="))
-	 targetDir := zapPrefix(!args, "--targetDir=")
-	 uniAll.setTargetDir(targetDir)
-	 }
-      else {
-	 uniAll.processFile(arg)
-	 }
-      }
+
+    while arg := ::get(args) do {
+        if match("--",arg) then {
+            case arg of {
+                "--help"     : helpMesg()
+                "--resolve"  : uniAll.fullyResolve("yes")
+                "--noresolve": uniAll.fullyResolve("no")
+                "--debug"    : debug := "yes"
+                "--nodebug"  : debug := &null
+                "--linkSrc"  : uniAll.setSaveSrc("yes")
+                "--nolinkSrc": uniAll.setSaveSrc()
+                }
+            uniAll.setSourcePath(zapPrefix(arg, "--sourcePath="))
+            targetDir := zapPrefix(!args, "--targetDir=")
+            uniAll.setTargetDir(targetDir)
+            }
+        else {
+            uniAll.processFile(arg)
+            }
+        }
+
 end
 
 # <p>
 # Quit after displaying a short usage message.
 # </p>
 procedure helpMesg()
-   write("Usage: UniDoc [argument ...]")
-   write()
-   write("  Arguments may be options or file names and are processed")
-   write("  from left to right.  Some options remain in effect from the")
-   write("  point they appear until negated by a later option.  Other")
-   write("  options affect all files.")
-   write()
-   write("Options:")
-   write()
-   write("--resolve    - Try to resolve entities referenced in any")
-   write("               of the following named source files.")
-   write()
-   write("--noresolve  - Don't try to resolve entities referenced in")
-   write("               any of the following named source files. (default)")
-   write()
-   write("--targetDir=DIR - Put the generated HTML documents in DIR")
-   write("                  (DIR defaults to \"./htmlDoc/\"")
-   write()
-   write("--sourcePath=DIRLIST - also look in DIRLIST for source files")
-   write()
-   write("--indexFile=FILE - Name the base index file FILE.")
-   write("                  (FILE defaults to \"index.html\"")
-   write()
-   write("--title=TITLE    - Use TITLE as the title for output")
-   write("                  (TITLE defaults to \"Generated Documentation\"")
-   write("--linkSrc    - Try to include links back to the source code.")
-   write("                  (Note: can be tricked if multiple source files")
-   write("                   have the same name!)")
-   write()
-   write("--nolinkSrc  - Don't include links to the source code (default).")
-   stop()
+    write("Usage: UniDoc [argument ...]")
+    write()
+    write("  Arguments may be options or file names and are processed")
+    write("  from left to right.  Some options remain in effect from the")
+    write("  point they appear until negated by a later option.  Other")
+    write("  options affect all files.")
+    write()
+    write("Options:")
+    write()
+    write("--resolve    - Try to resolve entities referenced in any")
+    write("               of the following named source files.")
+    write()
+    write("--noresolve  - Don't try to resolve entities referenced in")
+    write("               any of the following named source files. (default)")
+    write()
+    write("--targetDir=DIR - Put the generated HTML documents in DIR")
+    write("                  (DIR defaults to \"./htmlDoc/\"")
+    write()
+    write("--sourcePath=DIRLIST - also look in DIRLIST for source files")
+    write()
+    write("--indexFile=FILE - Name the base index file FILE.")
+    write("                  (FILE defaults to \"index.html\"")
+    write()
+    write("--title=TITLE    - Use TITLE as the title for output")
+    write("                  (TITLE defaults to \"Generated Documentation\"")
+    write("--linkSrc    - Try to include links back to the source code.")
+    write("                  (Note: can be tricked if multiple source files")
+    write("                   have the same name!)")
+    write()
+    write("--nolinkSrc  - Don't include links to the source code (default).")
+    stop()
 end
+

--- a/uni/unidoc/UniFile.icn
+++ b/uni/unidoc/UniFile.icn
@@ -15,8 +15,8 @@
 
 package UniDoc
 
-import lang
 import util
+import lang
 
 # <p>
 # A class that supports buffered production of tokens from a file containing
@@ -25,317 +25,320 @@ import util
 #   call <b>setSaveSrc("yes")</b> is made on this class.
 # </p>
 class UniFile : Object (iKeySet, uKeySet, oldTokens, buffer, line, f, fName,
-			insideFlag, debug, saveSrc, cBuf)
+                       insideFlag, debug, saveSrc, cBuf)
 
-   # <p>
-   # Turn on/off debugging.  Turning on (by using a non-null value
-   #   for <b>dbg</b> produces <i>lots</i> of output!
-   # </p>
-   method setDebug(dbg)
-      debug := dbg
-   end
+    # <p>
+    # Turn on/off debugging.  Turning on (by using a non-null value
+    #   for <b>dbg</b> produces <i>lots</i> of output!
+    # </p>
+    method setDebug(dbg)
+        debug := dbg
+    end
 
-   # <p>
-   # Turn on/off recognition of Unicon-specific keywords.
-   # Icon program may be using these keywords as variable names.
-   # </p>
-   method setInside(flag)
-      insideFlag := flag
-   end
+    # <p>
+    # Turn on/off recognition of Unicon-specific keywords.
+    # Icon program may be using these keywords as variable names.
+    # </p>
+    method setInside(flag)
+        insideFlag := flag
+    end
 
-   # <p>
-   # Turn on/off saving of source code (default is <i>off</i>).
-   # </p>
-   method setSaveSrc(flag)
-      saveSrc := flag
-   end
+    # <p>
+    # Turn on/off saving of source code (default is <i>off</i>).
+    # </p>
+    method setSaveSrc(flag)
+        saveSrc := flag
+    end
 
-   # <p>
-   # Succeed if source code is being saved.
-   # </p>
-   method hasSource()
-      return \saveSrc
-   end
+    # <p>
+    # Succeed if source code is being saved.
+    # </p>
+    method hasSource()
+        return \saveSrc
+    end
 
-   # <p>
-   # Produce the source file name
-   # </p>
-   method getFilename()
-      return fName
-   end
+    # <p>
+    # Produce the source file name
+    # </p>
+    method getFilename()
+        return fName
+    end
 
-   # <p>
-   # Generate the source code lines.
-   # </p>
-   method getSrc()
-      if hasSource() then {
-	 suspend (\cBuf).getLines()
-	 }
-   end
+    # <p>
+    # Generate the source code lines.
+    # </p>
+    method getSrc()
+        if hasSource() then {
+            suspend (\cBuf).getLines()
+            }
+    end
 
-   # <p>
-   # Tag a source code line so it can be referenced from the documentation.
-   # </p>
-   method setTag(tagName)
-      if \saveSrc then (\cBuf).insertTag(tagName)
-   end
+    # <p>
+    # Tag a source code line so it can be referenced from the documentation.
+    # </p>
+    method setTag(tagName)
+        if \saveSrc then (\cBuf).insertTag(tagName)
+    end
 
-   # <p>
-   # Produce the next token from the file.  Fails on EOF
-   # </p>
-   # <p>
-   #    Always skips trailing whitespace before returning.
-   # </p>
-   method nextToken()
-      local t, word, result
+    # <p>
+    # Produce the next token from the file.  Fails on EOF
+    # </p>
+    # <p>
+    #    Always skips trailing whitespace before returning.
+    # </p>
+    method nextToken()
+        local t, word, result
 
-      if t := ::get(oldTokens) then return t
+        if t := ::get(oldTokens) then return t
 
-      if *line = 0 then {
-	 readline() | fail
-	 if *line = 0 then { # Empty line read in
-	    return BlankLine()
-	    }
-	 }
+        if *line = 0 then {
+            readline() | fail
+            if *line = 0 then { # Empty line read in
+                return BlankLine()
+                }
+            }
 
-      line ? {
-	 ws()
-	 if ="#" then {
-	    result := Comment(tab(0))
-	    clearLine()
-	    showToken(result)
-	    return result
-	    }
+        line ? {
+            ws()
+            if ="#" then {
+                result := Comment(tab(0))
+                clearLine()
+                showToken(result)
+                return result
+                }
 
-	 if (word := (matchVar() || ((="::"||matchVar())|""))) & ws() then {
-	    if isKeyword(word) then {
-	       result := Keyword(word)
-	       }
-	    else {      # assume it's a var, ok if wrong!
-	       result := Name(word)
-	       }
-	    line := tab(0)
-	    showToken(result)
-	    return result
-	    }
+            if (word := (matchVar() || ((="::"||matchVar())|""))) & ws() then {
+                if isKeyword(word) then {
+                    result := Keyword(word)
+                    }
+                else {      # assume it's a var, ok if wrong!
+                    result := Name(word)
+                    }
+                line := tab(0)
+                showToken(result)
+                return result
+                }
 
-	 if (s := matchString()) & ws() then {
-	    result := String(s)
-	    line := tab(0)
-	    showToken(result)
-	    return result
-	    }
+            if (s := matchString()) & ws() then {
+                result := String(s)
+                line := tab(0)
+                showToken(result)
+                return result
+                }
 
-	 if ="(" & ws() then {
-	    line := tab(0)
-	    result := LParen()
-	    showToken(result)
-	    return result
-	    }
+            if ="(" & ws() then {
+                line := tab(0)
+                result := LParen()
+                showToken(result)
+                return result
+                }
 
-	 if =")" & ws() then {
-	    line := tab(0)
-	    result := RParen()
-	    showToken(result)
-	    return result
-	    }
+            if =")" & ws() then {
+                line := tab(0)
+                result := RParen()
+                showToken(result)
+                return result
+                }
 
-	 if ="::" then {        # Class with no package!
-	    if (word := matchVar()) & ws() then {
-	       # assume it's a var, ok if wrong!
-	       result := Name("::"||word)
-	       }
-	    line := tab(0)
-	    showToken(result)
-	    return result
-	    }
-	 if =":" & ws() then {
-	    line := tab(0)
-	    result := Colon()
-	    showToken(result)
-	    return result
-	    }
+            if ="::" then {        # Class with no package!
+                if (word := matchVar()) & ws() then {
+                    # assume it's a var, ok if wrong!
+                    result := Name("::"||word)
+                    }
+                line := tab(0)
+                showToken(result)
+                return result
+                }
+            if =":" & ws() then {
+                line := tab(0)
+                result := Colon()
+                showToken(result)
+                return result
+                }
 
-	 if ="," & ws() then {
-	    line := tab(0)
-	    result := Comma()
-	    showToken(result)
-	    return result
-	    }
+            if ="," & ws() then {
+                line := tab(0)
+                result := Comma()
+                showToken(result)
+                return result
+                }
 
-	 if (s := matchCSet() | move(1)) & ws() then {
-	    line := tab(0)
-	    result := Noise(s)
-	    showToken(result)
-	    return result
-	    }
+            if (s := matchCSet() | move(1)) & ws() then {
+                line := tab(0)
+                result := Noise(s)
+                showToken(result)
+                return result
+                }
 
-	 write("nextToken: '",fName,"' cannot happen!")
-	 snapshot("----> ")
-	 }
-   end
+            write("nextToken: '",fName,"' cannot happen!")
+            snapshot("----> ")
+            }
 
-   # <p>
-   # Display a token's type and value.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method showToken(token)
-      if \debug then {
-	 write("\t\tToken: ",token.Type()," (",token.value,")")
-	 }
-   end
+    end
 
-   # <p>
-   # Push an arbitrary token back onto the stream
-   # </p>
-   method pushback(token)
-      push(oldTokens, token)
-   end
+    # <p>
+    # Display a token's type and value.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method showToken(token)
+        if \debug then {
+            write("\t\tToken: ",token.Type()," (",token.value,")")
+            }
+    end
 
-   # <p>
-   # Read in a line of Unicon program text, joining continuations
-   #   and splitting on semicolons.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method readline()
-      static WS
-      initial WS := ' \t'
+    # <p>
+    # Push an arbitrary token back onto the stream
+    # </p>
+    method pushback(token)
+        push(oldTokens, token)
+    end
 
-      while line := lTrim(buffer || Read(f), ' \t') do {
-	 setBuffer(line)
-	 line := ""
-	 buffer ? {
-	    repeat {
-	       if not (line ||:= tab(upto('\'"#;'))) then {
-		  line := buffer
-		  clearBuffer()
-		  return line
-		  }
-	       else {  # Hard cases, might have continuation
+    # <p>
+    # Read in a line of Unicon program text, joining continuations
+    #   and splitting on semicolons.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method readline()
+        static WS
+        initial WS := ' \t'
+    
+        while line := lTrim(buffer || Read(f), ' \t') do {
+            setBuffer(line)
+            line := ""
+            buffer ? {
+                repeat {
+                    if not (line ||:= tab(upto('\'"#;'))) then {
+                        line := buffer
+                        clearBuffer()
+                        return line
+                        }
+                    else {  # Hard cases, might have continuation
+    
+                        if =";" then {          # Not so hard after all
+                            setBuffer(tab(0))
+                            return line
+                            }
+    
+                        if ="#" then {          # Also easy
+                            line := buffer
+                            clearBuffer()
+                            return line
+                            }
+    
+                        if any('\'') then {    l    # Hard
+                            if not (line ||:= matchCSet()) then {
+                                # Must be a continued cset!
+                                setBuffer(buffer[1:-1] | "")
+                                break
+                                }
+                            }
+    
+                        if any('"') then {         # Hard
+                            if not (line ||:= matchString()) then {
+                                # Must be a continued string!
+                                setBuffer(buffer[1:-1] | "")
+                                break
+                                }
+                            }
+    
+                        }
+                    }
+                }
+            }
+    
+        if *buffer > 0 then {
+            line := buffer
+            clearBuffer()
+            line
+            }
+    
+    end
 
-		  if =";" then {          # Not so hard after all
-		     setBuffer(tab(0))
-		     return line
-		     }
+    # <p>
+    # Read in a line of source code.  Add it to the source code buffer and
+    # return it.
+    # </p>
+    method Read(f)
+        if line := read(f) then {
+            if \saveSrc then (\cBuf).add(line)
+            return line
+            }
+    end
 
-		  if ="#" then {          # Also easy
-		     line := buffer
-		     clearBuffer()
-		     return line
-		     }
+    # <p>
+    # Are we at the end of the current line?
+    # </p>
+    method EOS()
+       return ((*oldTokens = 0) & (*line = 0))
+    end
 
-		  if any('\'') then {    # Hard
-		     if not (line ||:= matchCSet()) then {
-			# Must be a continued cset!
-			setBuffer(buffer[1:-1] | "")
-			break
-			}
-		     }
+    # <p>
+    # Clear the input stream readahead
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method clearLine()
+        clearPushback()
+        return line := ""
+    end
 
-		  if any('"') then {         # Hard
-		     if not (line ||:= matchString()) then {
-			# Must be a continued string!
-			setBuffer(buffer[1:-1] | "")
-			break
-			}
-		     }
-		  }
-	       }
-	    }
-	 }
+    # <p>
+    # Clear any pushed back tokens
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method clearPushback()
+        oldTokens := []
+    end
 
-      if *buffer > 0 then {
-	 line := buffer
-	 clearBuffer()
-	 line
-	 }
-   end
+    # <p>
+    # Clear the buffer
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method clearBuffer()
+        return buffer := ""
+    end
 
-   # <p>
-   # Read in a line of source code.  Add it to the source code buffer and
-   # return it.
-   # </p>
-   method Read(f)
-      if line := read(f) then {
-	 if \saveSrc then (\cBuf).add(line)
-	 return line
-	 }
-   end
+    # <p>
+    # Force the buffer to a known content.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method setBuffer(s)
+        return buffer := s
+    end
 
-   # <p>
-   # Are we at the end of the current line?
-   # </p>
-   method EOS()
-      return ((*oldTokens = 0) & (*line = 0))
-   end
+    # <p>
+    # Close this file.
+    # </p>
+    method close()
+        cBuf := &null
+        ::close(f)
+    end
 
-   # <p>
-   # Clear the input stream readahead
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method clearLine()
-      clearPushback()
-      return line := ""
-   end
+    # <p>
+    # Is a word a keyword?
+    # </p>
+    method isKeyword(word)
+        if member(iKeySet, word) then {
+            if word == "end" then setInside()
+            if word == ("procedure"|"record"|"global") then setInside("yes")
+            return
+            }
+        if /insideFlag then {
+            return member(uKeySet, word)
+            }
+    end
 
-   # <p>
-   # Clear any pushed back tokens
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method clearPushback()
-      oldTokens := []
-   end
-
-   # <p>
-   # Clear the buffer
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method clearBuffer()
-      return buffer := ""
-   end
-
-   # <p>
-   # Force the buffer to a known content.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method setBuffer(s)
-      return buffer := s
-   end
-
-   # <p>
-   # Close this file.
-   # </p>
-   method close()
-      cBuf := &null
-      ::close(f)
-   end
-
-   # <p>
-   # Is a word a keyword?
-   # </p>
-   method isKeyword(word)
-      if member(iKeySet, word) then {
-	 if word == "end" then setInside()
-	 if word == ("procedure"|"record"|"global") then setInside("yes")
-	 return
-	 }
-      if /insideFlag then {
-	 return member(uKeySet, word)
-	 }
-   end
-
-# <b>Fails if cannot open <tt>fName</tt> for reading.</b>
-initially (fileName, path)
-   /path := ""
-   fName := delSuffix(fileName,".icn")||".icn"
-   f := open(path||fName) | fail
-   clearBuffer()
-   line := ""
-   # the only keywords we care about, everything else is noise...
-   iKeySet := ::set(["link", "procedure", "end", "global", "record"])
-   uKeySet := ::set(["package", "import", "class", "method", "initially"])
-   oldTokens := []
-   cBuf := CodeBuf()
+    # <b>Fails if cannot open <tt>fName</tt> for reading.</b>
+    initially (fileName, path)
+        /path := ""
+        fName := delSuffix(fileName,".icn")||".icn"
+        f := open(path||fName) | fail
+        clearBuffer()
+        line := ""
+        # the only keywords we care about, everything else is noise...
+        iKeySet := ::set(["link", "procedure", "end", "global", "record"])
+        uKeySet := ::set(["package", "import", "class", "method", "initially"])
+        oldTokens := []
+        cBuf := CodeBuf()
 end
 
 #<p>
@@ -347,33 +350,33 @@ end
 #</p>
 class CodeBuf : Object (buffer)
 
-   #<p>
-   # Generate the source code lines that have been buffered up.
-   #</p>
-   method getLines()
-      suspend !buffer
-   end
+    #<p>
+    # Generate the source code lines that have been buffered up.
+    #</p>
+    method getLines()
+        suspend !buffer
+    end
 
-   #<p>
-   # Add a source code line to the end of the buffer.
-   # <i>Protects</i> the line by having the converter hide any
-   # text that might interfere with the conversion process later.
-   #</p>
-   method add(line)
-      put(buffer, (UniDoc::protectLine(line) | line)||"\n")
-   end
+    #<p>
+    # Add a source code line to the end of the buffer.
+    # <i>Protects</i> the line by having the converter hide any
+    # text that might interfere with the conversion process later.
+    #</p>
+    method add(line)
+       put(buffer, (UniDoc::protectLine(line) | line)||"\n")
+    end
 
-   #<p>
-   # Insert a <i>tag</i> just <i>prior</i> the last source code line.
-   # The tag is produced by the converter given the source code file
-   #   name and the tagged name.
-   #</p>
-   method insertTag(tagName)
-      last := pull(buffer)
-      put(buffer, UniDoc::makeTag(tagName))
-      put(buffer, \last)
-   end
+    #<p>
+    # Insert a <i>tag</i> just <i>prior</i> the last source code line.
+    # The tag is produced by the converter given the source code file
+    #   name and the tagged name.
+    #</p>
+    method insertTag(tagName)
+        last := pull(buffer)
+        put(buffer, UniDoc::makeTag(tagName))
+        put(buffer, \last)
+    end
 
-initially ()
-   buffer    := []
+    initially ()
+        buffer    := []
 end

--- a/uni/unidoc/UniForm.icn
+++ b/uni/unidoc/UniForm.icn
@@ -25,84 +25,84 @@ import lang
 # </p>
 class Sequence : Object (contents, comments)
 
-   # <p>
-   # Produce the size of the Sequence.
-   # </p>
-   method size()
-      return *contents
-   end
-   # <p>
-   # Change the contents of the Sequence.
-   # </p>
-   method set(newContents)
-      contents := newContents
-   end
-   # <p>
-   # Add an item to the Sequence
-   # </p>
-   method add(item)
-      put(contents, item)
-   end
-   # <p>
-   # Generate all the items in the Sequence
-   # </p>
-   method get()
-      suspend \!contents
-   end
+    # <p>
+    # Produce the size of the Sequence.
+    # </p>
+    method size()
+        return *contents
+    end
+    # <p>
+    # Change the contents of the Sequence.
+    # </p>
+    method set(newContents)
+        contents := newContents
+    end
+    # <p>
+    # Add an item to the Sequence
+    # </p>
+    method add(item)
+        put(contents, item)
+    end
+    # <p>
+    # Generate all the items in the Sequence
+    # </p>
+    method get()
+        suspend \!contents
+    end
 
-   # <p>
-   # Succeeds if <b>item</b> is contained in the Sequence
-   # </p>
-   method contains(item)
-      return item === !contents
-   end
+    # <p>
+    # Succeeds if <b>item</b> is contained in the Sequence
+    # </p>
+    method contains(item)
+        return item === !contents
+    end
 
-   # <p>
-   # Change the comments associated with the Sequence
-   # </p>
-   method setComments(newComments)
-      comments := \newComments | Comments()
-   end
-   # <p>
-   # Produce the Comments() associated with the Sequence
-   # </p>
-   method getComments()
-      return comments
-   end
-   # <p>
-   # Add a new line to the current comment paragraph.
-   # </p>
-   method addComment(newComment)
-      comments.addComment(newComment)
-   end
-   # <p>
-   # Start a new comment paragraph
-   # </p>
-   method startNewComments(newComment)
-      comments.newBlock()
-      addComment(newComment)
-   end
+    # <p>
+    # Change the comments associated with the Sequence
+    # </p>
+    method setComments(newComments)
+        comments := \newComments | Comments()
+    end
+    # <p>
+    # Produce the Comments() associated with the Sequence
+    # </p>
+    method getComments()
+        return comments
+    end
+    # <p>
+    # Add a new line to the current comment paragraph.
+    # </p>
+    method addComment(newComment)
+        comments.addComment(newComment)
+    end
+    # <p>
+    # Start a new comment paragraph
+    # </p>
+    method startNewComments(newComment)
+        comments.newBlock()
+        addComment(newComment)
+    end
 
-   # <p>
-   # Succeeds if any item in the sequence has comments attached to it.
-   #   (Used in UniHTML class to determine whether or not parameter
-   #    and field sequences need to be expanded in detail.)
-   # </p></p>
-   # Fails if no comments attached to any item.
-   # </p>
-   method itemsHaveComments()
-      local item, c
+    # <p>
+    # Succeeds if any item in the sequence has comments attached to it.
+    #   (Used in UniHTML class to determine whether or not parameter
+    #    and field sequences need to be expanded in detail.)
+    # </p></p>
+    # Fails if no comments attached to any item.
+    # </p>
+    method itemsHaveComments()
+        local item, c
 
-      every item := !contents do {
-	 if c := (\item).getComments() then {
-	    if c.size() > 0 then return
-	    }
-	 }
-   end
-
-initially
-   /contents := []
-   /comments := Comments()
+        every item := !contents do {
+            if c := (\item).getComments() then {
+                if c.size() > 0 then return
+                }
+            }
+    end
+    
+    initially
+        /contents := []
+        /comments := Comments()
 end
 
 # <p>
@@ -110,178 +110,178 @@ end
 # </p>
 class Set : Object (contents, comments)
 
-   # <p>
-   # Produce the size of the Set
-   # </p>
-   method size()
-      return *contents
-   end
-   # <p>
-   # Change the Set contents
-   # </p>
-   method set(newContents)
-      contents := newContents
-   end
-   # <p>
-   # Insert an item into the Set
-   # </p>
-   method add(iName, item)
-      contents[iName] := item
-   end
-   # <p>
-   # Delete an item from the Set, given that item's name
-   # </p>
-   method del(iName)
-      contents[iName] := &null
-   end
-   # <p>
-   # Generate a sorted (by name) sequence of the items in the Set
-   # </p>
-   method get()
-      suspend \(!sort(contents))[2]
-   end
-   # <p>
-   # Get a specific item from the Set, given that item's name
-   # </p>
-   method getByName(iName)
-      return contents[iName]
-   end
-   # <p>
-   # Generate a sorted sequence of the names of the items in the Set
-   # </p>
-   method getNames()
-      suspend \(!sort(contents))[1]
-   end
+    # <p>
+    # Produce the size of the Set
+    # </p>
+    method size()
+        return *contents
+    end
+    # <p>
+    # Change the Set contents
+    # </p>
+    method set(newContents)
+        contents := newContents
+    end
+    # <p>
+    # Insert an item into the Set
+    # </p>
+    method add(iName, item)
+        contents[iName] := item
+    end
+    # <p>
+    # Delete an item from the Set, given that item's name
+    # </p>
+    method del(iName)
+        contents[iName] := &null
+    end
+    # <p>
+    # Generate a sorted (by name) sequence of the items in the Set
+    # </p>
+    method get()
+        suspend \(!sort(contents))[2]
+    end
+    # <p>
+    # Get a specific item from the Set, given that item's name
+    # </p>
+    method getByName(iName)
+        return contents[iName]
+    end
+    # <p>
+    # Generate a sorted sequence of the names of the items in the Set
+    # </p>
+    method getNames()
+        suspend \(!sort(contents))[1]
+    end
 
-   # <p>
-   # Succeed if item is in the Set
-   # </p>
-   method contains(item)
-      return item === !contents
-   end
-   # <p>
-   # Succeed if the named item is in the Set
-   # </p>
-   method containsName(iName)
-      return iName == key(contents)
-   end
+    # <p>
+    # Succeed if item is in the Set
+    # </p>
+    method contains(item)
+        return item === !contents
+    end
+    # <p>
+    # Succeed if the named item is in the Set
+    # </p>
+    method containsName(iName)
+        return iName == key(contents)
+    end
 
-   # <p>
-   # Change the comments associated with this Set
-   # </p>
-   method setComments(newComments)
-      comments := \newComments | Comments()
-   end
-   # <p>
-   # Produce this Set's Comments()
-   # </p>
-   method getComments()
-      return comments
-   end
-   # <p>
-   # Add a line to the this Set's current comment paragraph
-   # </p>
-   method addComment(newComment)
-      comments.addComment(newComment)
-   end
-   # <p>
-   # Start a new comment paragraph
-   # </p>
-   method startNewComments(newComment)
-      comments.newBlock()
-      addComment(newComment)
-   end
+    # <p>
+    # Change the comments associated with this Set
+    # </p>
+    method setComments(newComments)
+        comments := \newComments | Comments()
+    end
+    # <p>
+    # Produce this Set's Comments()
+    # </p>
+    method getComments()
+        return comments
+    end
+    # <p>
+    # Add a line to the this Set's current comment paragraph
+    # </p>
+    method addComment(newComment)
+        comments.addComment(newComment)
+    end
+    # <p>
+    # Start a new comment paragraph
+    # </p>
+    method startNewComments(newComment)
+        comments.newBlock()
+        addComment(newComment)
+    end
 
-initially
-   /contents := table()
-   /comments := Comments()
+    initially
+        /contents := table()
+        /comments := Comments()
 end
 
 # <p>
 # Base class for representing a Unicon language entity.
 # </p>
-class UEntity : Class (name, parent, comments, srcFile)
+class UEntity : Object (name, parent, comments, srcFile)
 
-   # <p>
-   # Name this entity
-   # </p>
-   method setName(newName)
-      name := newName
-   end
-   # <p>
-   # Produce this entity's name
-   # </p>
-   method getName()
-      return \name
-   end
+    # <p>
+    # Name this entity
+    # </p>
+    method setName(newName)
+        name := newName
+    end
+    # <p>
+    # Produce this entity's name
+    # </p>
+    method getName()
+        return \name
+    end
 
-   # <p>
-   # Remember the parent entity for this entity.
-   # </p>
-   method setParent(newParent)
-      parent := newParent
-   end
-   # <p>
-   # Produce this entity's parent entity.
-   # </p>
-   method getParent()
-      return \parent | ""
-   end
+    # <p>
+    # Remember the parent entity for this entity.
+    # </p>
+    method setParent(newParent)
+        parent := newParent
+    end
+    # <p>
+    # Produce this entity's parent entity.
+    # </p>
+    method getParent()
+        return \parent | ""
+    end
 
-   # <p>
-   # Remember the source file name for this entity.
-   # </p>
-   method setSrcFile(fName)
-      srcFile := fName
-   end
-   # <p>
-   # Produce the source file for this entity.
-   # </p>
-   method getSrcFile()
-      return \srcFile
-   end
+    # <p>
+    # Remember the source file name for this entity.
+    # </p>
+    method setSrcFile(fName)
+        srcFile := fName
+    end
+    # <p>
+    # Produce the source file for this entity.
+    # </p>
+    method getSrcFile()
+        return \srcFile
+    end
 
-   # <p>
-   # Produce a nice name for the type of this entity.
-   # </p>
-   method getFormType()
-      return UniDoc::getFormType(self)
-   end
+    # <p>
+    # Produce a nice name for the type of this entity.
+    # </p>
+    method getFormType()
+        return UniDoc::getFormType(self)
+    end
 
-   # <p>
-   # Change the comments associated with this entity
-   # </p>
-   method setComments(newComments)
-      comments := \newComments | Comments()
-   end
-   # <p>
-   # Produce the Comments() associated with this entity
-   # </p>
-   method getComments()
-      return comments
-   end
-   # <p>
-   # Add a comment to this entity's current comment paragraph
-   # </p>
-   method addComment(newComment)
-      comments.add(newComment)
-   end
-   # <p>
-   # Start a new comment paragraph for this entity
-   # </p>
-   method startNewComments(newComment)
-      comments.newBlock()
-      comments.add(newComment)
-   end
-   # <p>
-   # Add an entire comment paragraph to this entity's comments
-   # </p>
-   method mergeComments(newComments)
-      comments.append(newComments)
-   end
+    # <p>
+    # Change the comments associated with this entity
+    # </p>
+    method setComments(newComments)
+        comments := \newComments | Comments()
+    end
+    # <p>
+    # Produce the Comments() associated with this entity
+    # </p>
+    method getComments()
+        return comments
+    end
+    # <p>
+    # Add a comment to this entity's current comment paragraph
+    # </p>
+    method addComment(newComment)
+        comments.add(newComment)
+    end
+    # <p>
+    # Start a new comment paragraph for this entity
+    # </p>
+    method startNewComments(newComment)
+        comments.newBlock()
+        comments.add(newComment)
+    end
+    # <p>
+    # Add an entire comment paragraph to this entity's comments
+    # </p>
+    method mergeComments(newComments)
+        comments.append(newComments)
+    end
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -290,47 +290,47 @@ end
 # </p>
 class UName : UEntity (name, parent, comments, category, defValue, typeValue)
 
-   # <p>
-   # Remember the category of this name (i.e. what it represents)
-   # </p>
-   method setCategory(newCategory)
-      category := newCategory
-   end
-   # <p>
-   # Produce the category for this name
-   # </p>
-   method getCategory()
-      return category
-   end
+    # <p>
+    # Remember the category of this name (i.e. what it represents)
+    # </p>
+    method setCategory(newCategory)
+        category := newCategory
+    end
+    # <p>
+    # Produce the category for this name
+    # </p>
+    method getCategory()
+        return category
+    end
 
-   # <p>
-   # If this name has an associated default value, remember it.
-   # </p>
-   method setDefValue(newDefValue)
-      defValue := newDefValue
-   end
-   # <p>
-   # Produce the default value, if any.
-   # </p>
-   method getDefValue()
-      return \defValue
-   end
+    # <p>
+    # If this name has an associated default value, remember it.
+    # </p>
+    method setDefValue(newDefValue)
+        defValue := newDefValue
+    end
+    # <p>
+    # Produce the default value, if any.
+    # </p>
+    method getDefValue()
+        return \defValue
+    end
 
-   # <p>
-   # If this name has an associated type, remember it.
-   # </p>
-   method setTypeValue(newTypeValue)
-      typeValue := newTypeValue
-   end
-   # <p>
-   # Produce the type value, if any.
-   # </p>
-   method getTypeValue()
-      return \typeValue
-   end
+    # <p>
+    # If this name has an associated type, remember it.
+    # </p>
+    method setTypeValue(newTypeValue)
+        typeValue := newTypeValue
+    end
+    # <p>
+    # Produce the type value, if any.
+    # </p>
+    method getTypeValue()
+        return \typeValue
+    end
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -338,34 +338,34 @@ end
 # </p>
 class UGlobal : UEntity (name, parent, comments, defValue, typeValue)
 
-   # <p>
-   # If this name has an associated default value, remember it.
-   # </p>
-   method setDefValue(newDefValue)
-      defValue := newDefValue
-   end
-   # <p>
-   # Produce the default value, if any.
-   # </p>
-   method getDefValue()
-      return \defValue
-   end
+    # <p>
+    # If this name has an associated default value, remember it.
+    # </p>
+    method setDefValue(newDefValue)
+        defValue := newDefValue
+    end
+    # <p>
+    # Produce the default value, if any.
+    # </p>
+    method getDefValue()
+        return \defValue
+    end
 
-   # <p>
-   # If this name has an associated type, remember it.
-   # </p>
-   method setTypeValue(newTypeValue)
-      typeValue := newTypeValue
-   end
-   # <p>
-   # Produce the type value, if any.
-   # </p>
-   method getTypeValue()
-      return \typeValue
-   end
+    # <p>
+    # If this name has an associated type, remember it.
+    # </p>
+    method setTypeValue(newTypeValue)
+        typeValue := newTypeValue
+    end
+    # <p>
+    # Produce the type value, if any.
+    # </p>
+    method getTypeValue()
+        return \typeValue
+    end
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -373,28 +373,28 @@ end
 # </p>
 class UMethod : UEntity (name, parent, comments, params)
 
-   # <p>
-   # Set the parameter list for this method
-   # </p>
-   method setParams(newParams)
-      params := newParams
-   end
-   # <p>
-   # Produce the parameter list for this method
-   # </p>
-   method getParams()
-      return params
-   end
-   # <p>
-   # Add a parameter to the parameter list.
-   # </p>
-   method addParam(newParam)
-      params.add(newParam)
-   end
+    # <p>
+    # Set the parameter list for this method
+    # </p>
+    method setParams(newParams)
+        params := newParams
+    end
+    # <p>
+    # Produce the parameter list for this method
+    # </p>
+    method getParams()
+        return params
+    end
+    # <p>
+    # Add a parameter to the parameter list.
+    # </p>
+    method addParam(newParam)
+        params.add(newParam)
+    end
 
-initially
-   /comments := Comments()
-   /params := Sequence()
+    initially
+        /comments := Comments()
+        /params := Sequence()
 end
 
 # <p>
@@ -402,28 +402,28 @@ end
 # </p>
 class UProc : UEntity (name, parent, comments, params)
 
-   # <p>
-   # Set the parameter list for this method
-   # </p>
-   method setParams(newParams)
-      params := newParams
-   end
-   # <p>
-   # Produce the parameter list for this method
-   # </p>
-   method getParams()
-      return params
-   end
-   # <p>
-   # Add a parameter to the parameter list.
-   # </p>
-   method addParam(newParam)
-      params.add(newParam)
-   end
+    # <p>
+    # Set the parameter list for this method
+    # </p>
+    method setParams(newParams)
+        params := newParams
+    end
+    # <p>
+    # Produce the parameter list for this method
+    # </p>
+    method getParams()
+        return params
+    end
+    # <p>
+    # Add a parameter to the parameter list.
+    # </p>
+    method addParam(newParam)
+        params.add(newParam)
+    end
 
-initially
-   /comments := Comments()
-   /params := Sequence()
+    initially
+        /comments := Comments()
+        /params := Sequence()
 end
 
 # <p>
@@ -431,37 +431,37 @@ end
 # </p>
 class URecord : UEntity (name, parent, comments, fields)
 
-   # <p>
-   # Set the field list for this method
-   # </p>
-   method setParams(newFields)
-      fields := newFields
-   end
-   # <p>
-   # Produce the field list for this method
-   # </p>
-   method getParams()
-      return fields
-   end
-   # <p>
-   # Add a field to the field list.
-   # </p>
-   method addField(newField)
-      fields.add(newField)
-   end
+    # <p>
+    # Set the field list for this method
+    # </p>
+    method setParams(newFields)
+        fields := newFields
+    end
+    # <p>
+    # Produce the field list for this method
+    # </p>
+    method getParams()
+        return fields
+    end
+    # <p>
+    # Add a field to the field list.
+    # </p>
+    method addField(newField)
+        fields.add(newField)
+    end
 
-initially
-   /comments := Comments()
-   /fields := Sequence()
+    initially
+        /comments := Comments()
+        /fields := Sequence()
 end
 
 # <p>
-# An import
+# An import 
 # </p>
 class UImport : UEntity (name, parent, comments)
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -469,8 +469,8 @@ end
 # </p>
 class ULink : UEntity (name, parent, comments)
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -479,148 +479,148 @@ end
 class UClass : UEntity ( name, parent, comments, constructor,
                          superClasses, fields, methods, pack, file)
 
-   # <p>
-   # Set this class' name
-   # </p>
-   method setName(newName)
-      newName ?:= {
-	 tabSkip("::")
-	 tab(0)
-	 }
-      name := newName
-   end
+    # <p>
+    # Set this class' name
+    # </p>
+    method setName(newName)
+        newName ?:= {
+             tabSkip("::")
+             tab(0)
+             }
+        name := newName
+    end
+        
+    # <p>
+    # Return the full name (with package name included) for this class.
+    # </p>
+    method getFullName()
+        if \pack then {
+            return pack.getName()||"::"||getName()
+            }
+        return "::"||getName()
+    end
 
-   # <p>
-   # Return the full name (with package name included) for this class.
-   # </p>
-   method getFullName()
-      if \pack then {
-	 return pack.getName()||"::"||getName()
-	 }
-      return "::"||getName()
-   end
+    # <p>
+    # Set the Sequence() of superclass names.
+    # </p>
+    method setSuperClasses(newSuperClasses)
+        superClasses := newSuperClasses
+    end
+    # <p>
+    # Get the Sequence() of superclass names.
+    # </p>
+    method getSuperClasses()
+        return superClasses
+    end
+    # <p>
+    # Append a superclass name to the Sequence() of superclass names.
+    # </p>
+    method addSuperClass(superClass)
+        superClasses.add(superClass)
+    end
 
-   # <p>
-   # Set the Sequence() of superclass names.
-   # </p>
-   method setSuperClasses(newSuperClasses)
-      superClasses := newSuperClasses
-   end
-   # <p>
-   # Get the Sequence() of superclass names.
-   # </p>
-   method getSuperClasses()
-      return superClasses
-   end
-   # <p>
-   # Append a superclass name to the Sequence() of superclass names.
-   # </p>
-   method addSuperClass(superClass)
-      superClasses.add(superClass)
-   end
+    # <p>
+    # Set the Sequence() of parameters (really fields).  Given this
+    #   name to be compatible with other entities that have parameter
+    #   or field lists associated with them.)
+    # </p>
+    method setParams(newParams)
+        fields := newParams
+    end
+    # <p>
+    # Produce the Sequence() of parameters.
+    # </p>
+    method getParams()
+        return fields
+    end
+    # <p>
+    # Append a field to the Sequence() of parameters.
+    # </p>
+    method addField(newField)
+        fields.add(newField)
+    end
 
-   # <p>
-   # Set the Sequence() of parameters (really fields).  Given this
-   #   name to be compatible with other entities that have parameter
-   #   or field lists associated with them.)
-   # </p>
-   method setParams(newParams)
-      fields := newParams
-   end
-   # <p>
-   # Produce the Sequence() of parameters.
-   # </p>
-   method getParams()
-      return fields
-   end
-   # <p>
-   # Append a field to the Sequence() of parameters.
-   # </p>
-   method addField(newField)
-      fields.add(newField)
-   end
+    # <p>
+    # Set the Set() of methods defined in this class.
+    # </p>
+    method setMethods(newMethods)
+        methods := newMethods
+    end
+    # <p>
+    # Produce the Set() of methods defined in this class.
+    # </p>
+    method getMethods()
+        return methods
+    end
+    # <p>
+    # Add a method to the Set()of methods.
+    # </p>
+    method addMethod(aMethod)
+        methods.add(aMethod.getName(),aMethod)
+    end
+    # <p>
+    # Does this class define a method with the given name?  <i>Does not
+    # include inherited methods.</i>
+    # </p>
+    method hasMethod(aMethodName)
+        return methods.containsName(aMethodName)
+    end
+    # <p>
+    # Produce the method with the given name if any.  <i>Does not
+    # include inherited methdos.</i>
+    # </p>
+    method getMethod(aMethodName)
+        return methods.getByName(aMethodName)
+    end
 
-   # <p>
-   # Set the Set() of methods defined in this class.
-   # </p>
-   method setMethods(newMethods)
-      methods := newMethods
-   end
-   # <p>
-   # Produce the Set() of methods defined in this class.
-   # </p>
-   method getMethods()
-      return methods
-   end
-   # <p>
-   # Add a method to the Set()of methods.
-   # </p>
-   method addMethod(aMethod)
-      methods.add(aMethod.getName(),aMethod)
-   end
-   # <p>
-   # Does this class define a method with the given name?  <i>Does not
-   # include inherited methods.</i>
-   # </p>
-   method hasMethod(aMethodName)
-      return methods.containsName(aMethodName)
-   end
-   # <p>
-   # Produce the method with the given name if any.  <i>Does not
-   # include inherited methdos.</i>
-   # </p>
-   method getMethod(aMethodName)
-      return methods.getByName(aMethodName)
-   end
+    # <p>
+    # Set the constructor (initially clause).
+    # </p>
+    method setConstructor(newConstructor)
+        constructor := newConstructor
+    end
+    # <p>
+    # Produce the constructor.
+    # </p>
+    method getConstructor()
+        return constructor
+    end
 
-   # <p>
-   # Set the constructor (initially clause).
-   # </p>
-   method setConstructor(newConstructor)
-      constructor := newConstructor
-   end
-   # <p>
-   # Produce the constructor.
-   # </p>
-   method getConstructor()
-      return constructor
-   end
+    # <p>
+    # Set the package that this class belongs to.  <i>Every class belongs
+    #   to a package, even if its the default package.</i>
+    # </p>
+    method setPackage(aPack)
+        pack := aPack
+    end
+    # <p>
+    # Produce the package containing this class.
+    # </p>
+    method getPackage()
+        return pack
+    end
 
-   # <p>
-   # Set the package that this class belongs to.  <i>Every class belongs
-   #   to a package, even if its the default package.</i>
-   # </p>
-   method setPackage(aPack)
-      pack := aPack
-   end
-   # <p>
-   # Produce the package containing this class.
-   # </p>
-   method getPackage()
-      return pack
-   end
+    # <p>
+    # Set the file that contains this class.
+    # </p>
+    method setFile(aFile)
+        file := aFile
+    end
+    # <p>
+    # Produce the file that contains this class.
+    # </p>
+    method getFile()
+        return file
+    end
 
-   # <p>
-   # Set the file that contains this class.
-   # </p>
-   method setFile(aFile)
-      file := aFile
-   end
-   # <p>
-   # Produce the file that contains this class.
-   # </p>
-   method getFile()
-      return file
-   end
-
-initially
-   /comments := Comments()
-   /superClasses := Sequence()
-   /methods      := Set()
-   /fields       := Sequence()
-   if \name then {
-      setName(name)
-      }
+    initially
+        /comments := Comments()
+        /superClasses := Sequence()
+        /methods      := Set()
+        /fields       := Sequence()
+        if \name then {
+            setName(name)
+            }
 end
 
 # <p>
@@ -633,19 +633,19 @@ end
 #
 class UConstructor : UEntity (name, parent, comments, params)
 
-   method setParams(newParams)
-      params := newParams
-   end
-   method getParams()
-      return params
-   end
-   method addParam(newParam)
-      /params := Sequence()
-      params.add(newParam)
-   end
+    method setParams(newParams)
+        params := newParams
+    end
+    method getParams()
+        return params
+    end
+    method addParam(newParam)
+        /params := Sequence()
+        params.add(newParam)
+    end
 
-initially
-   /comments := Comments()
+    initially
+        /comments := Comments()
 end
 
 # <p>
@@ -655,409 +655,409 @@ end
 class UPackage : UEntity (name, parent, comments, files, procs, imports,
                                 classes, globals, records)
 
-   # <p>
-   # Set the Set() of files that contain code defined in this package.
-   # </p>
-   method setFiles(newFiles)
-      files := newFiles
-   end
-   # <p>
-   # Produce the Set() of files that contain code defined in this package.
-   # </p>
-   method getFiles()
-      return files
-   end
-   # <p>
-   # Add a new file to the Set() of files that contain code defined in
-   #   this package.
-   # </p>
-   method addFile(newFile)
-      files.add(newFile.getName(), newFile)
-   end
-   # <p>
-   # Delete a file from the Set() of files that contain code defined
-   #   in this package.  <i>Usually used to remove files from the
-   #   default package set.</i>
-   method delFile(fName)
-      files.del(fName)
-   end
-   # <p>
-   # Produce a sorted (by name) list of files that contain code
-   #   defined in this package.
-   # </p>
-   method getFileNames()
-      local clist
+    # <p>
+    # Set the Set() of files that contain code defined in this package.
+    # </p>
+    method setFiles(newFiles)
+        files := newFiles
+    end
+    # <p>
+    # Produce the Set() of files that contain code defined in this package.
+    # </p>
+    method getFiles()
+        return files
+    end
+    # <p>
+    # Add a new file to the Set() of files that contain code defined in
+    #   this package.
+    # </p>
+    method addFile(newFile)
+        files.add(newFile.getName(), newFile)
+    end
+    # <p>
+    # Delete a file from the Set() of files that contain code defined
+    #   in this package.  <i>Usually used to remove files from the
+    #   default package set.</i>
+    method delFile(fName)
+        files.del(fName)
+    end
+    # <p>
+    # Produce a sorted (by name) list of files that contain code
+    #   defined in this package.
+    # </p>
+    method getFileNames()
+        local clist
 
-      every put(clist := [], files.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], files.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the Set() of imports.
-   # </p>
-   method setImports(newImports)
-      imports := newImports
-   end
-   # <p>
-   # Produce the Set() of imports.
-   # </p>
-   method getImports()
-      return imports
-   end
-   # <p>
-   # Add an import to this package.
-   # </p>
-   method addImport(newImport)
-      imports.add(newImport.getName(), newImport)
-   end
-   # <p>
-   # Produce a sorted list of the names of this package's imports.
-   # </p>
-   method getImportNames()
-      local clist
+    # <p>
+    # Set the Set() of imports.
+    # </p>
+    method setImports(newImports)
+        imports := newImports
+    end
+    # <p>
+    # Produce the Set() of imports.
+    # </p>
+    method getImports()
+        return imports
+    end
+    # <p>
+    # Add an import to this package.
+    # </p>
+    method addImport(newImport)
+        imports.add(newImport.getName(), newImport)
+    end
+    # <p>
+    # Produce a sorted list of the names of this package's imports.
+    # </p>
+    method getImportNames()
+        local clist
 
-      every put(clist := [], imports.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], imports.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the procedures defined in this package.
-   # </p>
-   method setProcedures(newProcs)
-      procs := newProcs
-   end
-   # <p>
-   # Produce the procedures defined in this package.
-   # </p>
-   method getProcedures()
-      return procs
-   end
-   # <p>
-   # Add a procedure to this package.
-   # </p>
-   method addProcedure(newProc)
-      procs.add(newProc.getName(), newProc)
-   end
-   # <p>
-   # Produce a sorted list of the names of this package's procedures.
-   # </p>
-   method getProcedureNames()
-      local clist
+    # <p>
+    # Set the procedures defined in this package.
+    # </p>
+    method setProcedures(newProcs)
+        procs := newProcs
+    end
+    # <p>
+    # Produce the procedures defined in this package.
+    # </p>
+    method getProcedures()
+        return procs
+    end
+    # <p>
+    # Add a procedure to this package.
+    # </p>
+    method addProcedure(newProc)
+        procs.add(newProc.getName(), newProc)
+    end
+    # <p>
+    # Produce a sorted list of the names of this package's procedures.
+    # </p>
+    method getProcedureNames()
+        local clist
 
-      every put(clist := [], procs.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], procs.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the classes defined in this package.
-   # </p>
-   method setClasses(newClasses)
-      classes := newClasses
-   end
-   # <p>
-   # Produce the classes in this package.
-   # </p>
-   method getClasses()
-      return classes
-   end
-   # <p>
-   # Given the name of a class, return that class if it's
-   #   defined in this package.
-   # </p>
-   method getClass(cName)
-      return classes.getByName(cName)
-   end
-   # <p>
-   # Add a class to this package.
-   # </p>
-   method addClass(newClass)
-      classes.add(newClass.getName(), newClass)
-   end
-   # <p>
-   # Produce a list (sorted by name) of this package's classes.
-   # </p>
-   method getClassNames()
-      local clist
+    # <p>
+    # Set the classes defined in this package.
+    # </p>
+    method setClasses(newClasses)
+        classes := newClasses
+    end
+    # <p>
+    # Produce the classes in this package.
+    # </p>
+    method getClasses()
+        return classes
+    end
+    # <p>
+    # Given the name of a class, return that class if it's
+    #   defined in this package.
+    # </p>
+    method getClass(cName)
+        return classes.getByName(cName)
+    end
+    # <p>
+    # Add a class to this package.
+    # </p>
+    method addClass(newClass)
+        classes.add(newClass.getName(), newClass)
+    end
+    # <p>
+    # Produce a list (sorted by name) of this package's classes.
+    # </p>
+    method getClassNames()
+        local clist
 
-      every put(clist := [], classes.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], classes.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the globals defined in this package.
-   # </p>
-   method setGlobals(newGlobals)
-      globals := newGlobals
-   end
-   # <p>
-   # Produce the globals defined in this package.
-   # </p>
-   method getGlobals()
-      return globals
-   end
-   # <p>
-   # Add a global to this package.
-   # </p>
-   method addGlobal(newGlobal)
-      globals.add(newGlobal.getName(), newGlobal)
-   end
-   # <p>
-   # Produce a list (sorted by name) of this package's globals.
-   # </p>
-   method getGlobalNames()
-      local clist
+    # <p>
+    # Set the globals defined in this package.
+    # </p>
+    method setGlobals(newGlobals)
+        globals := newGlobals
+    end
+    # <p>
+    # Produce the globals defined in this package.
+    # </p>
+    method getGlobals()
+        return globals
+    end
+    # <p>
+    # Add a global to this package.
+    # </p>
+    method addGlobal(newGlobal)
+        globals.add(newGlobal.getName(), newGlobal)
+    end
+    # <p>
+    # Produce a list (sorted by name) of this package's globals.
+    # </p>
+    method getGlobalNames()
+        local clist
 
-      every put(clist := [], globals.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], globals.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the records defined in this package.
-   # </p>
-   method setRecords(newRecords)
-      records := newRecords
-   end
-   # <p>
-   # Produce the records defined in this package.
-   # </p>
-   method getRecords()
-      return records
-   end
-   # <p>
-   # Add a record to this package.
-   # </p>
-   method addRecord(newRecord)
-      records.add(newRecord.getName(), newRecord)
-   end
-   # <p>
-   # Produce a sorted list of the names of the records defined in this
-   #   package.
-   # </p>
-   method getRecordNames()
-      local clist
+    # <p>
+    # Set the records defined in this package.
+    # </p>
+    method setRecords(newRecords)
+        records := newRecords
+    end
+    # <p>
+    # Produce the records defined in this package.
+    # </p>
+    method getRecords()
+        return records
+    end
+    # <p>
+    # Add a record to this package.
+    # </p>
+    method addRecord(newRecord)
+        records.add(newRecord.getName(), newRecord)
+    end
+    # <p>
+    # Produce a sorted list of the names of the records defined in this
+    #   package.
+    # </p>
+    method getRecordNames()
+        local clist
 
-      every put(clist := [], records.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], records.getNames())
+        return sort(clist)
+    end
 
-initially
-   /files    := Set()
-   /imports  := Set()
-   /procs    := Set()
-   /classes  := Set()
-   /globals  := Set()
-   /records  := Set()
-   /comments := Comments()
+    initially
+        /files    := Set()
+        /imports  := Set()
+        /procs    := Set()
+        /classes  := Set()
+        /globals  := Set()
+        /records  := Set()
+        /comments := Comments()
 end
 
 # <p>
 # A file (composed of anything except another file)
 # </p>
 class UFile : UEntity (name, parent, comments, imports, links, pack,
-		       procs, classes, globals, records)
+                             procs, classes, globals, records)
 
-   # <p>
-   # Set the imports listed in this file.
-   # </p>
-   method setImports(newImports)
-      imports := newImports
-   end
-   # <p>
-   # Produce the imports listed in this file.
-   # </p>
-   method getImports()
-      return imports
-   end
-   # <p>
-   # Add an import to this file.
-   # </p>
-   method addImport(newImport)
-      imports.add(newImport)
-   end
-   # <p>
-   # Produce a sorted list of the names of files imported by this file.
-   # </p>
-   method getImportNames()
-      local clist
+    # <p>
+    # Set the imports listed in this file.
+    # </p>
+    method setImports(newImports)
+        imports := newImports
+    end
+    # <p>
+    # Produce the imports listed in this file.
+    # </p>
+    method getImports()
+        return imports
+    end
+    # <p>
+    # Add an import to this file.
+    # </p>
+    method addImport(newImport)
+        imports.add(newImport)
+    end
+    # <p>
+    # Produce a sorted list of the names of files imported by this file.
+    # </p>
+    method getImportNames()
+        local clist
 
-      every put(clist := [], imports.get().getName())
-      return sort(clist)
-   end
+        every put(clist := [], imports.get().getName())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the links listed in this file.
-   # </p>
-   method setLinks(newLinks)
-      links := newLinks
-   end
-   # <p>
-   # Produce the links listed in this file.
-   # </p>
-   method getLinks()
-      return links
-   end
-   # <p>
-   # Add a link to this file.
-   # </p>
-   method addLink(newLink)
-      links.add(newLink)
-   end
-   # <p>
-   # Produce a sorted list of the names of files lined by this file.
-   # </p>
-   method getLinkNames()
-      local clist
+    # <p>
+    # Set the links listed in this file.
+    # </p>
+    method setLinks(newLinks)
+        links := newLinks
+    end
+    # <p>
+    # Produce the links listed in this file.
+    # </p>
+    method getLinks()
+        return links
+    end
+    # <p>
+    # Add a link to this file.
+    # </p>
+    method addLink(newLink)
+        links.add(newLink)
+    end
+    # <p>
+    # Produce a sorted list of the names of files lined by this file.
+    # </p>
+    method getLinkNames()
+        local clist
 
-      every put(clist := [], links.get().getName())
-      return sort(clist)
-   end
+        every put(clist := [], links.get().getName())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the package that this file belongs in.
-   # </p>
-   method setPackage(newPack)
-      pack := newPack
-   end
-   # <p>
-   # Produce the package associated with this file.
-   # </p>
-   method getPackage()
-      return pack
-   end
-   # <p>
-   # Produce the name of the package associated with this file.
-   # </p>
-   method getPackageName()
-      return pack.getName()
-   end
+    # <p>
+    # Set the package that this file belongs in.
+    # </p>
+    method setPackage(newPack)
+        pack := newPack
+    end
+    # <p>
+    # Produce the package associated with this file.
+    # </p>
+    method getPackage()
+        return pack
+    end
+    # <p>
+    # Produce the name of the package associated with this file.
+    # </p>
+    method getPackageName()
+        return pack.getName()
+    end
 
-   # <p>
-   # Set the procedures listed in this file.
-   # </p>
-   method setProcedures(newProcs)
-      procs := newProcs
-   end
-   # <p>
-   # Produce the procedures listed in this file.
-   # </p>
-   method getProcedures()
-      return procs
-   end
-   # <p>
-   # Add an procedure to this file.
-   # </p>
-   method addProcedure(newProc)
-      procs.add(newProc.getName(), newProc)
-   end
-   # <p>
-   # Produce a sorted list of the names of the procedures in this file.
-   # </p>
-   method getProcedureNames()
-      local clist
+    # <p>
+    # Set the procedures listed in this file.
+    # </p>
+    method setProcedures(newProcs)
+        procs := newProcs
+    end
+    # <p>
+    # Produce the procedures listed in this file.
+    # </p>
+    method getProcedures()
+        return procs
+    end
+    # <p>
+    # Add an procedure to this file.
+    # </p>
+    method addProcedure(newProc)
+        procs.add(newProc.getName(), newProc)
+    end
+    # <p>
+    # Produce a sorted list of the names of the procedures in this file.
+    # </p>
+    method getProcedureNames()
+        local clist
 
-      every put(clist := [], procs.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], procs.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the classes listed in this file.
-   # </p>
-   method setClasses(newClasses)
-      classes := newClasses
-   end
-   # <p>
-   # Produce the classes listed in this file.
-   # </p>
-   method getClasses()
-      return classes
-   end
-   # <p>
-   # Produce the class with the given name if it's defined in this file.
-   # </p>
-   method getClass(cName)
-      return classes.getByName(cName)
-   end
-   # <p>
-   # Add a class to this file.
-   # </p>
-   method addClass(newClass)
-      classes.add(newClass.getName(), newClass)
-   end
-   # <p>
-   # Produce a sorted list of the names of classes defined by this file.
-   # </p>
-   method getClassNames()
-      local clist
+    # <p>
+    # Set the classes listed in this file.
+    # </p>
+    method setClasses(newClasses)
+        classes := newClasses
+    end
+    # <p>
+    # Produce the classes listed in this file.
+    # </p>
+    method getClasses()
+        return classes
+    end
+    # <p>
+    # Produce the class with the given name if it's defined in this file.
+    # </p>
+    method getClass(cName)
+        return classes.getByName(cName)
+    end
+    # <p>
+    # Add a class to this file.
+    # </p>
+    method addClass(newClass)
+        classes.add(newClass.getName(), newClass)
+    end
+    # <p>
+    # Produce a sorted list of the names of classes defined by this file.
+    # </p>
+    method getClassNames()
+        local clist
 
-      every put(clist := [], classes.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], classes.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the globals listed in this file.
-   # </p>
-   method setGlobals(newGlobals)
-      globals := newGlobals
-   end
-   # <p>
-   # Produce the globals listed in this file.
-   # </p>
-   method getGlobals()
-      return globals
-   end
-   # <p>
-   # Add a global to this file.
-   # </p>
-   method addGlobal(newGlobal)
-      globals.add(newGlobal.getName(), newGlobal)
-   end
-   # <p>
-   # Produce a sorted list of the names of globals listed by this file.
-   # </p>
-   method getGlobalNames()
-      local clist
+    # <p>
+    # Set the globals listed in this file.
+    # </p>
+    method setGlobals(newGlobals)
+        globals := newGlobals
+    end
+    # <p>
+    # Produce the globals listed in this file.
+    # </p>
+    method getGlobals()
+        return globals
+    end
+    # <p>
+    # Add a global to this file.
+    # </p>
+    method addGlobal(newGlobal)
+        globals.add(newGlobal.getName(), newGlobal)
+    end
+    # <p>
+    # Produce a sorted list of the names of globals listed by this file.
+    # </p>
+    method getGlobalNames()
+        local clist
 
-      every put(clist := [], globals.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], globals.getNames())
+        return sort(clist)
+    end
 
-   # <p>
-   # Set the records listed in this file.
-   # </p>
-   method setRecords(newRecords)
-      records := newRecords
-   end
-   # <p>
-   # Produce the records listed in this file.
-   # </p>
-   method getRecords()
-      return records
-   end
-   # <p>
-   # Add a record to this file.
-   # </p>
-   method addRecord(newRecord)
-      records.add(newRecord.getName(), newRecord)
-   end
-   # <p>
-   # Produce a sorted list of the names of records defined by this file.
-   # </p>
-   method getRecordNames()
-      local clist
+    # <p>
+    # Set the records listed in this file.
+    # </p>
+    method setRecords(newRecords)
+        records := newRecords
+    end
+    # <p>
+    # Produce the records listed in this file.
+    # </p>
+    method getRecords()
+        return records
+    end
+    # <p>
+    # Add a record to this file.
+    # </p>
+    method addRecord(newRecord)
+        records.add(newRecord.getName(), newRecord)
+    end
+    # <p>
+    # Produce a sorted list of the names of records defined by this file.
+    # </p>
+    method getRecordNames()
+        local clist
 
-      every put(clist := [], records.getNames())
-      return sort(clist)
-   end
+        every put(clist := [], records.getNames())
+        return sort(clist)
+    end
 
-initially
-   /imports := Sequence()
-   /links   := Sequence()
-   # There's at most one package for a file, so no sequence needed!
-   /procs   := Set()
-   /classes := Set()
-   /globals := Set()
-   /records := Set()
-   /comments := Comments()
+    initially
+        /imports := Sequence()
+        /links   := Sequence()
+        # There's at most one package for a file, so no sequence needed!
+        /procs   := Set()
+        /classes := Set()
+        /globals := Set()
+        /records := Set()
+        /comments := Comments()
 end
 
 # <p>
@@ -1068,69 +1068,70 @@ end
 # </p>
 class Comments: Object (head, tail)
 
-   # <p>
-   # How many comments are there?
-   # </p>
-   method size()
-      local block, s
+    # <p>
+    # How many comments are there?
+    # </p>
+    method size()
+        local block, s
 
-      s := 0
-      block := head
-      while \block do {
-	 s +:= block.size()
-	 block := block.nextblock
-	 }
-      return s
-   end
+        s := 0
+        block := head
+        while \block do {
+            s +:= block.size()
+            block := block.nextblock
+            }
+        return s
+    end
 
-   # <p>
-   # Add a comment to the current comment block.
-   # </p>
-   method add(newComment)
-      tail.put(newComment)
-   end
+    # <p>
+    # Add a comment to the current comment block.
+    # </p>
+    method add(newComment)
+        tail.put(newComment)
+    end
 
-   # <p>
-   # Generates the chain of comment blocks.
-   # Fails if no comment blocks available.
-   # </p>
-   method get()
-      local block
+    # <p>
+    # Generates the chain of comment blocks.
+    # Fails if no comment blocks available.
+    # </p>
+    method get()
+        local block
 
-      block := head
-      while \block do {
-	 if block.size() > 0 then {
-	    suspend block
-	    }
-	 block := block.nextblock
-	 }
-   end
+        block := head
+        while \block do {
+            if block.size() > 0 then {
+                suspend block
+                }
+            block := block.nextblock
+            }
 
-   # <p>
-   # Start a new comment block
-   # </p>
-   method newBlock()
-      tail.nextblock := CommentBlock()
-      tail := tail.nextblock
-   end
+    end
 
-   # <p>
-   # Append another list of comments to this list.
-   # </p>
-   method append(newComments)
-      tail.nextblock := newComments.get()
-   end
+    # <p>
+    # Start a new comment block
+    # </p>
+    method newBlock()
+        tail.nextblock := CommentBlock()
+        tail := tail.nextblock
+    end
 
-   # <p>
-   # Produce the first "sentence" of this sequence of comments.
-   #    Later, the definition of "sentence" will be improved.
-   # </p>
-   method getFirstSentence()
-      return head.getFirstSentence()
-   end
+    # <p>
+    # Append another list of comments to this list.
+    # </p>
+    method append(newComments)
+        tail.nextblock := newComments.get()
+    end
 
-initially
-   tail := head := CommentBlock()
+    # <p>
+    # Produce the first "sentence" of this sequence of comments.
+    #    Later, the definition of "sentence" will be improved.
+    # </p>
+    method getFirstSentence()
+        return head.getFirstSentence()
+    end
+
+    initially
+        tail := head := CommentBlock()
 end
 
 # <p>
@@ -1138,77 +1139,77 @@ end
 # </p>
 class CommentBlock: Object (legacy, comments, nextblock)
 
-   # <p>
-   # Produce the number of lines in this paragraph.
-   # </p>
-   method size()
-      return *comments
-   end
+    # <p>
+    # Produce the number of lines in this paragraph.
+    # </p>
+    method size()
+        return *comments
+    end
 
-   # <p>
-   # Succeed if this comment paragraph appears to be a 'legacy'
-   #   comment paragraph.  A <i>legacy</i> comment paragraph is
-   #   one that does not start with an HTML key, though it can
-   #   still contain HTML clauses.
-   # </p>
-   method isLegacy()
-      return \legacy
-   end
+    # <p>
+    # Succeed if this comment paragraph appears to be a 'legacy'
+    #   comment paragraph.  A <i>legacy</i> comment paragraph is
+    #   one that does not start with an HTML key, though it can
+    #   still contain HTML clauses.
+    # </p>
+    method isLegacy()
+        return \legacy
+    end
 
-   # <p>
-   # Add a comment to the paragraph.
-   # </p>
-   method put(newComment)
-      if firstNonBlank() then {    # see if this is a legacy comment or not.
-	 if match("<", lTrim(newComment)) then {
-	    legacy := &null
-	    }
-	 else {
-	    legacy := "yes"
-	    }
-	 }
-      ::put(comments, newComment)
-   end
+    # <p>
+    # Add a comment to the paragraph.
+    # </p>
+    method put(newComment)
+        if firstNonBlank() then {    # see if this is a legacy comment or not.
+            if match("<", lTrim(newComment)) then {
+                legacy := &null
+                }
+            else {
+                legacy := "yes"
+                }
+            }
+        ::put(comments, newComment)
+    end
 
-   # <p>
-   # Succeeds if the newComment has been preceded
-   #   only by blank comments.
-   # </p>
-   # <i>This is intended for internal use only!</i>
-   method firstNonBlank()
-      local c
+    # <p>
+    # Succeeds if the newComment has been preceded
+    #   only by blank comments.
+    # </p>
+    # <i>This is intended for internal use only!</i>
+    method firstNonBlank()
+        local c
 
-      every c := !comments do {
-	 if *trim(c, ' \t\n') > 0 then fail
-	 }
-      return
-   end
+        every c := !comments do {
+            if *trim(c, ' \t\n') > 0 then fail
+            }
+        return
+    end
 
-   # <p>
-   # Generate all the comments in this paragraph
-   # </p>
-   method get()
-      suspend !comments
-   end
+    # <p>
+    # Generate all the comments in this paragraph
+    # </p>
+    method get()
+        suspend !comments
+    end
 
-   # <p>
-   # Produce the first "sentence" of this comment block.  Later,
-   #    the definition of "sentence" will be improved.
-   # </p>
-   method getFirstSentence()
-      return \comments[1]
-   end
+    # <p>
+    # Produce the first "sentence" of this comment block.  Later,
+    #    the definition of "sentence" will be improved.
+    # </p>
+    method getFirstSentence()
+        return \comments[1]
+    end
 
-initially
-   comments := []
-   nextblock := &null
+    initially
+        comments := []
+        nextblock := &null
 end
 
 #<p>
 # Produce a more useful name for the type of form <tt>obj</tt>.
 #</p>
 procedure getFormType(obj)
-   return case obj.className() of {
+    return case obj.className() of {
         "UniDoc::UName"        : obj.getCategory()
         "UniDoc::UGlobal"      : "global"
         "UniDoc::UMethod"      : "method"
@@ -1222,3 +1223,4 @@ procedure getFormType(obj)
         "UniDoc::UFile"        : "file"
         }
 end
+

--- a/uni/unidoc/UniHTML.icn
+++ b/uni/unidoc/UniHTML.icn
@@ -881,23 +881,39 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure checkSpecial(s, keyMap)
-    local ns
+    local ns, inPre, inCode
     static cMap      # map of UniDoc special comments fields for sbal()
     initial {
         cMap := table()
         cMap["<["] := "]>"
         }
+    inPre := inCode := 0
     ns := ""
     s ? {
-        while ns ||:= tab(find("<[")) do {
-            if not parseClause(sbal(cMap), keyMap) then {
-                ns ||:= "&lt;["
-                }
-            }
+        # Have to ignore UniDoc special comments inside <pre> or <code> blocks
+        while ns ||:= tab(find("<")) do {
+           if ns ||:= 1(="<pre>",inPre +:= 1) then next
+           if ns ||:= 1(="</pre>",inPre := decr(inPre)) then next
+           if ns ||:= 1(="<code>",inCode +:= 1) then next
+           if ns ||:= 1(="</code>",inCode := decr(inCode)) then next
+           if (inPre = 0) & (inCode = 0) then {
+              if match("<[") then {
+                 if not parseClause(sbal(cMap), keyMap) then {
+                    ns ||:= (move(2),"&lt;[")
+                    }
+                 }
+              else ns ||:= move(1)
+              }
+           else ns ||:= (move(1), "&lt;")
+           }
         ns ||:= tab(0)
         }
 
     return ns
+end
+
+procedure decr(n)
+   return (n > 0, n-1)|0
 end
 
 # <p>

--- a/uni/unidoc/UniHTML.icn
+++ b/uni/unidoc/UniHTML.icn
@@ -537,14 +537,15 @@ class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath,
                     return "file_"||delSuffix(bName, ".icn")||".html"
                     }
             "UniDoc::UClass"      : {
-                    pName := obj.getParent().getName()
+                    pName := fixName(obj.getPackage().getName())
                     pName := "class_"||delSuffix(pName,".icn")
-                    return pName||"_"||fixName(bName)||".html"
+                    return pName||"_"||bName||".html"
                     }
-            "UniDoc::UImport"     |
+            "UniDoc::UImport"     : {
+                    return idoc.locatePack(bName)
+                    }
             "UniDoc::UPackage"    : {
-                    pName := "pack_"
-                    return pName||fixName(bName)||".html"
+                    return "pack_"||fixName(bName)||".html"
                     }
             "UniDoc::UProc"       |
             "UniDoc::URecord"     |
@@ -564,7 +565,7 @@ class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath,
                         else {
                             # See if there's already an HTML page for it!
                             if pName := idoc.classOnLinkPath(p, bName) then {
-                                return pName||".html";
+                                return pName;
                                 }
                             write("can't find: ",bName)
                             }
@@ -614,7 +615,7 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure adjustDir(fName)
-   if \dirFlag & not match("../", fName) then {
+   if \dirFlag & not match("../"|"/", fName) then {
        fName := "../"||fName
        }
    return fName

--- a/uni/unidoc/UniHTML.icn
+++ b/uni/unidoc/UniHTML.icn
@@ -21,592 +21,593 @@ global dirFlag
 #   the internal representation of Unicon programs that is produced
 #   by the <b>UniALL</b> class.
 # </p>
-class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath, debug)
+class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath,
+                       debug)
 
-   # <p>
-   # Construct all the needed HTML pages.  <i>All other methods are
-   #   intended for internal use only.</i>
-   # </p>
-   method buildPages()
-      buildMainIndex()
-      buildBeginPage()
-      buildMasterNavIndex()
-      buildAllIndex()
-      buildPackageIndices()
-      buildClassIndices()
-      buildFileIndices()
-      buildClassFiles()
-      buildPackageFiles()
-      buildFileFiles()
-   end
+    # <p>
+    # Construct all the needed HTML pages.  <i>All other methods are
+    #   intended for internal use only.</i>
+    # </p>
+    method buildPages()
+        buildMainIndex()
+        buildBeginPage()
+        buildMasterNavIndex()
+        buildAllIndex()
+        buildPackageIndices()
+        buildClassIndices()
+        buildFileIndices()
+        buildClassFiles()
+        buildPackageFiles()
+        buildFileFiles()
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildMainIndex()
-      local page
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildMainIndex()
+        local page
 
-      page := openStdHtmlFile(baseDir, mainIndex)
+        page := openStdHtmlFile(baseDir, mainIndex)
 
-      write(page, "<html>")
-      write(page, "<title>")
-      write(page, title)
-      write(page, "</title>")
-      write(page, "</head>")
+        write(page, "<html>")
+        write(page, "<title>")
+        write(page, title)
+        write(page, "</title>")
+        write(page, "</head>")
 
-      write(page, "<frameset cols=\"20%,80%\">")
-      write(page, "<frameset rows=\"40%,60%\">")
-      write(page, "<frame src=\"nav.",mainIndex,"\" name=\"navFrame\">")
-      write(page, "<frame src=\"index_all_",mainIndex,
-		  "\" name=\"listFrame\">")
-      write(page, "</frameset>")
-      write(page, "<frame src=\"begin_",mainIndex,"\" name=\"displayFrame\">")
-      write(page, "</frameset>")
+        write(page, "<frameset cols=\"20%,80%\">")
+        write(page, "<frameset rows=\"40%,60%\">")
+        write(page, "<frame src=\"nav.",mainIndex,"\" name=\"navFrame\">")
+        write(page, "<frame src=\"index_all_",mainIndex,
+                                       "\" name=\"listFrame\">")
+        write(page, "</frameset>")
+        write(page, "<frame src=\"begin_",mainIndex,"\" name=\"displayFrame\">")
+        write(page, "</frameset>")
 
-      write(page, "<noframes>")
-      write(page, "<h2>Frame Alert</h2>")
-      write(page, "<p>")
-      write(page, "This document requires the use of frames to ")
-      write(page, "display properly.  If you see this message, then")
-      write(page, "you don't have frames enabled in your browser.")
-      write(page, "</p>")
+        write(page, "<noframes>")
+        write(page, "<h2>Frame Alert</h2>")
+        write(page, "<p>")
+        write(page, "This document requires the use of frames to ")
+        write(page, "display properly.  If you see this message, then")
+        write(page, "you don't have frames enabled in your browser.")
+        write(page, "</p>")
 
-      write(page, "</html>")
-      close(page)
-   end
+        write(page, "</html>")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildBeginPage()
-      local page, bc
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildBeginPage()
+        local page, bc
 
-      page := openStdHtmlFile(baseDir, "begin_"||mainIndex)
-      write(page, "<html>")
-      pageTop(page)
-      outputHeading(page, title||"- Full Index", "+6", "#ccccff")
-      bc := "#eeeeff"
-      outputUrlSection(page, "Files:",     idoc.getAllFiles(),     &null, bc)
-      outputUrlSection(page, "Packages:",  idoc.getAllPackages(),  &null, bc)
-      outputUrlSection(page, "Classes:",   idoc.getAllClasses(),   &null, bc)
-      outputUrlSection(page, "Procedures:",idoc.getAllProcedures(),&null, bc)
-      outputUrlSection(page, "Records:",   idoc.getAllRecords(),   &null, bc)
-      outputUrlSection(page, "Global variables",
-		       idoc.getAllGlobals(),   &null, bc)
-      pageBottom(page)
-      write(page, "</html>")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, "begin_"||mainIndex)
+        write(page, "<html>")
+        pageTop(page)
+        outputHeading(page, title||"- Full Index", "+6", "#ccccff")
+        bc := "#eeeeff"
+        outputUrlSection(page, "Files:",     idoc.getAllFiles(),     &null, bc)
+        outputUrlSection(page, "Packages:",  idoc.getAllPackages(),  &null, bc)
+        outputUrlSection(page, "Classes:",   idoc.getAllClasses(),   &null, bc)
+        outputUrlSection(page, "Procedures:",idoc.getAllProcedures(),&null, bc)
+        outputUrlSection(page, "Records:",   idoc.getAllRecords(),   &null, bc)
+        outputUrlSection(page, "Global variables",
+                                             idoc.getAllGlobals(),   &null, bc)
+        pageBottom(page)
+        write(page, "</html>")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildMasterNavIndex()
-      local page, f, fName, ffName, p, pfName
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildMasterNavIndex()
+        local page, f, fName, ffName, p, pfName
 
-      page := openStdHtmlFile(baseDir, "nav."||mainIndex)
-      write(page, "<html>")
-      pageTop(page)
-      write(page, "<h1>Navigation</h1>")
-      write(page, "<p></p>")
-      write(page, listFrameRef("all_"||mainIndex,"Everything"))
-      write(page, "<p></p>")
-      write(page, "<h2>Files</h2>")
-      write(page, "<p></p>")
-      every f := !idoc.getAllFiles() do {
-	 fName  := delSuffix(f.getName(), ".icn")||".icn"
-	 ffName := delSuffix(getURL(f), ".html")||".html"
-	 write(page, listFrameRef(fixName(ffName), fName))
-	 }
-      write(page, "<h2>Packages</h2>")
-      write(page, "<p></p>")
-      every p := (!sort(idoc.packages))[2] do {
-	 pfName := delSuffix(getURL(p), ".html")||".html"
-	 write(page, listFrameRef(fixName(pfName), p.getName()))
-	 }
-      pageBottom(page, "quiet")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, "nav."||mainIndex)
+        write(page, "<html>")
+        pageTop(page)
+        write(page, "<h1>Navigation</h1>")
+        write(page, "<p></p>")
+        write(page, listFrameRef("all_"||mainIndex,"Everything"))
+        write(page, "<p></p>")
+        write(page, "<h2>Files</h2>")
+        write(page, "<p></p>")
+        every f := !idoc.getAllFiles() do {
+            fName  := delSuffix(f.getName(), ".icn")||".icn"
+            ffName := delSuffix(getURL(f), ".html")||".html"
+            write(page, listFrameRef(fixName(ffName), fName))
+            }
+        write(page, "<h2>Packages</h2>")
+        write(page, "<p></p>")
+        every p := (!sort(idoc.packages))[2] do {
+            pfName := delSuffix(getURL(p), ".html")||".html"
+            write(page, listFrameRef(fixName(pfName), p.getName()))
+            }
+        pageBottom(page, "quiet")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildAllIndex()
-      local page
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildAllIndex()
+        local page
 
-      page := openStdHtmlFile(baseDir, "index_all_"||mainIndex)
-      pageTop(page)
-      write(page, "<h1>",displayFrameRef("begin_"||mainIndex, "Full Index"),
-		  "</h1>")
-      outputNameList(page, "Packages",   idoc.getAllPackages())
-      outputNameList(page, "Classes",    idoc.getAllClasses())
-      outputNameList(page, "Procedures", idoc.getAllProcedures())
-      outputNameList(page, "Records",    idoc.getAllRecords())
-      outputNameList(page, "Variables",  idoc.getAllGlobals())
-      outputFileList(page, "Files",      idoc.getAllFiles())
-      pageBottom(page, "quiet")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, "index_all_"||mainIndex)
+        pageTop(page)
+        write(page, "<h1>",displayFrameRef("begin_"||mainIndex, "Full Index"),
+                    "</h1>")
+        outputNameList(page, "Packages",   idoc.getAllPackages())
+        outputNameList(page, "Classes",    idoc.getAllClasses())
+        outputNameList(page, "Procedures", idoc.getAllProcedures())
+        outputNameList(page, "Records",    idoc.getAllRecords())
+        outputNameList(page, "Variables",  idoc.getAllGlobals())
+        outputFileList(page, "Files",      idoc.getAllFiles())
+        pageBottom(page, "quiet")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildPackageIndices()
-      local pack
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildPackageIndices()
+        local pack
 
-      every pack := !idoc.packages do {
-	 buildOnePackageIndex(pack)
-	 }
-   end
+        every pack := !idoc.packages do {
+            buildOnePackageIndex(pack)
+            }
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildOnePackageIndex(pack)
-      local pName, pfName, page
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildOnePackageIndex(pack)
+        local pName, pfName, page
 
-      pName := pack.getName()
-      pfName := delSuffix(getURL(pack), ".html")||".html"
-      page := openStdHtmlFile(baseDir, "index_"||pfName)
-      pageTop(page)
-      write(page, "<h1>",displayFrameRef(getURL(pack), pName),"</h2>")
-      outputNameList(page, "Classes",    mkList(pack.getClasses()))
-      outputNameList(page, "Procedures", mkList(pack.getProcedures()))
-      outputNameList(page, "Records",    mkList(pack.getRecords()))
-      outputNameList(page, "Variables",  mkList(pack.getGlobals()))
-      outputFileList(page, "Files",      mkList(pack.getFiles()))
-      pageBottom(page, "quiet")
-      close(page)
-   end
+        pName := pack.getName()
+        pfName := delSuffix(getURL(pack), ".html")||".html"
+        page := openStdHtmlFile(baseDir, "index_"||pfName)
+        pageTop(page)
+        write(page, "<h1>",displayFrameRef(getURL(pack), pName),"</h2>")
+        outputNameList(page, "Classes",    mkList(pack.getClasses()))
+        outputNameList(page, "Procedures", mkList(pack.getProcedures()))
+        outputNameList(page, "Records",    mkList(pack.getRecords()))
+        outputNameList(page, "Variables",  mkList(pack.getGlobals()))
+        outputFileList(page, "Files",      mkList(pack.getFiles()))
+        pageBottom(page, "quiet")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildClassIndices()
-      local pack, aClass
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildClassIndices()
+        local pack, aClass
 
-      every pack := !idoc.packages do {
-	 every aClass := pack.getClasses().get() do {
-	    buildOneClassIndex(aClass)
-	    }
-	 }
-   end
+        every pack := !idoc.packages do {
+            every aClass := pack.getClasses().get() do {
+                buildOneClassIndex(aClass)
+                }
+            }
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildOneClassIndex(aClass)
-      local cName, cfName, page
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildOneClassIndex(aClass)
+        local cName, cfName, page
 
-      cName := aClass.getName()
-      cfName := delSuffix(getURL(aClass), ".html")||".html"
-      page := openStdHtmlFile(baseDir, "index_"||cfName)
-      pageTop(page)
-      write(page, "<h1>",displayFrameRef(getURL(aClass), cName),"</h2>")
-      outputNameList(page, "Methods",    mkList(aClass.getMethods()))
-      outputNameList(page, "Fields",     mkList(aClass.getParams()))
-      pageBottom(page, "quiet")
-      close(page)
-   end
+        cName := aClass.getName()
+        cfName := delSuffix(getURL(aClass), ".html")||".html"
+        page := openStdHtmlFile(baseDir, "index_"||cfName)
+        pageTop(page)
+        write(page, "<h1>",displayFrameRef(getURL(aClass), cName),"</h2>")
+        outputNameList(page, "Methods",    mkList(aClass.getMethods()))
+        outputNameList(page, "Fields",     mkList(aClass.getParams()))
+        pageBottom(page, "quiet")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildFileIndices()
-      local file
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildFileIndices()
+        local file
 
-      every file := !idoc.files do {
-	 buildOneFileIndex(file)
-	 }
-   end
+        every file := !idoc.files do {
+            buildOneFileIndex(file)
+            }
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildOneFileIndex(f)
-      local fName, ffName, page
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildOneFileIndex(f)
+        local fName, ffName, page
 
-      fName := delSuffix(f.getName(), ".icn")||".icn"
-      ffName := delSuffix(getURL(f), ".html")||".html"
-      page := openStdHtmlFile(baseDir, "index_"||ffName)
-      pageTop(page)
-      write(page, "<h1>",displayFrameRef(getURL(f), fName),"</h2>")
-      outputNameList(page, "Classes",    mkList(f.getClasses()))
-      outputNameList(page, "Procedures", mkList(f.getProcedures()))
-      outputNameList(page, "Records",    mkList(f.getRecords()))
-      outputNameList(page, "Variables",  mkList(f.getGlobals()))
-      outputNameList(page, "Imports",    mkList(f.getImports()))
-      outputNameList(page, "Links",      mkList(f.getLinks()))
-      pageBottom(page, "quiet")
-      close(page)
-   end
+        fName := delSuffix(f.getName(), ".icn")||".icn"
+        ffName := delSuffix(getURL(f), ".html")||".html"
+        page := openStdHtmlFile(baseDir, "index_"||ffName)
+        pageTop(page)
+        write(page, "<h1>",displayFrameRef(getURL(f), fName),"</h2>")
+        outputNameList(page, "Classes",    mkList(f.getClasses()))
+        outputNameList(page, "Procedures", mkList(f.getProcedures()))
+        outputNameList(page, "Records",    mkList(f.getRecords()))
+        outputNameList(page, "Variables",  mkList(f.getGlobals()))
+        outputNameList(page, "Imports",    mkList(f.getImports()))
+        outputNameList(page, "Links",      mkList(f.getLinks()))
+        pageBottom(page, "quiet")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildClassFiles()
-      write("Building HTML files for classes:")
-      every buildClass(!idoc.getAllClasses())
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildClassFiles()
+        write("Building HTML files for classes:")
+        every buildClass(!idoc.getAllClasses())
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildPackageFiles()
-      write("Building HTML files for ",*idoc.packages," packages:")
-      every buildPackage(!idoc.getAllPackages())
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildPackageFiles()
+        write("Building HTML files for ",*idoc.packages," packages:")
+        every buildPackage(!idoc.getAllPackages())
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildFileFiles()
-      write("Building HTML files for ",*idoc.files," files:")
-      every buildFile(!idoc.files)
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildFileFiles()
+        write("Building HTML files for ",*idoc.files," files:")
+        every buildFile(!idoc.files)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method defineDiversions()
-      return "<STYLE TYPE=\"text/css\">\n"                    ||
-             "div.colored {\n"                                ||
-             "   background-color: #f1f1ff;\n"                ||
-             "   opacity: 0.9;\n"                             ||
-             "   filter:alpha(opacity=50); /* IE's opacity*/" ||
-             "   width: relative;\n"                          ||
-             "   }\n"                                         ||
-             "div.indented {\n"                               ||
-             "   padding-left: 25pt;\n"                       ||
-             "   font-size: small;\n"                         ||
-             "   width: relative;\n"                          ||
-             "   }\n"                                         ||
-             "</STYLE>"
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method defineDiversions()
+        return "<STYLE TYPE=\"text/css\">\n"                    ||
+               "div.colored {\n"                                ||
+               "   background-color: #f1f1ff;\n"                ||
+               "   opacity: 0.9;\n"                             ||
+               "   filter:alpha(opacity=50); /* IE's opacity*/" ||
+               "   width: relative;\n"                          ||
+               "   }\n"                                         ||
+               "div.indented {\n"                               ||
+               "   padding-left: 25pt;\n"                       ||
+               "   font-size: small;\n"                         ||
+               "   width: relative;\n"                          ||
+               "   }\n"                                         ||
+               "</STYLE>"
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildClass(aClass)
-      local page, pack, pName, file, fName
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildClass(aClass)
+        local page, pack, pName, file, fName
 
-      page := openStdHtmlFile(baseDir, getURL(aClass))
-      write("\t",getURL(aClass))
-      write(page, "<html>")
-      write(page, "<head>")
-      write(page, "<title>",aClass.getName(),"</title>")
-      write(page, defineDiversions())
-      write(page, "</head>")
-      pageTop(page)
-      outputHeading(page, "Class "||aClass.getName(), "+6")
-      outputComments(page, "<h2>Summary</h2>", aClass.getComments())
-      write(page, "<dl>")
-      outputUrlList(page, "Superclasses:",  mkList(aClass.getSuperClasses()))
-      pack  := aClass.getPackage()
-      pName := pack.getName()
-      pack  := getURL(pack)
-      write(page, "<dt>Package:</dt><dd>",listFrameRef(pack, pName),"</dd>")
-      file  := aClass.getFile()
-      fName := delSuffix(file.getName(),".icn")||".icn"
-      file  := getURL(file)
-      write(page, "<dt>File:</dt><dd>",listFrameRef(file, fName),"</dd>")
-      write(page, "</dl>")
-      outputUrlList(page, "Methods:",          mkList(aClass.getMethods()))
-      outputInheritedMethods(page, aClass)
-      outputUrlList(page, "Fields:",           mkList(aClass.getParams()))
-      sRef := displaySrcURL(aClass, "Source code.") 
-      if sRef ~== "Source code." then {
-	 write(page, "<b><i>", sRef, "</i></b><p></p>")
-	 }
-      outputHeading(page, "Details", "+4")
-      outputHeading(page, "Constructor", "+2", "#eeeeff")
-      outputFunction(page, aClass.getConstructor())
-      outputMethods(page, "Methods:", aClass)
-      outputVars(page,  "Fields:",             mkList(aClass.getParams()))
-      pageBottom(page)
-      write(page, "</html>")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, getURL(aClass))
+        write("\t",getURL(aClass))
+        write(page, "<html>")
+        write(page, "<head>")
+        write(page, "<title>",aClass.getName(),"</title>")
+        write(page, defineDiversions())
+        write(page, "</head>")
+        pageTop(page)
+        outputHeading(page, "Class "||aClass.getName(), "+6")
+        outputComments(page, "<h2>Summary</h2>", aClass.getComments())
+        write(page, "<dl>")
+        outputUrlList(page, "Superclasses:",  mkList(aClass.getSuperClasses()))
+        pack  := aClass.getPackage()
+        pName := pack.getName()
+        pack  := getURL(pack)
+        write(page, "<dt>Package:</dt><dd>",listFrameRef(pack, pName),"</dd>")
+        file  := aClass.getFile()
+        fName := delSuffix(file.getName(),".icn")||".icn"
+        file  := getURL(file)
+        write(page, "<dt>File:</dt><dd>",listFrameRef(file, fName),"</dd>")
+        write(page, "</dl>")
+        outputUrlList(page, "Methods:",          mkList(aClass.getMethods()))
+        outputInheritedMethods(page, aClass)
+        outputUrlList(page, "Fields:",           mkList(aClass.getParams()))
+        sRef := displaySrcURL(aClass, "Source code.") 
+        if sRef ~== "Source code." then {
+            write(page, "<b><i>", sRef, "</i></b><p></p>")
+            }
+        outputHeading(page, "Details", "+4")
+        outputHeading(page, "Constructor", "+2", "#eeeeff")
+        outputFunction(page, aClass.getConstructor())
+        outputMethods(page, "Methods:", aClass)
+        outputVars(page,  "Fields:",             mkList(aClass.getParams()))
+        pageBottom(page)
+        write(page, "</html>")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildPackage(aPack)
-      local page, p, r, g
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildPackage(aPack)
+        local page, p, r, g
 
-      page := openStdHtmlFile(baseDir, getURL(aPack))
-      write("\t",getURL(aPack))
-      write(page, "<html>")
-      write(page, "<head>")
-      write(page, "<title>",aPack.getName(),"</title>")
-      write(page, defineDiversions())
-      write(page, "</head>")
-      pageTop(page)
-      outputHeading(page, "Package "||aPack.getName(), "+6")
-      outputComments(page, "<h2>Summary</h2>", aPack.getComments())
-      outputUrlList(page, "Classes:",          mkList(aPack.getClasses()))
-      outputUrlList(page, "Procedures:",       mkList(aPack.getProcedures()))
-      outputUrlList(page, "Records:",          mkList(aPack.getRecords()))
-      outputUrlList(page, "Global variables:", mkList(aPack.getGlobals()))
-      outputUrlList(page, "Files in package:", mkList(aPack.getFiles()))
-      p := mkList(aPack.getProcedures())
-      r := mkList(aPack.getRecords())
-      g := mkList(aPack.getGlobals())
-      if *(p|r|g) > 0 then {
-	 outputHeading(page, "Details", "+4")
-	 outputCalls(page, "Procedures:",         p)
-	 outputCalls(page, "Records:",            r)
-	 outputVars(page,  "Global variables:",   g)
-	 }
-      pageBottom(page)
-      write(page, "</html>")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, getURL(aPack))
+        write("\t",getURL(aPack))
+        write(page, "<html>")
+        write(page, "<head>")
+        write(page, "<title>",aPack.getName(),"</title>")
+        write(page, defineDiversions())
+        write(page, "</head>")
+        pageTop(page)
+        outputHeading(page, "Package "||aPack.getName(), "+6")
+        outputComments(page, "<h2>Summary</h2>", aPack.getComments())
+        outputUrlList(page, "Classes:",          mkList(aPack.getClasses()))
+        outputUrlList(page, "Procedures:",       mkList(aPack.getProcedures()))
+        outputUrlList(page, "Records:",          mkList(aPack.getRecords()))
+        outputUrlList(page, "Global variables:", mkList(aPack.getGlobals()))
+        outputUrlList(page, "Files in package:", mkList(aPack.getFiles()))
+        p := mkList(aPack.getProcedures())
+        r := mkList(aPack.getRecords())
+        g := mkList(aPack.getGlobals())
+        if *(p|r|g) > 0 then {
+            outputHeading(page, "Details", "+4")
+            outputCalls(page, "Procedures:",         p)
+            outputCalls(page, "Records:",            r)
+            outputVars(page,  "Global variables:",   g)
+            }
+        pageBottom(page)
+        write(page, "</html>")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method buildFile(aFile)
-      local page, aName, p, r, g
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method buildFile(aFile)
+        local page, aName, p, r, g
 
-      page := openStdHtmlFile(baseDir, getURL(aFile))
-      aName := delSuffix(aFile.getName(), ".icn")||".icn"
-      write("\t",getURL(aFile))
-      write(page, "<html>")
-      write(page, "<head>")
-      write(page, "<title>",aName,"</title>")
-      write(page, defineDiversions())
-      write(page, "</head>")
-      pageTop(page)
-      outputHeading(page, "File "||aName, "+6")
-      outputComments(page, "<h2>Summary</h2>", aFile.getComments())
-      outputUrlList(page, "Classes:",          mkList(aFile.getClasses()))
-      outputUrlList(page, "Procedures:",       mkList(aFile.getProcedures()))
-      outputUrlList(page, "Records:",          mkList(aFile.getRecords()))
-      outputUrlList(page, "Global variables:", mkList(aFile.getGlobals()))
-      outputUrlList(page, "Imports: ",         mkList(aFile.getImports()))
-      outputUrlList(page, "Links: ",           mkList(aFile.getLinks()))
-      p := aFile.getPackage()
-      write(page, "<p>This file is part of the <b>",
-	    displayURL(getURL(p), p.getName()),
-	    "</b> package.</p>")
-      sRef := displaySrcURL(aFile, "Source code.") 
-      if sRef ~== "Source code." then {
-	 write(page, "<b><i>", sRef, "</i></b><p></p>")
-	 }
-      p := mkList(aFile.getProcedures())
-      r := mkList(aFile.getRecords())
-      g := mkList(aFile.getGlobals())
-      if *(p|r|g) > 0 then {
-	 outputHeading(page, "Details", "+4")
-	 outputCalls(page, "Procedures:",         p)
-	 outputCalls(page, "Records:",            r)
-	 outputVars(page,  "Global variables:",   g)
-	 }
-      pageBottom(page)
-      write(page, "</html>")
-      close(page)
-   end
+        page := openStdHtmlFile(baseDir, getURL(aFile))
+        aName := delSuffix(aFile.getName(), ".icn")||".icn"
+        write("\t",getURL(aFile))
+        write(page, "<html>")
+        write(page, "<head>")
+        write(page, "<title>",aName,"</title>")
+        write(page, defineDiversions())
+        write(page, "</head>")
+        pageTop(page)
+        outputHeading(page, "File "||aName, "+6")
+        outputComments(page, "<h2>Summary</h2>", aFile.getComments())
+        outputUrlList(page, "Classes:",          mkList(aFile.getClasses()))
+        outputUrlList(page, "Procedures:",       mkList(aFile.getProcedures()))
+        outputUrlList(page, "Records:",          mkList(aFile.getRecords()))
+        outputUrlList(page, "Global variables:", mkList(aFile.getGlobals()))
+        outputUrlList(page, "Imports: ",         mkList(aFile.getImports()))
+        outputUrlList(page, "Links: ",           mkList(aFile.getLinks()))
+        p := aFile.getPackage()
+        write(page, "<p>This file is part of the <b>",
+                        displayURL(getURL(p), p.getName()),
+                       "</b> package.</p>")
+        sRef := displaySrcURL(aFile, "Source code.") 
+        if sRef ~== "Source code." then {
+            write(page, "<b><i>", sRef, "</i></b><p></p>")
+            }
+        p := mkList(aFile.getProcedures())
+        r := mkList(aFile.getRecords())
+        g := mkList(aFile.getGlobals())
+        if *(p|r|g) > 0 then {
+            outputHeading(page, "Details", "+4")
+            outputCalls(page, "Procedures:",         p)
+            outputCalls(page, "Records:",            r)
+            outputVars(page,  "Global variables:",   g)
+            }
+        pageBottom(page)
+        write(page, "</html>")
+        close(page)
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputMethods(page, label, aClass)
-      local metd, mList
-
-      mList := mkList(aClass.getMethods())
-      if *mList > 0 then {
-	 outputHeading(page, label, "+2", "#eeeeff")
-	 every metd := !mList do {
-	    outputFunction(page, metd)
-	    if sc := idoc.overrides(aClass, metd.getName()) then {
-	       sName := sc.getName()
-	       mName := metd.getName()
-	       metd  := sc.getMethod(mName)
-	       write(page, "<dd><i>This method overrides</i> <b>",
-                           displayURL(getURL(metd), mName),
-                           "</b> <i>in class</i> <b>",
-                           displayURL(getURL(sc), sName),"</b>")
-	       }
-	    write(page, "<hr>")
-	    }
-	 }
-   end
-
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputInheritedMethods(page, aClass)
-      local iTab, sc, scName, sUrl
-
-      iTab := idoc.inherited(aClass)
-      if *iTab > 0 then {
-	 every sc := !idoc.makeNameTab(iTab) do {
-	    scName := sc.getName()
-	    sUrl := getURL(sc)
-	    outputUrlList(page, "Methods inherited from "||
-                                displayURL(sUrl, scName)||":",
-                                mkList(iTab[sc]))
-	    }
-	 }
-   end
-
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputNameList(page, heading, aList)
-      local obj, oName
-
-      if *aList > 0 then {
-	 write(page, "<p></p>")
-	 write(page, "<h2>",heading,"</h2>")
-	 write(page, "<p></p>")
-	 every obj := !aList do {
-	    oName := obj.getName()
-	    write(page, displayFrameRef(getURL(obj), oName))
-	    }
-	 }
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputMethods(page, label, aClass)
+        local metd, mList
     
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputFileList(page, heading, aList)
-      local f, fName
+        mList := mkList(aClass.getMethods())
+        if *mList > 0 then {
+            outputHeading(page, label, "+2", "#eeeeff")
+            every metd := !mList do {
+                outputFunction(page, metd)
+                if sc := idoc.overrides(aClass, metd.getName()) then {
+                    sName := sc.getName()
+                    mName := metd.getName()
+                    metd  := sc.getMethod(mName)
+                    write(page, "<dd><i>This method overrides</i> <b>",
+                                displayURL(getURL(metd), mName),
+                                "</b> <i>in class</i> <b>",
+                                displayURL(getURL(sc), sName),"</b>")
+                    }
+                write(page, "<hr>")
+                }
+            }
+    end
 
-      if *aList > 0 then {
-	 write(page, "<p></p>")
-	 write(page, "<h2>",heading,"</h2>")
-	 write(page, "<p></p>")
-	 every f := !aList do {
-	    fName := delSuffix(f.getName(), ".icn")||".icn"
-	    write(page, displayFrameRef(getURL(f), fName))
-	    }
-	 }
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputInheritedMethods(page, aClass)
+        local iTab, sc, scName, sUrl
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputUrlSection(page, label, aList, fSize, bColor)
-      if *aList > 0 then {
-	 outputHeading(page, label, fSize, bColor)
-	 outputUrlList(page, &null, aList)
-	 }
-   end
+        iTab := idoc.inherited(aClass)
+        if *iTab > 0 then {
+            every sc := !idoc.makeNameTab(iTab) do {
+                scName := sc.getName()
+                sUrl := getURL(sc)
+                outputUrlList(page, "Methods inherited from "||
+                                       displayURL(sUrl, scName)||":",
+                                    mkList(iTab[sc]))
+                }
+            }
+    end
 
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method outputUrlList(page, label, aList)
-      local s, item, iName, iUrl
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputNameList(page, heading, aList)
+        local obj, oName
 
-      if *aList > 0 then {
-	 write(page, "<dt><b>",\label,"</b></dt><dd>")
-	 s := ""
-	 every item := !aList do {
-	    iName := item.getName()
-	    iUrl  := getURL(item)
-	    s ||:= displayURL(iUrl, iName)||", "
-	    }
-	 write(page, s[1:-2])
-	 write(page, "</dd><p></p>")
-	 }
-   end
-
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method getURL(obj)
-      /fileMap := table()
-      /fileMap[obj] := mkURL(obj)
-      return fileMap[obj]
-   end
+        if *aList > 0 then {
+            write(page, "<p></p>")
+            write(page, "<h2>",heading,"</h2>")
+            write(page, "<p></p>")
+            every obj := !aList do {
+                oName := obj.getName()
+                write(page, displayFrameRef(getURL(obj), oName))
+                }
+            }
+    end
     
-   # <p>
-   # <i>This is intended for internal use only!</i>
-   # </p>
-   method mkURL(obj)
-      local bName, pName, cat, p, nObj
-    
-      bName := obj.getName()
-      case obj.className() of {
-	 "UniDoc::ULink"       |
-         "UniDoc::UFile"       : {
-	    return "file_"||delSuffix(bName, ".icn")||".html"
-	    }
-	 "UniDoc::UClass"      : {
-	    pName := obj.getParent().getName()
-	    pName := "class_"||delSuffix(pName,".icn")
-	    return pName||"_"||fixName(bName)||".html"
-	    }
-	 "UniDoc::UImport"     |
-         "UniDoc::UPackage"    : {
-	    pName := "pack_"
-	    return pName||fixName(bName)||".html"
-	    }
-	 "UniDoc::UProc"       |
-         "UniDoc::URecord"     |
-         "UniDoc::UGlobal"     |
-         "UniDoc::UMethod"     |
-         "UniDoc::UConstructor": {
-	    pName := mkURL(obj.getParent())
-	    return pName||"#"||bName
-	    }
-	 "UniDoc::UName"       : {
-	    cat := obj.category
-	    if cat == "class" then {
-	       p := obj.getParent()
-	       if nObj := idoc.locateSuperClass(p, bName) then {
-		  return mkURL(nObj)
-		  }
-	       else {
-		  # See if there's already an HTML page for it!
-		  if pName := idoc.classOnLinkPath(p, bName) then {
-		     return pName||".html";
-		     }
-		  write("can't find: ",bName)
-		  }
-	       }
-	    pName := mkURL(obj.getParent())
-	    return pName||"#"||bName
-	    }
-	 }
-      stop("mkURL: cannot handle class type ",obj.className(),"!")
-   end
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputFileList(page, heading, aList)
+        local f, fName
 
-initially
-   /title     := "Generated Documentation"
-   /baseDir   := "./htmlDoc"
-   baseDir    := trim(baseDir, '/\\')||"/"
-   mkdir(baseDir) | close(open(baseDir)) |
-      stop("Cannot access directory '",baseDir,"'.")
-   /mainIndex := "index.html"
-   mainIndex  := delSuffix(mainIndex, ".html") || ".html"
+        if *aList > 0 then {
+            write(page, "<p></p>")
+            write(page, "<h2>",heading,"</h2>")
+            write(page, "<p></p>")
+            every f := !aList do {
+                fName := delSuffix(f.getName(), ".icn")||".icn"
+                write(page, displayFrameRef(getURL(f), fName))
+                }
+            }
+    end
+
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputUrlSection(page, label, aList, fSize, bColor)
+        if *aList > 0 then {
+            outputHeading(page, label, fSize, bColor)
+            outputUrlList(page, &null, aList)
+            }
+    end
+    
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method outputUrlList(page, label, aList)
+        local s, item, iName, iUrl
+
+        if *aList > 0 then {
+            write(page, "<dt><b>",\label,"</b></dt><dd>")
+            s := ""
+            every item := !aList do {
+                iName := item.getName()
+                iUrl  := getURL(item)
+                s ||:= displayURL(iUrl, iName)||", "
+                }
+            write(page, s[1:-2])
+            write(page, "</dd><p></p>")
+            }
+    end
+
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method getURL(obj)
+        /fileMap := table()
+        /fileMap[obj] := mkURL(obj)
+        return fileMap[obj]
+    end
+    
+    # <p>
+    # <i>This is intended for internal use only!</i>
+    # </p>
+    method mkURL(obj)
+        local bName, pName, cat, p, nObj
+    
+        bName := obj.getName()
+        case obj.className() of {
+            "UniDoc::ULink"       |
+            "UniDoc::UFile"       : {
+                    return "file_"||delSuffix(bName, ".icn")||".html"
+                    }
+            "UniDoc::UClass"      : {
+                    pName := obj.getParent().getName()
+                    pName := "class_"||delSuffix(pName,".icn")
+                    return pName||"_"||fixName(bName)||".html"
+                    }
+            "UniDoc::UImport"     |
+            "UniDoc::UPackage"    : {
+                    pName := "pack_"
+                    return pName||fixName(bName)||".html"
+                    }
+            "UniDoc::UProc"       |
+            "UniDoc::URecord"     |
+            "UniDoc::UGlobal"     |
+            "UniDoc::UMethod"     |
+            "UniDoc::UConstructor": {
+                    pName := mkURL(obj.getParent())
+                    return pName||"#"||bName
+                    }
+            "UniDoc::UName"       : {
+                    cat := obj.category
+                    if cat == "class" then {
+                        p := obj.getParent()
+                        if nObj := idoc.locateSuperClass(p, bName) then {
+                            return mkURL(nObj)
+                            }
+                        else {
+                            # See if there's already an HTML page for it!
+                            if pName := idoc.classOnLinkPath(p, bName) then {
+                                return pName||".html";
+                                }
+                            write("can't find: ",bName)
+                            }
+                        }
+                    pName := mkURL(obj.getParent())
+                    return pName||"#"||bName
+                    }
+            }
+        stop("mkURL: cannot handle class type ",obj.className(),"!")
+    end
+
+    initially
+        /title     := "Generated Documentation"
+        /baseDir   := "./htmlDoc"
+        baseDir    := trim(baseDir, '/\\')||"/"
+        mkdir(baseDir) | close(open(baseDir)) |
+            stop("Cannot access directory '",baseDir,"'.")
+        /mainIndex := "index.html"
+        mainIndex  := delSuffix(mainIndex, ".html") || ".html"
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure navFrameRef(ref, label)
-   ref := delSuffix(ref, ".html")||".html"
-   ref := adjustDir("index_"||ref)
-   return "<a href=\""                             ||
-              ref||"\" target=\"listFrame\">"      ||
-              label                                ||
-          "</a><br>"
+    ref := delSuffix(ref, ".html")||".html"
+    ref := adjustDir("index_"||ref)
+    return "<a href=\""                             ||
+               ref||"\" target=\"listFrame\">"      ||
+               label                                ||
+           "</a><br>"
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure listFrameRef(ref, label)
-   ref := delSuffix(ref, ".html")||".html"
-   ref := adjustDir("index_"||ref)
-   return "<a href=\""                             ||
-              ref||"\" target=\"listFrame\">"      ||
-              label                                ||
-          "</a><br>"
+    ref := delSuffix(ref, ".html")||".html"
+    ref := adjustDir("index_"||ref)
+    return "<a href=\""                             ||
+               ref||"\" target=\"listFrame\">"      ||
+               label                                ||
+           "</a><br>"
 end
 
 # <p>
@@ -614,8 +615,8 @@ end
 # </p>
 procedure adjustDir(fName)
    if \dirFlag & not match("../", fName) then {
-      fName := "../"||fName
-      }
+       fName := "../"||fName
+       }
    return fName
 end
 
@@ -624,110 +625,110 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure displayFrameRef(ref, label)
-   ref := delSuffix(fixName(ref), ".html")||".html"
-   ref := adjustDir(ref)   # handle subdirectories
-   return "<a href=\""                                       ||
-              ref||"\" target=\"displayFrame\">"             ||
-              label                                          ||
-          "</a><br>"
+    ref := delSuffix(fixName(ref), ".html")||".html"
+    ref := adjustDir(ref)   # handle subdirectories
+    return "<a href=\""                                       ||
+               ref||"\" target=\"displayFrame\">"             ||
+               label                                          ||
+           "</a><br>"
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure displayURL(ref, label)
-   ref := fixName(ref)
-   ref := adjustDir(ref)   # handle subdirectories
-   return "<a href=\""                                       ||
-              ref||"\" target=\"displayFrame\">"             ||
-              label                                          ||
-          "</a>"
+    ref := fixName(ref)
+    ref := adjustDir(ref)   # handle subdirectories
+    return "<a href=\""                                       ||
+               ref||"\" target=\"displayFrame\">"             ||
+               label                                          ||
+           "</a>"
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure fixName(pName)
-   pName := if pName == "(main)" then "0main"
-   return pName
+    pName := if pName == "(main)" then "0main"
+    return pName
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure getTagFromURL(url)
-   reverse(url) ? return reverse(tab(upto('#'))||move(1))
+    reverse(url) ? return reverse(tab(upto('#'))||move(1))
 end
         
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputCalls(page, label, aList)
-   local item
+    local item
 
-   if *aList > 0 then {
-      outputHeading(page, label, "+2", "#eeeeff")
-      every item := !aList do {
-	 outputFunction(page, item)
-	 write(page, "<hr>")
-	 }
-      }
+    if *aList > 0 then {
+        outputHeading(page, label, "+2", "#eeeeff")
+        every item := !aList do {
+            outputFunction(page, item)
+            write(page, "<hr>")
+            }
+        }
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputVars(page, label, aList)
-   local item
+    local item
 
-   if *aList > 0 then {
-      outputHeading(page, label, "+2", "#eeeeff")
-      every item := !aList do {
-	 outputVar(page, item)
-	 write(page, "<hr>")
-	 }
-      }
+    if *aList > 0 then {
+        outputHeading(page, label, "+2", "#eeeeff")
+        every item := !aList do {
+            outputVar(page, item)
+            write(page, "<hr>")
+            }
+        }
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputFunction(page, metd)
-   local params, p, m, s, pc
+    local params, p, m, s, pc
 
-   write(page, getTag(metd))
-   m := mkCallStr(metd)
-   write(page, "<p><b><i><font size=+1>",displaySrcURL(metd, m),
-               "</font></i></b>")
-   params := metd.getParams()
-   if params.itemsHaveComments() then {
-      pc := Comments()
-      every p := params.get() do {
-	 s := "<[param "||p.getName()||" "||
-              (stripParagraph(cmts2html(p.getComments()))|"")||"]>"
-	 pc.add(s)
-	 }
-      params.setComments()
-      }
-   write(page, "<dd>")
-   outputParComments(page, &null, \pc);
-   outputComments(page, &null, metd.getComments())
-   write(page, "</dd>")
-   write(page, "</p>")
+    write(page, getTag(metd))
+    m := mkCallStr(metd)
+    write(page, "<p><b><i><font size=+1>",displaySrcURL(metd, m),
+                "</font></i></b>")
+    params := metd.getParams()
+    if params.itemsHaveComments() then {
+        pc := Comments()
+        every p := params.get() do {
+            s := "<[param "||p.getName()||" "||
+                 (stripParagraph(cmts2html(p.getComments()))|"")||"]>"
+            pc.add(s)
+            }
+        params.setComments()
+        }
+    write(page, "<dd>")
+    outputParComments(page, &null, \pc);
+    outputComments(page, &null, metd.getComments())
+    write(page, "</dd>")
+    write(page, "</p>")
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure getTag(obj)
-   return makeTag(obj.getName())
+    return makeTag(obj.getName())
 end
 
 # <p>
 # Convert a string into an HTML reference tag.
 # </p>
 procedure makeTag(s)
-   return "<a name=\""||s||"\">"
+    return "<a name=\""||s||"\">"
 end
 
 # <p>
@@ -735,9 +736,9 @@ end
 # not possible, just return the label.
 # </p>
 procedure displaySrcURL(obj, label)
-   if ref := adjustDir(mkSrcURL(obj)) then
-      return displayURL(ref, label)
-   return label
+    if ref := adjustDir(mkSrcURL(obj)) then
+        return displayURL(ref, label)
+    return label
 end
 
 # <p>
@@ -746,73 +747,73 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure mkSrcURL(obj)
-   local fName, bName, pName
+    local fName, bName, pName
 
-   if fName := obj.getSrcFile() then {
-      pName := "src_"||fixName(delSuffix(fName, ".icn"))||".html"
-      bName := obj.getFormType() || "_" || obj.getName()
-      if obj.getFormType() == "file" then return pName
-      return pName || "#" || bName
-      }
+    if fName := obj.getSrcFile() then {
+        pName := "src_"||fixName(delSuffix(fName, ".icn"))||".html"
+        bName := obj.getFormType() || "_" || obj.getName()
+        if obj.getFormType() == "file" then return pName
+        return pName || "#" || bName
+        }
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputVar(page, var)
-   write(page, getTag(var))
-   outputVarComments(page, displaySrcURL(var, var.getName()),
-		     var.getComments())
+    write(page, getTag(var))
+    outputVarComments(page, displaySrcURL(var, var.getName()),
+                            var.getComments())
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputComments(page, label, comments)
-   local s
+    local s
 
-   write(page, \label)
-   if s := cmts2html(comments) then {
-      write(page, s)
-      }
+    write(page, \label)
+    if s := cmts2html(comments) then {
+        write(page, s)
+        }
 end
 
 # <p>
 # <i>Output parameter comments
 # </p>
 procedure outputParComments(page, label, comments)
-   local s
+    local s
 
-   write(page, \label)
-   if s := cmts2html(comments) then {
-      write(page, s)
-      }
+    write(page, \label)
+    if s := cmts2html(comments) then {
+        write(page, s)
+        }
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputVarComments(page, varName, comments)
-   local s
+    local s
 
-   if s := cmts2html(comments) then {
-      s := stripParagraph(s)
-      if *s > 0 then {
-	 write(page, "<dd><b>",varName,"</b> -- <i>",s,"</i></dd>")
-	 }
-      else {
-	 write(page, "<dd><b>",varName,"</b></dd>")
-	 }
-      }
+    if s := cmts2html(comments) then {
+        s := stripParagraph(s)
+        if *s > 0 then {
+            write(page, "<dd><b>",varName,"</b> -- <i>",s,"</i></dd>")
+            }
+        else {
+            write(page, "<dd><b>",varName,"</b></dd>")
+            }
+        }
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure stripParagraph(s)
-   s ? return 2(="<p>\n",  tab(-*"</p>\n"),  ="</p>\n") |
-              2(="<pre>\n",tab(-*"</pre>\n"),="</pre>\n")
-   return s
+    s ? return 2(="<p>\n",  tab(-*"</p>\n"),  ="</p>\n") |
+               2(="<pre>\n",tab(-*"</pre>\n"),="</pre>\n")
+    return s
 end
         
 
@@ -820,56 +821,58 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure cmts2html(comments)
-   local s1, s2, s, t, cblock, keyMap
+    local s1, s2, s, t, cblock, keyMap
 
-   if \comments then {
-      keyMap := table()
-      s := ""
-      s1:= ""
-      every cblock := comments.get() do {
-	 s ||:= if cblock.isLegacy() then "<pre>\n"
-	 every s ||:= cblock.get() || "\n"
-	 s ||:= if cblock.isLegacy() then "</pre>\n"
-	 }
-      s := checkSpecial(s, keyMap)
-      if \(throws := keyMap["throws"]) then {   
-	 t := "\n<b>Throws:</b> "
-	 t ||:= "<table>\n"
-	 while t ||:= ::get(throws)
-	 s1 := t || "\n</table>\n" || s1
-	 }
-      if \(fails := keyMap["fails"]) then {   
-         t := "\n<b>Fails:</b> "
-         t ||:= "<table>\n"
-         while t ||:= ::get(fails)
-         s1 := t || "\n</table>\n" || s1
-         }
-      if \(returns := keyMap["returns"]) then {   
-	 t := "\n<b>Returns:</b> "
-	 t ||:= "<table>\n"
-	 while t ||:= ::get(returns)
-         s1 := t || "\n</table>\n" || s1
-         }
-      if \(generates := keyMap["generates"]) then {   
-         t := "\n<b>Generates:</b> "
-         t ||:= "<table>\n"
-         while t ||:= ::get(generates)
-         s1 := t || "\n</table>\n" || s1
-         }
-      if \(params := keyMap["params"]) then {   
-         t := "\n<b>Parameter"||(if *params > 1 then "s" else "")||":</b> "
-         t ||:= "<table>\n"
-         while t ||:= ::get(params)
-         s1 := t || "\n</table>\n" || s1
-         }
+    if \comments then {
+        keyMap := table()
+        s := ""
+        s1:= ""
+        every cblock := comments.get() do {
+            s ||:= if cblock.isLegacy() then "<pre>\n"
+            every s ||:= cblock.get() || "\n"
+            s ||:= if cblock.isLegacy() then "</pre>\n"
+            }
+        s := checkSpecial(s, keyMap)
+        if \(throws := keyMap["throws"]) then {   
+            t := "\n<b>Throws:</b> "
+            t ||:= "<table>\n"
+            while t ||:= ::get(throws)
+            s1 := t || "\n</table>\n" || s1
+            }
+        if \(fails := keyMap["fails"]) then {   
+            t := "\n<b>Fails:</b> "
+            t ||:= "<table>\n"
+            while t ||:= ::get(fails)
+            s1 := t || "\n</table>\n" || s1
+            }
+        if \(returns := keyMap["returns"]) then {   
+            t := "\n<b>Returns:</b> "
+            t ||:= "<table>\n"
+            while t ||:= ::get(returns)
+            s1 := t || "\n</table>\n" || s1
+            }
+        if \(generates := keyMap["generates"]) then {   
+            t := "\n<b>Generates:</b> "
+            t ||:= "<table>\n"
+            while t ||:= ::get(generates)
+            s1 := t || "\n</table>\n" || s1
+            }
+        if \(params := keyMap["params"]) then {   
+            t := "\n<b>Parameter"||(if *params > 1 then "s" else "")||":</b> "
+            t ||:= "<table>\n"
+            while t ||:= ::get(params)
+            s1 := t || "\n</table>\n" || s1
+            }
 
-     if *s1 > 0 then {
-        s1 := "\n<DIV CLASS=\"indented\">\n<DIV CLASS=\"colored\">\n" ||
-              s1 ||
-              "\n</DIV>\n</DIV>\n"
+        if *s1 > 0 then {
+            s1 := "\n<DIV CLASS=\"indented\">\n<DIV CLASS=\"colored\">\n" ||
+                  s1 ||
+                  "\n</DIV>\n</DIV>\n"
+            }
+
+        return s1 || s
         }
-     return s1 || s
-     }
+
 end
 
 # <p>
@@ -877,23 +880,23 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure checkSpecial(s, keyMap)
-   local ns
-   static cMap      # map of UniDoc special comments fields for sbal()
-   initial {
-      cMap := table()
-      cMap["<["] := "]>"
-      }
-   ns := ""
-   s ? {
-      while ns ||:= tab(find("<[")) do {
-	 if not parseClause(sbal(cMap), keyMap) then {
-	    ns ||:= "&lt["
-	    }
-	 }
-      ns ||:= tab(0)
-      }
+    local ns
+    static cMap      # map of UniDoc special comments fields for sbal()
+    initial {
+        cMap := table()
+        cMap["<["] := "]>"
+        }
+    ns := ""
+    s ? {
+        while ns ||:= tab(find("<[")) do {
+            if not parseClause(sbal(cMap), keyMap) then {
+                ns ||:= "&lt;["
+                }
+            }
+        ns ||:= tab(0)
+        }
 
-   return ns
+    return ns
 end
 
 # <p>
@@ -905,40 +908,40 @@ end
 #  comment fields.
 # </p>
 procedure parseClause(s, kMap)
-   local t
-   t := map(s)
-   s ? {
-      if match("<[throw",t) then {
-	 ="<[" & tab(many(&letters))
-	 /kMap["throws"] := []
-	 put(kMap["throws"], parseThrows(tab(find("]>"))))
-	 return
-	 }
-      else if match("<[generate",t) then {
-	 ="<[" & tab(many(&letters))
-	 /kMap["generates"] := []
-	 put(kMap["generates"], parseGenerates(tab(find("]>"))))
-	 return
-	 }
-      else if match("<[return",t) then {
-	 ="<[" & tab(many(&letters))
-	 /kMap["returns"] := []
-	 put(kMap["returns"], parseReturns(tab(find("]>"))))
-	 return
-	 }
-      else if match("<[fail",t) then {
-	 ="<[" & tab(many(&letters))
-	 /kMap["fails"] := []
-	 put(kMap["fails"], parseFails(tab(find("]>"))))
-	 return
-	 }
-      else if match("<[param",t) then {
-	 ="<[" & tab(many(&letters))
-	 /kMap["params"] := []
-	 put(kMap["params"], parseParams(tab(find("]>"))))
-	 return
-	 }
-      }
+    local t
+    t := map(s)
+    s ? {
+        if match("<[throw",t) then {
+            ="<[" & tab(many(&letters))
+            /kMap["throws"] := []
+            put(kMap["throws"], parseThrows(tab(find("]>"))))
+            return
+            }
+        else if match("<[generate",t) then {
+            ="<[" & tab(many(&letters))
+            /kMap["generates"] := []
+            put(kMap["generates"], parseGenerates(tab(find("]>"))))
+            return
+            }
+        else if match("<[return",t) then {
+            ="<[" & tab(many(&letters))
+            /kMap["returns"] := []
+            put(kMap["returns"], parseReturns(tab(find("]>"))))
+            return
+            }
+        else if match("<[fail",t) then {
+            ="<[" & tab(many(&letters))
+            /kMap["fails"] := []
+            put(kMap["fails"], parseFails(tab(find("]>"))))
+            return
+            }
+        else if match("<[param",t) then {
+            ="<[" & tab(many(&letters))
+            /kMap["params"] := []
+            put(kMap["params"], parseParams(tab(find("]>"))))
+            return
+            }
+        }
 end
 
 # <p>
@@ -946,21 +949,22 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure parseThrows(s)
-   local ns
-   static ws
-   initial ws := ' \t'
+    local ns
+    static ws
+    initial ws := ' \t'
 
-   ns := ""
-   s ? {
-      tab(many(ws))
-      ns ||:= "\t<tr valign=TOP><td><div class=\"indented\"><tt>" ||
-              tab(upto(ws)|0)                          ||
-              "</tt></div></td>"
-      if not pos(0) then {
-	 ns ||:= "<td><div class=\"indented\">"||tab(0)||"</div></td>"
-	 }
-      return ns || "</tr>"
-      }
+    ns := ""
+    s ? {
+        tab(many(ws))
+        ns ||:= "\t<tr valign=TOP><td><div class=\"indented\"><tt>" ||
+                tab(upto(ws)|0)                          ||
+                "</tt></div></td>"
+        if not pos(0) then {
+            ns ||:= "<td><div class=\"indented\">"||tab(0)||"</div></td>"
+            }
+        return ns || "</tr>"
+        }
+
 end
 
 # <p>
@@ -968,21 +972,22 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure parseParams(s)
-   local ns
-   static ws
-   initial ws := ' \t'
+    local ns
+    static ws
+    initial ws := ' \t'
 
-   ns := ""
-   s ? {
-      tab(many(ws))
-      ns ||:= "\t<tr valign=TOP><td><div class=\"indented\"><tt>" ||
-              tab(upto(ws)|0)                          ||
-              "</tt></div></td>"
-      if not pos(0) then {
-	 ns ||:= "<td><div class=\"indented\">"||tab(0)||"</div></td>"
-	 }
-      return ns || "</tr>"
-      }
+    ns := ""
+    s ? {
+        tab(many(ws))
+        ns ||:= "\t<tr valign=TOP><td><div class=\"indented\"><tt>" ||
+                tab(upto(ws)|0)                          ||
+                "</tt></div></td>"
+        if not pos(0) then {
+            ns ||:= "<td><div class=\"indented\">"||tab(0)||"</div></td>"
+            }
+        return ns || "</tr>"
+        }
+
 end
 
 # <p>
@@ -990,7 +995,7 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure parseGenerates(s)
-   return "\t<tr valign=TOP><td><div class=\"indented\">"||s||"</div></td></tr>"
+    return "\t<tr valign=TOP><td><div class=\"indented\">" || s || "</div></td></tr>"
 end
 
 # <p>
@@ -998,7 +1003,7 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure parseReturns(s)
-   return "\t<tr valign=TOP><td><div class=\"indented\">" || s || "</div></td></tr>"
+    return "\t<tr valign=TOP><td><div class=\"indented\">" || s || "</div></td></tr>"
 end
 
 # <p>
@@ -1006,7 +1011,7 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure parseFails(s)
-   return "\t<tr valign=TOP><td><div class=\"indented\">" || s || "</div></td></tr>"
+    return "\t<tr valign=TOP><td><div class=\"indented\">" || s || "</div></td></tr>"
 end
 
 # <p>
@@ -1015,14 +1020,14 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure outputHeading(page, label, fSize, bColor)
-   /fSize  := "+2"
-   /bColor := "#ccccff"
-   write(page, "<table border=\"1\" cellpadding=\"3\" ",
-                      "cellspacing=\"0\" width=\"100%\">")
-   write(page, "<tr bgcolor=\"",bColor,"\">")
-   write(page, "<td colspan=1><font size=\"",fSize,"\">")
-   write(page, "<b>", label, "</b></font></td>")
-   write(page, "</tr></table>")
+    /fSize  := "+2"
+    /bColor := "#ccccff"
+    write(page, "<table border=\"1\" cellpadding=\"3\" ",
+                       "cellspacing=\"0\" width=\"100%\">")
+    write(page, "<tr bgcolor=\"",bColor,"\">")
+    write(page, "<td colspan=1><font size=\"",fSize,"\">")
+    write(page, "<b>", label, "</b></font></td>")
+    write(page, "</tr></table>")
 end
 
 # <p>
@@ -1030,32 +1035,32 @@ end
 #  processing by replacing them with their HTML equivalents.
 # </p>
 procedure protectLine(s)
-   static hMap
-   initial {
-      hMap := table()
-      hMap["&"] := "&amp;"
-      hMap["<"] := "&lt;"
-      hMap[">"] := "&gt;"
-      }
-   return Utils::replaceStrs(s, hMap)
+    static hMap
+    initial {
+        hMap := table()
+        hMap["&"] := "&amp;"
+        hMap["<"] := "&lt;"
+        hMap[">"] := "&gt;"
+        }
+    return util::replaceStrs(s, hMap)
 end
 
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure openStdHtmlFile(path, name, mode)
-   local fName, dName, f
+    local fName, dName, f
 
-   dirFlag := &null        # assume not in subdirectory
+    dirFlag := &null        # assume not in subdirectory
 
-   /mode := "w"
-   fName := path || "/" || name
-   if upto('w', mode) then {   # Make sure directory path exists
-      makeDirPath(fName)
-      if isSubDir(name) then dirFlag := "yes"  # assumption was wrong
-      }
-   f := open(fName, mode) | stop("Cannot open '",fName,"'!:\n")
-   return f
+    /mode := "w"
+    fName := path || "/" || name
+    if upto('w', mode) then {   # Make sure directory path exists
+        makeDirPath(fName)
+        if isSubDir(name) then dirFlag := "yes"  # assumption was wrong
+        }
+    f := open(fName, mode) | stop("Cannot open '",fName,"'!:\n")
+    return f
 end
 
 # <p>
@@ -1063,7 +1068,7 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure isSubDir(fName)
-   return upto('/', fName)
+    return upto('/', fName)
 end
 
 # <p>
@@ -1071,12 +1076,12 @@ end
 # <i>This is intended for internal use only!</i>
 # </p>
 procedure makeDirPath(fName)
-   reverse(fName) ? {
-      if tab(upto('/')) then {
-	 mkdir(reverse(tab(0)))
-	 }
-      }
-   return
+    reverse(fName) ? {
+        if tab(upto('/')) then {
+            mkdir(reverse(tab(0)))
+            }
+        }
+    return
 end
 
 
@@ -1085,7 +1090,7 @@ end
 # </p>
 # <i>This is intended for internal use only!</i>
 procedure pageTop(page)
-   write(page, "<body bgcolor=\"#ffffff\">")
+    write(page, "<body bgcolor=\"#ffffff\">")
 end
 
 # <p>
@@ -1094,34 +1099,35 @@ end
 # </p>
 # <i>This is intended for internal use only!</i>
 procedure pageBottom(page, sFlag)
-   if /sFlag then {
-      write(page, "<hr>",
-	    "<font size=\"-4\">",
-	    "<i>This page produced by <b>UniDoc</b></i>.",
-	    "</font>")
-      }
-   write(page, "</body>")
+    if /sFlag then {
+        write(page, "<hr>",
+                "<font size=\"-4\">",
+                "<i>This page produced by <b>UniDoc</b> on ",
+                &date," @ ",&clock,"</i>.",
+                "</font>")
+        }
+    write(page, "</body>")
 end
 
 # <p>
 # Output a source code file as an HTML document.
 # </p>
 procedure writeSrcFile(targetDir, uFile)
-   local tName
+    local tName
 
-   fName := uFile.getFilename()
-   tName := delSuffix(fName, ".icn") || ".html"
-   if page := openStdHtmlFile(targetDir, "src_"||tName, "w") then {
-      write(page, "<html>")
-      write(page, "<head>")
-      write(page, "<title>",fName," - source code","</title>")
-      write(page, "</head>")
-      pageTop(page)
-      outputHeading(page, "Source file "||fName, "+6")
-      write(page, "<pre>")
-      every writes(page, uFile.getSrc())
-      write(page, "</pre>")
-      pageBottom(page)
-      close(page)
-      }
+    fName := uFile.getFilename()
+    tName := delSuffix(fName, ".icn") || ".html"
+    if page := openStdHtmlFile(targetDir, "src_"||tName, "w") then {
+        write(page, "<html>")
+        write(page, "<head>")
+        write(page, "<title>",fName," - source code","</title>")
+        write(page, "</head>")
+        pageTop(page)
+        outputHeading(page, "Source file "||fName, "+6")
+        write(page, "<pre>")
+        every writes(page, uFile.getSrc())
+        write(page, "</pre>")
+        pageBottom(page)
+        close(page)
+        }
 end

--- a/uni/unidoc/UniToken.icn
+++ b/uni/unidoc/UniToken.icn
@@ -19,21 +19,21 @@ import lang
 # </p>
 class Token : Object (value)
 
-   # <p>
-   # Set the token value.
-   # </p>
-   method set(newValue)
-      value := newValue
-   end
-   # <p>
-   # Produce the token value.
-   # </p>
-   method get()
-      return value
-   end
+    # <p>
+    # Set the token value.
+    # </p>
+    method set(newValue)
+        value := newValue
+    end
+    # <p>
+    # Produce the token value.
+    # </p>
+    method get()
+        return value
+    end
 
-initially
-   /value := ""
+    initially
+        /value := ""
 end
 
 # <p>

--- a/uni/unidoc/buildDocs.sh
+++ b/uni/unidoc/buildDocs.sh
@@ -3,17 +3,33 @@
 # Build and install the UniDoc documentation
 
 # Assumes you're running this from the unidoc source directory
-UBASE=../..
-SBASE=${UBASE}/uni/lib
+UBASE=$(realpath ../..)
+SBASE=${UBASE}/uni
 TBASE=${UBASE}/doc/uni-api
-title="Unicon Uni Lib API"
+DIRS="lib unidoc"
+# SDIRS and LDIRS are comma-separated lists
+SDIRS="${SBASE}/lib,${UBASE}/ipl/procs"
+LDIRS="${TBASE}/lib"
+basetitle="Unicon Uni API "
 
-echo
-echo "[Building docs for ${title}]"
-echo "UBASE is ${UBASE}"
-echo
-mkdir -p ${TBASE}
-cd ${SBASE}
-UniDoc --title="${title}" --linkSrc \
-       --sourcePath=${SBASE} \
-       --resolve --targetDir=${TBASE} *.icn
+cdir=$(pwd)
+for dir in ${DIRS}; do
+     echo
+     echo "[Building API docs for ${dir}]"
+     echo
+     title="${basetitle} for ${dir}"
+     SD=${SBASE}/${dir}
+     TD=${TBASE}/${dir}
+     mkdir -p ${TD}
+     cd ${SD}
+     /opt/unicon/uni/unidoc/UniDoc --title="${title}" --linkSrc \
+            --sourcePath=${SDIRS} \
+            --linkPath=${LDIRS} \
+            --resolve --targetDir=${TD} *.icn
+     cd ${cdir}
+     echo
+     echo
+     echo
+     echo
+done
+

--- a/uni/unidoc/buildDocs.sh
+++ b/uni/unidoc/buildDocs.sh
@@ -4,8 +4,11 @@
 
 # Assumes you're running this from the unidoc source directory
 UBASE=$(realpath ../..)
+if [ -z "${htmldir}" ]; then
+   htmldir=${UBASE}/doc
+fi
 SBASE=${UBASE}/uni
-TBASE=${UBASE}/doc/uni-api
+TBASE=${htmldir}/uni-api
 DIRS="lib unidoc"
 # SDIRS and LDIRS are comma-separated lists
 SDIRS="${SBASE}/lib,${UBASE}/ipl/procs"

--- a/uni/unidoc/buildDocs.sh
+++ b/uni/unidoc/buildDocs.sh
@@ -2,10 +2,11 @@
 
 # Build and install the UniDoc documentation
 
-LBASE=/opt/unicon/ipl
-SBASE=${HOME}/.src/Unicon/Samples/UniDoc
-TBASE=/var/www/html/unicon/unisamples/UniDoc
-title="UniDoc Code Generator"
+# You must reset UBASE for your system's location of Unicon.
+UBASE=/opt/unicon
+SBASE=${UBASE}/uni/lib
+TBASE=${UBASE}/doc/uni-api
+title="Unicon Uni Lib API"
 
 echo
 echo "[Building docs for ${title}]"
@@ -14,5 +15,5 @@ echo
 mkdir -p ${TBASE}
 cd ${SBASE}
 UniDoc --title="${title}" --linkSrc \
-       --sourcePath=${SBASE}/../../Classes \
+       --sourcePath=${SBASE} \
        --resolve --targetDir=${TBASE} *.icn

--- a/uni/unidoc/buildDocs.sh
+++ b/uni/unidoc/buildDocs.sh
@@ -2,8 +2,8 @@
 
 # Build and install the UniDoc documentation
 
-# You must reset UBASE for your system's location of Unicon.
-UBASE=/opt/unicon
+# Assumes you're running this from the unidoc source directory
+UBASE=../..
 SBASE=${UBASE}/uni/lib
 TBASE=${UBASE}/doc/uni-api
 title="Unicon Uni Lib API"

--- a/uni/unidoc/buildIPLdoc.sh
+++ b/uni/unidoc/buildIPLdoc.sh
@@ -2,8 +2,8 @@
 
 # Build and install the IPL documentation
 
-# You must reset UBASE for your system's location of Unicon.
-UBASE=/opt/unicon
+# Assumes you're running this from the unidoc source directory
+UBASE=../..
 SBASE=${UBASE}/ipl
 TBASE=${UBASE}/doc/ipl-api
 DIRS=(procs gprocs mprocs progs gprogs mprogs)

--- a/uni/unidoc/buildIPLdoc.sh
+++ b/uni/unidoc/buildIPLdoc.sh
@@ -2,17 +2,19 @@
 
 # Build and install the IPL documentation
 
-SBASE=/opt/unicon/ipl
-TBASE=/var/www/html/unicon/ipl
+# You must reset UBASE for your system's location of Unicon.
+UBASE=/opt/unicon
+SBASE=${UBASE}/ipl
+TBASE=${UBASE}/doc/ipl-api
 DIRS=(procs gprocs mprocs progs gprogs mprogs)
+basetitle="Unicon IPL API"
 
 cdir=$(pwd)
 for dir in ${DIRS}; do
      echo
      echo "[Building IPL docs for ${dir}]"
      echo
-     echo -n "Please enter the title for this section: "
-     read title
+     title="${basetitle} for ${dir}"
      SD=${SBASE}/${dir}
      TD=${TBASE}/${dir}
      mkdir -p ${TD}

--- a/uni/unidoc/buildIPLdoc.sh
+++ b/uni/unidoc/buildIPLdoc.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/bin/sh
 
 # Build and install the IPL documentation
 
@@ -6,7 +6,10 @@
 UBASE=../..
 SBASE=${UBASE}/ipl
 TBASE=${UBASE}/doc/ipl-api
-DIRS=(procs gprocs mprocs progs gprogs mprogs)
+DIRS="procs gprocs mprocs progs gprogs mprogs"
+# SDIRS and LDIRS are comma-separated lists
+#  (This script doesn't use LDIRS
+SDIRS="${UBASE}/ipl/procs"
 basetitle="Unicon IPL API"
 
 cdir=$(pwd)
@@ -19,7 +22,8 @@ for dir in ${DIRS}; do
      TD=${TBASE}/${dir}
      mkdir -p ${TD}
      cd ${SD}
-     UniDoc --title="${title}" --resolve --linkSrc --targetDir=${TD} *.icn
+     UniDoc --title=\"${title}\" --resolve \
+            --sourcePath=${SDIRS} --linkSrc --targetDir=${TD} *.icn
      echo
      echo
      echo

--- a/uni/unidoc/buildIPLdoc.sh
+++ b/uni/unidoc/buildIPLdoc.sh
@@ -3,9 +3,12 @@
 # Build and install the IPL documentation
 
 # Assumes you're running this from the unidoc source directory
-UBASE=../..
+UBASE=$(realpath ../..)
+if [ -z "${htmldir}" ]; then
+   htmldir=${UBASE}/doc
+fi
 SBASE=${UBASE}/ipl
-TBASE=${UBASE}/doc/ipl-api
+TBASE=${htmldir}/ipl-api
 DIRS="procs gprocs mprocs progs gprogs mprogs"
 # SDIRS and LDIRS are comma-separated lists
 #  (This script doesn't use LDIRS


### PR DESCRIPTION
The UniDoc sources now compile and run using the uni/lib support instead of the old UniLib librareis. 
 Note that the build*.sh scripts require customization for each system they are run on to propertly locate the Unicon source hierarchy.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>
