### PR TITLE
Extra debugging help in DEVMODE.

### DIFF
--- a/doc/ib/appD.tex
+++ b/doc/ib/appD.tex
@@ -1324,11 +1324,42 @@ a value, a core dump is produced if an Icon program terminates as a result of
 \texttt{ICONCORE} when making modifications to Icon. For an extended debugging
 session, it may be convenient to set \texttt{dodump} in \textfn{runtime/init.r} to 1.
 
+\subsection{Extra help in \texttt{DEVMODE} (Unicon)}
+When Unicon is built with \texttt{DEVMODE} enabled there are some extra
+facilities that are provided to help with debugging.
+\subsubsection{Breakpoints in the Unicon program}
+It is difficult (when debugging the runtime system) to arrange for a breakpoint
+to occur at a particular location in the Unicon program. In \texttt{DEVMODE}
+there is a new standard function, which is callable from Unicon, named
+\texttt{dbgbreak}. Writing something like the code fragment below will
+cause a debugger breakpoint at the desired moment -- provided the debugger is
+instructed to place a break point at the function called \texttt{Zdbgbrk}.
+\begin{iconcode}
+\$ifdef \_DEVMODE\\
+\>if check\_for\_condition() then \{ dbgbrk() \}\\
+\$endif\\
+\end{iconcode}
+Note that use of \texttt{dbgbrk} should always be protected by
+\texttt{\$ifdef \_DEVMODE} because the function is only defined when
+\texttt{DEVMODE} is enabled.
+\subsubsection{Identifying the current Unicon line}
+The position in the Unicon program can always be established by looking into the
+runtime system with the debugger. A couple of functions make this process
+easier. The functions may be invoked directly from \texttt{gdb} or \texttt{lldb}.
+Both functions are parameterless.
+\begin{quote}
+\begin{description}
+\item[\texttt{dbgUFL}] Print the current Unicon file and line number.
+\item[\texttt{dbgUTrace}] Print a Unicon stack trace.
+\end{description}
+\end{quote}
+
 \subsection{Heap Verification (Unicon)}
 \label{HeapVerifier}
 Icon may be built with optional extra heap checking code that is enabled by
-defining \texttt{DebugHeap} in \textfn{h/define.h}. The extra checking is
-defined in \textfn{h/rmacros.h} and may be summarized by
+defining \texttt{DebugHeap} in \textfn{h/define.h} or by giving the
+\texttt{--enable-verifyheap} argument to \texttt{configure}.
+The extra checking is defined in \textfn{h/rmacros.h} and may be summarized by
 \begin{iconcode}
 /* Debug Heap macros.  These add runtime checks to catch (most)\\
  * illegal block references resulting from untended pointers.\\

--- a/src/h/rexterns.h
+++ b/src/h/rexterns.h
@@ -425,3 +425,9 @@ extern long vrfy;
 extern void vrfyLog(const char *fmt, ...);
 extern void vrfy_Live_Table(struct b_table *b);
 #endif                  /* VerifyHeap */
+
+#ifdef DEVMODE
+extern void dbgUFL();
+extern void dbgUtrace();
+extern int dbgbrkpoint();
+#endif                  /* DEVMODE */

--- a/src/runtime/rdebug.r
+++ b/src/runtime/rdebug.r
@@ -1237,6 +1237,27 @@ void heaperr(char *msg, union block *p, int t)
  *----------------------------------------------------------------------
  */
 
+/* This function may be called from the debugger to display the current
+ * file and line number in the Unicon program
+ */
+void dbgUFL()
+{
+#if COMPILER
+  fprintf(stdout, "File %s; Line %d\n", file_name, line_num);
+#else                     /* COMPILER */
+  CURTSTATE();
+  fprintf(stdout, "File: %s Line: %d\n",
+          findfile(curtstate->c->es_ipc.opnd),
+          findline(curtstate->c->es_ipc.opnd));
+#endif                     /* COMPILER */
+}
+
+/* Call this from the debugger to print a (Unicon) stack trace back */
+void dbgUTrace()
+{
+  CURTSTATE_AND_CE();
+  tracebk(pfp, glbl_argp, NULL);
+} 
 
 /* This function may be used in test code where the criterion for a
  * break point is complex (it may be easier easier to write C code and
@@ -1256,4 +1277,4 @@ body {
 }
 end
 
-#endif					/* DEVMODE */
+#endif                  /* DEVMODE */


### PR DESCRIPTION
Two debugger helper functions have been defined with --enable-devmode.
dbgUFL()     print current Unicon file and line number.
dbgUTrace()  print a Unicon stack traceback.
A section describing their use has been added to Appendix D of the IB.