### PR TITLE
Always use the unvarnished branch name when building.

### DIFF
--- a/Makedefs.in
+++ b/Makedefs.in
@@ -113,7 +113,7 @@ REPO_REV_COUNT="$(shell LC_ALL=C git rev-list --first-parent --count HEAD)"
 REPO_REV_HASH="$(shell LC_ALL=C git rev-parse --short HEAD)"
 REPO_REV="$(REPO_REV_COUNT)-$(REPO_REV_HASH)"
 REPO_REV_DESCR="$(shell LC_ALL=C git describe --long --always --dirty='-modified')"
-REPO_REV_BRANCH="$(shell LC_ALL=C git rev-parse --abbrev-ref HEAD)"
+REPO_REV_BRANCH="$(shell LC_ALL=C git rev-parse --abbrev-ref HEAD | sed -e 's!heads/!!')"
 
 #  configuration parameters
 


### PR DESCRIPTION
If the branch name is the same name as a tag (which will happen on
long term maintenance branches) using git rev-parse to extract the
branch name results in extra information to make it "non-ambiguous".
Using git branch --show-current always returns the branch name with
nothing added.