### PR TITLE
Make &version a generator.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ LPATH=
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
+REPO_REV_DESCR="$(shell LC_ALL=C git describe --long HEAD)"
+REPO_REV_BRANCH="$(shell LC_ALL=C git branch --show-current)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -343,6 +345,13 @@ update_rev:
 	elif test ! -f src/h/revision.h ; then \
 	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
+	@if test -z $(REPO_REV_DESCR) ; then \
+	   echo "#define gitDescription \"commit $(REPO_REV_HASH)\"" > src/h/build.h; \
+	else \
+	   echo "#define gitDescription \"$(REPO_REV_DESCR)\"" > src/h/build.h; \
+	fi
+	@echo "#define gitBranch \"$(REPO_REV_BRANCH)\"" >> src/h/build.h;
+
 
 MV=3
 VV=13.1.$(MV)

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,6 +10,8 @@ LPATH=
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
+REPO_REV_DESCR="$(shell LC_ALL=C git describe --long HEAD)"
+REPO_REV_BRANCH="$(shell LC_ALL=C git branch --show-current)"
 
 SHELL=sh
 SHTOOL=./shtool
@@ -343,6 +345,12 @@ update_rev:
 	elif test ! -f src/h/revision.h ; then \
 	   echo "#define REPO_REVISION \"0\"" > src/h/revision.h; \
 	fi
+	@if test -z $(REPO_REV_DESCR) ; then \
+	   echo "#define gitDescription \"commit $(REPO_REV_HASH)\"" > src/h/build.h; \
+	else \
+	   echo "#define gitDescription \"$(REPO_REV_DESCR)\"" > src/h/build.h; \
+	fi
+	@echo "#define gitBranch \"$(REPO_REV_BRANCH)\"" >> src/h/build.h;
 
 MV=3
 VV=13.1.$(MV)

--- a/src/h/version.h
+++ b/src/h/version.h
@@ -7,6 +7,9 @@
 #undef UVersion
 #undef IVersion
 
+/* Include build information for files that need version details */
+#include "../h/build.h"
+
 /*
  *  Icon version number and date.
  *  These are the only two entries that change any more.

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -9,6 +9,8 @@ include ../../Makedefs
 REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD )"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
+REPO_REV_DESCR="$(shell LC_ALL=C git describe --long HEAD)"
+REPO_REV_BRANCH="$(shell LC_ALL=C git branch --show-current)"
 
 HDRS = ../h/define.h ../h/config.h ../h/typedefs.h ../h/monitor.h\
 	  ../h/proto.h ../h/cstructs.h ../h/cpuconf.h ../h/grttin.h\
@@ -164,6 +166,12 @@ update_rev:
 	elif test ! -f ../h/revision.h ; then \
 	   echo "#define REPO_REVISION \"0\"" > ../h/revision.h; \
 	fi
+	@if test -z $(REPO_REV_DESCR) ; then \
+	   echo "#define gitDescription \"commit $(REPO_REV_HASH)\"" > ../h/build.h; \
+	else \
+	   echo "#define gitDescription \"$(REPO_REV_DESCR)\"" > ../h/build.h; \
+	fi
+	@echo "#define gitBranch \"$(REPO_REV_BRANCH)\"" >> ../h/build.h;
 
 keyword.$(O) : keyword.r $(HDRS) ../h/feature.h ../h/revision.h
 	$(CMNT)	@echo "   [ICONC RTT] $< "

--- a/src/runtime/keyword.r
+++ b/src/runtime/keyword.r
@@ -915,9 +915,16 @@ keyword{1} ucase
    constant 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 end
 
-"&version - a string indentifying this version of Icon."
-keyword{1} version
-   constant Version
+"&version - strings identifying this version of Unicon."
+keyword{3} version
+   abstract {
+      return string
+    }
+   inline {
+      suspend C_string Version;        /* As before, from version.h */
+      suspend C_string gitDescription; /* output from "git describe --long HEAD" */
+      return  C_string gitBranch;      /* output from "git branch --show-current" */
+   }
 end
 
 "&errno - variable containing error number from previous posix command."

--- a/uni/unicon/unicon.icn
+++ b/uni/unicon/unicon.icn
@@ -440,6 +440,50 @@ procedure handle_C(arg)
    calc_posix_loc()
 end
 
+procedure versionLine()
+   static vline
+   local latest, LTB, LTBchars, v
+   initial {
+      v := []
+      every put(v, &version)
+      LTBchars := '0123456789.'
+      vline := v[1] || " ("
+      v[2]? {
+         latest := tab(many(LTBchars))
+         if = "-" then {
+            if v[3] ~== "master" then { # Are we on a maintenance long term branch?
+               v[3] ? {
+                  LTB := tab(many(LTBchars))
+                  if \LTB == v[3] then LTB := 1 else LTB := &null
+               }
+            }
+
+            if "0" == tab(many(&digits)) then { # Latest commit is tagged
+               if v[3] == "master" then {
+                  vline ||:= "Release)"
+               } else if \LTB then {
+                  vline ||:= latest; vline ||:= " Maintenance Release)"
+               } else {
+                  vline ||:= v[2] || " Development \"" || v[3] || "\")"
+               }
+            } else { # Latest commit is not tagged
+               if v[3] == "master" then {
+                  vline ||:= v[2]; vline ||:= " pre-release)"
+               } else if \LTB then {
+                  vline ||:= v[2]; vline ||:= " Maintenance pre-release)"
+               } else {
+                  vline ||:= v[2] || " Development \"" || v[3] || "\")"
+               }
+            }
+         } else { # We don't understand the output of git describe
+            vline ||:= v[2] || ")"
+         }
+      }
+   }
+
+   return vline
+end
+
 procedure unicon(argv)
    local tmpfnames, tmpopt, skip, parseonly,
       EmptyNode, N_Empty, i, thepath, tmp_s, ucodefile,
@@ -514,11 +558,11 @@ procedure unicon(argv)
                      }
                   }
                "-version": {
-                  iwrite(&version)
+                  iwrite(versionLine())
                   return 0
                   }
                "-features": {
-                  iwrite(&version)
+                  iwrite(versionLine())
                   every iwrite(&features)
                   return 0
                   }


### PR DESCRIPTION
The first result is the string from version.h (exactly as before).
Subsequent results give details from the build (the output from
git describe --long HEAD) and the name of the branch that the software
was built on. The Unicon compiler uses the information to build a
more informative output when the -version option is given.