### PR TITLE
Expanded CI coverage and debian build updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+# Add 'repo' label to any root file changes
+repo:
+  - ./*
+
+iconx:
+  - src/runtime/*
+
+icont:
+  - src/icont/*
+
+iconc:
+  - src/iconc/*
+
+src:
+  - any: ['src/**/*']
+
+IPL:
+  - any: ['ipl/**/*']
+
+uni:
+  - any: ['uni/**/*']
+
+tests:
+  - any: ['tests/**/*']
+
+doc:
+  - any: ['doc/**/*']
+
+plugins:
+  - any: ['plugins/**/*']

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,27 +1,87 @@
 name: Build
 on:
   push:
+    branches:
+      - master
+      - ci
     paths-ignore:
     - 'docs/**'
 
   pull_request:
     branches:
       - master
+      - ci
+    paths-ignore:
+    - 'docs/**'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  Windows:
+    runs-on: ${{ matrix.cfg.os }}
+    name: ${{ matrix.cfg.name }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest, ubuntu-latest]
-
+        cfg:
+        -  { os: windows-latest,  name: 'Windows 64',   opt: '' }
+        #-  { os: windows-latest,  name: 'Windows 32',   opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
     steps:
-    - uses: actions/checkout@v1
-    - name: configure
-      run: sh configure
-    - name: make
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure
+      run: sh configure  ${{ matrix.cfg.opt }}
+
+    - name: Make
       run: make
-    - name: test
+
+    - name: Test
       run: make Test
 
+  macOs:
+    runs-on: macos-latest
+    steps:
 
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure
+      run: ./configure
+
+    - name: Make
+      run: make
+
+    - name: Test
+      run: make Test
+
+  Ubuntu:
+    runs-on: ${{ matrix.cfg.os }}
+    name: ${{ matrix.cfg.name }}
+    strategy:
+      matrix:
+        cfg:
+        -  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
+        -  { os: ubuntu-18.04,  name: 'Ubuntu 18.04',   opt: '' }
+        -  { os: ubuntu-20.04,  name: 'Ubuntu 20.04',   opt: '' }
+        -  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }
+        -  { os: ubuntu-latest, name: 'clang',          opt: 'CC=clang CXX=clang' }
+        -  { os: ubuntu-latest, name: 'No Graphics',    opt: '--disable-graphics' }
+        -  { os: ubuntu-latest, name: 'No Concurrency', opt: '--disable-concurrency' }
+        -  { os: ubuntu-latest, name: 'Thin Build',     opt: '--enable-thin' }
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib g++-multilib
+        sudo apt-get install -y build-essential fakeroot devscripts equivs
+        sudo mk-build-deps --install debian/control
+
+    - name: Configure
+      run: ./configure ${{ matrix.cfg.opt }}
+
+    - name: Make
+      run: make
+
+    - name: Test
+      run: make Test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   Windows:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ${{ matrix.cfg.os }}
     name: ${{ matrix.cfg.name }}
     strategy:
@@ -37,6 +38,7 @@ jobs:
       run: make Test
 
   macOs:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: macos-latest
     steps:
 
@@ -53,6 +55,7 @@ jobs:
       run: make Test
 
   Ubuntu:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ${{ matrix.cfg.os }}
     name: ${{ matrix.cfg.name }}
     strategy:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,12 +1,5 @@
 name: Build
 on:
-  push:
-    branches:
-      - master
-      - ci
-    paths-ignore:
-    - 'docs/**'
-
   pull_request:
     branches:
       - master
@@ -61,7 +54,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
+        #-  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
         -  { os: ubuntu-18.04,  name: 'Ubuntu 18.04',   opt: '' }
         -  { os: ubuntu-20.04,  name: 'Ubuntu 20.04',   opt: '' }
         -  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: windows-latest,  name: 'Windows 64',   opt: '' }
-        #-  { os: windows-latest,  name: 'Windows 32',   opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
+        -  { os: windows-latest,  name: 'Windows 64-bit',  opt: '' }
+        #-  { os: windows-latest,  name: 'Windows 32-bit', opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -58,14 +58,14 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
+        #-  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
         -  { os: ubuntu-18.04,  name: 'Ubuntu 18.04',   opt: '' }
         -  { os: ubuntu-20.04,  name: 'Ubuntu 20.04',   opt: '' }
         -  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }
         -  { os: ubuntu-latest, name: 'clang',          opt: 'CC=clang CXX=clang' }
         -  { os: ubuntu-latest, name: 'No Graphics',    opt: '--disable-graphics' }
         -  { os: ubuntu-latest, name: 'No Concurrency', opt: '--disable-concurrency' }
-        -  { os: ubuntu-latest, name: 'Thin Build',     opt: '--enable-thin' }
+        #-  { os: ubuntu-latest, name: 'Thin Build',     opt: '--enable-thin' }
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -74,14 +74,26 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-multilib g++-multilib
-        sudo apt-get install -y build-essential fakeroot devscripts equivs
+        sudo apt-get install -y build-essential fakeroot devscripts equivs dh-autoreconf
         sudo mk-build-deps --install debian/control
 
     - name: Configure
       run: ./configure ${{ matrix.cfg.opt }}
 
-    - name: Make
-      run: make
+    - name: Deb
+      run: |
+        make debin
+        cp ../unicondist/unicon_*.* .
+
+    - name: Publish
+      uses: actions/upload-artifact@v2
+      with:
+        name: unicon-deb-${{ matrix.cfg.name}}
+        path: unicon_*.*
+
+    - name: Install
+      run: sudo apt install ./*.deb
 
     - name: Test
       run: make Test
+

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -96,4 +96,6 @@ jobs:
 
     - name: Test
       run: make Test
+      env:
+        UC: unicon
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -60,6 +60,7 @@ jobs:
         -  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }
         -  { os: ubuntu-latest, name: 'Clang',          opt: 'CC=clang CXX=clang' }
         -  { os: ubuntu-latest, name: 'No Graphics',    opt: '--disable-graphics' }
+        -  { os: ubuntu-latest, name: 'No 3D Graphics', opt: '--disable-graphics3d' }
         -  { os: ubuntu-latest, name: 'No Concurrency', opt: '--disable-concurrency' }
         #-  { os: ubuntu-latest, name: 'Thin Build',     opt: '--enable-thin' }
     steps:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        if [[ "${{ matrix.name }}" = "Ubuntu 32-bit" ]]
+        if [[ "${{ matrix.cfg.name }}" = "Ubuntu 32-bit" ]]
         then
         sudo apt-get install -y gcc-multilib g++-multilib
         fi

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -58,11 +58,11 @@ jobs:
     strategy:
       matrix:
         cfg:
-        #-  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
+        -  { os: ubuntu-16.04,  name: 'Ubuntu 16.04',   opt: '' }
         -  { os: ubuntu-18.04,  name: 'Ubuntu 18.04',   opt: '' }
         -  { os: ubuntu-20.04,  name: 'Ubuntu 20.04',   opt: '' }
         -  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }
-        -  { os: ubuntu-latest, name: 'clang',          opt: 'CC=clang CXX=clang' }
+        -  { os: ubuntu-latest, name: 'Clang',          opt: 'CC=clang CXX=clang' }
         -  { os: ubuntu-latest, name: 'No Graphics',    opt: '--disable-graphics' }
         -  { os: ubuntu-latest, name: 'No Concurrency', opt: '--disable-concurrency' }
         #-  { os: ubuntu-latest, name: 'Thin Build',     opt: '--enable-thin' }
@@ -73,29 +73,18 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
+        if [[ "${{ matrix.name }}" = "Ubuntu 32-bit" ]]
+        then
         sudo apt-get install -y gcc-multilib g++-multilib
-        sudo apt-get install -y build-essential fakeroot devscripts equivs dh-autoreconf
+        fi
+        sudo apt-get install -y devscripts equivs
         sudo mk-build-deps --install debian/control
 
     - name: Configure
       run: ./configure ${{ matrix.cfg.opt }}
 
-    - name: Deb
-      run: |
-        make debin
-        cp ../unicondist/unicon_*.* .
-
-    - name: Publish
-      uses: actions/upload-artifact@v2
-      with:
-        name: unicon-deb-${{ matrix.cfg.name}}
-        path: unicon_*.*
-
-    - name: Install
-      run: sudo apt install ./*.deb
+    - name: Make
+      run: make
 
     - name: Test
       run: make Test
-      env:
-        UC: unicon
-

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# Labeles are configured in .github/labeler.yml
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@master
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   Ubuntu:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ${{ matrix.cfg.os }}
     name: ${{ matrix.cfg.name }}
     strategy:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,53 @@
+name: Binary Packages
+on:
+  push:
+    branches:
+      - master
+      - ci
+    paths-ignore:
+    - 'docs/**'
+
+jobs:
+  Ubuntu:
+    runs-on: ${{ matrix.cfg.os }}
+    name: ${{ matrix.cfg.name }}
+    strategy:
+      matrix:
+        cfg:
+        #-  { os: ubuntu-16.04,  name: 'Ubuntu-16.04_amd64',   opt: '' }
+        -  { os: ubuntu-18.04,  name: 'Ubuntu-18.04_amd64',   opt: '' }
+        -  { os: ubuntu-20.04,  name: 'Ubuntu-20.04_amd64',   opt: '' }
+        -  { os: ubuntu-20.04, name: 'Ubuntu-20.04_x86',  opt: '--host=i686-pc-linux-gnu' }
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-multilib g++-multilib
+        sudo apt-get install -y build-essential fakeroot devscripts equivs dh-autoreconf
+        sudo mk-build-deps --install debian/control
+
+    - name: Configure
+      run: ./configure ${{ matrix.cfg.opt }}
+
+    - name: Deb
+      run: |
+        make debin
+        cp ../unicondist/unicon_*.* .
+
+    - name: Publish
+      uses: actions/upload-artifact@v2
+      with:
+        name: unicon-${{ matrix.cfg.name}}
+        path: unicon_*.*
+
+    - name: Install
+      run: sudo apt install ./*.deb
+
+    - name: Test
+      run: make Test
+      env:
+        UC: unicon

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,7 +18,7 @@ jobs:
         #-  { os: ubuntu-16.04,  name: 'Ubuntu-16.04_amd64',   opt: '' }
         -  { os: ubuntu-18.04,  name: 'Ubuntu-18.04_amd64',   opt: '' }
         -  { os: ubuntu-20.04,  name: 'Ubuntu-20.04_amd64',   opt: '' }
-        -  { os: ubuntu-20.04, name: 'Ubuntu-20.04_x86',  opt: '--host=i686-pc-linux-gnu' }
+        #-  { os: ubuntu-20.04, name: 'Ubuntu-20.04_x86',  opt: '--host=i686-pc-linux-gnu' }
 
     steps:
     - name: Checkout

--- a/COPYING
+++ b/COPYING
@@ -883,3 +883,36 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================
+OpenSSL Notice
+==============================================================================
+
+The OpenSSL License is not compatible with the GPL, since it contains the following two clauses:
+
+   * 3. All advertising materials mentioning features or use of this
+   *    software must display the following acknowledgment:
+   *    "This product includes software developed by the OpenSSL Project
+   *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+   * 6. Redistributions of any form whatsoever must retain the following
+   *    acknowledgment:
+   *    "This product includes software developed by the OpenSSL Project
+   *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+The OpenSSL Exception:
+
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ 

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ update_rev:
 	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
 
-MV=2
+MV=3
 VV=13.1.$(MV)
 UTAR=unicon-$(VV).tar.gz
 UTARORIG=unicon_$(VV).orig.tar.gz
@@ -379,10 +379,14 @@ deb: dist
 debin: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -us -uc $(SIGNOPT) --lintian-opts --profile debian
 	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
+	ls -lh ../$(udist)/unicon-$(VV).deb
+
+
 
 debsrc: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -S $(SIGNOPT) --lintian-opts --profile debian
 	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
+	ls -lh ../$(udist)/unicon-$(VV).deb
 
 debsign:
 	cd ../$(udist) && debsign unicon_$(VV)-1_amd64.changes  $(SIGNOPT)
@@ -408,16 +412,19 @@ rpmbin: rpm
 	cd ../$(rpmdir)/SPECS &&  rpmbuild -ba unicon.spec
 	@ls ../$(rpmdir)/RPMS/
 	@echo "  Did we get : ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 rpmresume: rpm
 	cd ../$(rpmdir) &&  rpmbuild -bi --short-circuit unicon.spec
 	@ls ../$(rpmdir)/RPMS/
 	@echo "  Did we get : ../$(rpmdir)/SRPMS/unicon-$(VV)-*.*rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 rpmsrc:
 	cd ../$(rpmdir) &&  rpmbuild -bs unicon.spec
 	@ls ../$(rpmdir)/SRPMS/
 	@echo "  Did we get : ../$(rpmdir)/SRPMS/unicon-$(VV)-*.*.src.rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 
 ##################################################################

--- a/Makefile
+++ b/Makefile
@@ -378,15 +378,13 @@ deb: dist
 
 debin: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -us -uc $(SIGNOPT) --lintian-opts --profile debian
-	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
-	ls -lh ../$(udist)/unicon-$(VV).deb
+	ls -lh ../$(udist)/unicon_*.*
 
 
 
 debsrc: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -S $(SIGNOPT) --lintian-opts --profile debian
-	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
-	ls -lh ../$(udist)/unicon-$(VV).deb
+	ls -lh ../$(udist)/unicon_*.*
 
 debsign:
 	cd ../$(udist) && debsign unicon_$(VV)-1_amd64.changes  $(SIGNOPT)

--- a/Makefile.in
+++ b/Makefile.in
@@ -344,7 +344,7 @@ update_rev:
 	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
 
-MV=2
+MV=3
 VV=13.1.$(MV)
 UTAR=unicon-$(VV).tar.gz
 UTARORIG=unicon_$(VV).orig.tar.gz
@@ -379,10 +379,14 @@ deb: dist
 debin: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -us -uc $(SIGNOPT) --lintian-opts --profile debian
 	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
+	ls -lh ../$(udist)/unicon-$(VV).deb
+
+
 
 debsrc: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -S $(SIGNOPT) --lintian-opts --profile debian
 	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
+	ls -lh ../$(udist)/unicon-$(VV).deb
 
 debsign:
 	cd ../$(udist) && debsign unicon_$(VV)-1_amd64.changes  $(SIGNOPT)
@@ -408,16 +412,19 @@ rpmbin: rpm
 	cd ../$(rpmdir)/SPECS &&  rpmbuild -ba unicon.spec
 	@ls ../$(rpmdir)/RPMS/
 	@echo "  Did we get : ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 rpmresume: rpm
 	cd ../$(rpmdir) &&  rpmbuild -bi --short-circuit unicon.spec
 	@ls ../$(rpmdir)/RPMS/
 	@echo "  Did we get : ../$(rpmdir)/SRPMS/unicon-$(VV)-*.*rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 rpmsrc:
 	cd ../$(rpmdir) &&  rpmbuild -bs unicon.spec
 	@ls ../$(rpmdir)/SRPMS/
 	@echo "  Did we get : ../$(rpmdir)/SRPMS/unicon-$(VV)-*.*.src.rpm"
+	ls -lh ../$(rpmdir)/RPMS/unicon-$(VV)-*.*.rpm
 
 
 ##################################################################

--- a/Makefile.in
+++ b/Makefile.in
@@ -378,15 +378,13 @@ deb: dist
 
 debin: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -us -uc $(SIGNOPT) --lintian-opts --profile debian
-	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
-	ls -lh ../$(udist)/unicon-$(VV).deb
+	ls -lh ../$(udist)/unicon_*.*
 
 
 
 debsrc: deb
 	cd ../$(udist)/unicon-$(VV) && debuild -S $(SIGNOPT) --lintian-opts --profile debian
-	@echo "  Did we get : ../$(udist)/unicon-$(VV).deb"
-	ls -lh ../$(udist)/unicon-$(VV).deb
+	ls -lh ../$(udist)/unicon_*.*
 
 debsign:
 	cd ../$(udist) && debsign unicon_$(VV)-1_amd64.changes  $(SIGNOPT)

--- a/configure
+++ b/configure
@@ -6852,50 +6852,6 @@ SO=so
 # OS specific flags go here
 case $unicon_host in
      *linux*)
-      {
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	ac_c_flag_save="$CFLAGS"
-	CFLAGS="$CFLAGS -fno-unit-at-a-time"
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -fno-unit-at-a-time" >&5
-$as_echo_n "checking whether $CC supports -fno-unit-at-a-time... " >&6; }
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-
-else
-
-			CFLAGS="$ac_c_flag_save"
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	}
       LDFLAGS="$LDFLAGS -rdynamic "
       RLINK="-rdynamic -Wl,-E "
       RLIBS="-ldl -lcrypt "

--- a/configure
+++ b/configure
@@ -4812,6 +4812,51 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 	}
 
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Wno-parentheses-equality"
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wno-parentheses-equality" >&5
+$as_echo_n "checking whether $CC supports -Wno-parentheses-equality... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+
+else
+
+			CFLAGS="$ac_c_flag_save"
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+
 if test x"$devmode" = x"yes" ; then
   {
 	ac_ext=c

--- a/configure
+++ b/configure
@@ -6917,8 +6917,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
        DNT="-DNT"
        SO=dll
        DASHG="-G"
-       LDFLAGS="$LDFLAGS --static -m$BITS -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
-       CPPFLAGS="$CPPFLAGS --static -m$BITS -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
+       LDFLAGS="$LDFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
+       CPPFLAGS="$CPPFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
        LIBS="$LIBS -lgdi32 -lws2_32"
 
        WSTKLDFLAG="-Xlinker --stack -Xlinker 8192000"

--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,6 @@ SO=so
 # OS specific flags go here
 case $unicon_host in
      *linux*)
-      AC_CFLAG([-fno-unit-at-a-time])
       LDFLAGS="$LDFLAGS -rdynamic "
       RLINK="-rdynamic -Wl,-E "
       RLIBS="-ldl -lcrypt "

--- a/configure.ac
+++ b/configure.ac
@@ -296,8 +296,8 @@ case $unicon_host in
        DNT="-DNT"
        SO=dll
        DASHG="-G"
-       LDFLAGS="$LDFLAGS --static -m$BITS -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
-       CPPFLAGS="$CPPFLAGS --static -m$BITS -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
+       LDFLAGS="$LDFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
+       CPPFLAGS="$CPPFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
        LIBS="$LIBS -lgdi32 -lws2_32"
 
        WSTKLDFLAG="-Xlinker --stack -Xlinker 8192000"

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,8 @@ AC_CFLAG([-fno-omit-frame-pointer])
 
 AC_CFLAG([-fno-strict-aliasing])
 
+AC_CFLAG([-Wno-parentheses-equality])
+
 if test x"$devmode" = x"yes" ; then
   AC_CFLAG([-Wall])
   AC_CFLAG([-Wno-missing-braces])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+unicon (13.1.3-1) UNRELEASED; urgency=medium
+
+  * Prepare for ci
+
+ -- Jafar Al-Gharaibeh <to.jafar@gmail.com>  Thu, 24 Sep 2020 12:58:59 -0500
+
 unicon (13.1.2-1) bionic; urgency=medium
 
   * Fix icont's patchstr and add plugins
 
- -- Jafar Al-Gharaibeh <to.jafar@gmail.com>  Mon, 26 Mar 2019 17:52:36 -0500
+ -- Jafar Al-Gharaibeh <to.jafar@gmail.com>  Tue, 26 Mar 2019 17:52:36 -0500
 
 unicon (13.1.1-1) bionic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 unicon (13.1.3-1) UNRELEASED; urgency=medium
 
-  * Prepare for ci
+  * Migrate to git
 
  -- Jafar Al-Gharaibeh <to.jafar@gmail.com>  Thu, 24 Sep 2020 12:58:59 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Jafar Al-Gharaibeh <to.jafar@gmail.com>
 Build-Depends:
-	debhelper (>= 9),
+	debhelper (>= 9.20160709),
 	autotools-dev,
 	libc6,
 	libgcc1,

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Jafar Al-Gharaibeh <to.jafar@gmail.com>
 Build-Depends:
-	debhelper (>= 9.20160709),
+	debhelper (>= 9),
 	autotools-dev,
 	libc6,
 	libgcc1,

--- a/debian/copyright
+++ b/debian/copyright
@@ -48,4 +48,27 @@ License: GPL-2+
  The internet messaging facilities in src/libtp in source distributions are
  primarily the work of Steve Lumos, who has chosen to place them under the
  BSD license, found in the section below titled LIBTP LICENSE.
-
+ .
+ The OpenSSL License is not compatible with the GPL, since it contains the
+ following two clauses:
+   * 3. All advertising materials mentioning features or use of this
+   *    software must display the following acknowledgment:
+   *    "This product includes software developed by the OpenSSL Project
+   *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+   * 6. Redistributions of any form whatsoever must retain the following
+   *    acknowledgment:
+   *    "This product includes software developed by the OpenSSL Project
+   *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ The OpenSSL Exception:
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.

--- a/debian/copyright
+++ b/debian/copyright
@@ -72,3 +72,4 @@ License: GPL-2+
  * do not wish to do so, delete this exception statement from your
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
+ 

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 export DH_VERBOSE = 1
 export DH_OPTIONS = -v
 
-# Don't deal with any files in the .svn directory
+# Don't deal with any files in the revision control directory
 export DH_ALWAYS_EXCLUDE=CVS:.git
 
 
@@ -29,7 +29,7 @@ override_dh_auto_configure:
 #override_dh_installinit:
 #	dh_installinit --no-start
 
-# Do we need to custmize the install?
+# Do we need to custmoize the install?
 #override_dh_auto_install:
 #	dh_auto_install
 

--- a/debian/rules
+++ b/debian/rules
@@ -5,12 +5,9 @@ export DH_VERBOSE = 1
 export DH_OPTIONS = -v
 
 # Don't deal with any files in the .svn directory
-export DH_ALWAYS_EXCLUDE=CVS:.svn
+export DH_ALWAYS_EXCLUDE=CVS:.git
 
-# see FEATURE AREAS in dpkg-buildflags(1)
-#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-# see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
 # package maintainers to append LDFLAGS
@@ -24,17 +21,15 @@ DEB_CONFIGURE_EXTRA_FLAGS += --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH)
 %:
 	dh $@  --with autoreconf --with autotools-dev
 
-# Override configure to pass autoconf the configuration options that we want
+# Unicon build configuration
 override_dh_auto_configure:
 	dh_auto_configure -- --prefix=/usr --mandir=/usr/share/man --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH) --enable-verbosebuild
-
-#--enable-verbosebuild
 
 
 #override_dh_installinit:
 #	dh_installinit --no-start
 
-# Override install
+# Do we need to custmize the install?
 #override_dh_auto_install:
 #	dh_auto_install
 
@@ -42,13 +37,5 @@ override_dh_auto_configure:
 # for manually installed dependencies
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
-
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
-
-#override_dh_gencontrol:
-#	dh_gencontrol -- -Tsubstvars
 
 

--- a/src/gdbm/systems.h
+++ b/src/gdbm/systems.h
@@ -162,7 +162,7 @@
 #if HAVE_FTRUNCATE
 #define TRUNCATE(dbf) ftruncate (dbf->desc, 0)
 #else
-#define TRUNCATE(dbf) close( open (dbf->name, O_RDWR|O_TRUNC, mode));
+#define TRUNCATE(dbf) close( open (dbf->name, O_RDWR|O_TRUNC, mode))
 #endif
 
 /* Do we have 32bit or 64bit longs? */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,9 @@
 #  Makefile for testing Icon
 
 E=/bin/echo
-UC=../bin/unicon
+
+# define UC if it is not defined already
+UC?=../bin/unicon
 
 TESTS=general posix thread pattern mt
 


### PR DESCRIPTION
This PR includes:
* Expanded continuous integration testing. The CI now covers:
    - Ubuntu 18.04 and Ubuntu 20.04
   - Ubuntu 20.04 32-bit
    - macOS
   - Windows 64-bit 
  The CI also attempts to build Unicon on Ubuntu 20.04 with different config options:
    - No Graphics
    - No Concurrency
    - Using Clang complier
  Work to add Window 32-bit and more config options is ongoing

* Binary Package builds, currently only targeting:
   - Ubuntu 18.04
   - Ubuntu 20.04 

* PR automatic labels. When a PR is opened on GitHub, it will be labeled based on what
   files are being  changed. Example labels are IPL, iconx, and icont.

* Various fixes and updates to debian packaging.

* Silence parentheses-equality warning in clang and drop deprecated fno-unit-at-a-time flag 

* Add OpenSSL License exception text to COPYING

