### PR TITLE
Enable Libz on  macOS

### DIFF
--- a/src/h/config.h
+++ b/src/h/config.h
@@ -58,8 +58,6 @@
 #if MacOS
 //#define COpts "-I/usr/X11R6/include"
 
-#define NoLIBZ
-
 #define NamedSemaphores
 #define INTMAIN
 #define PROFIL_CHAR_P


### PR DESCRIPTION
Not sure why it was disabled, probably migrated from  an old config.