### PR TITLE
Uni lib

### DIFF
--- a/uni/gui/editabletextlist.icn
+++ b/uni/gui/editabletextlist.icn
@@ -112,7 +112,7 @@ class EditableTextList : LineBasedScrollArea(
    method set_transparent()
       self.transparent := 1
       view.set_transparent()
-      
+
    end
 
    #
@@ -896,7 +896,7 @@ class EditableTextList : LineBasedScrollArea(
       if /self.transparent then
          dwin:=self.cbwin
       else
-         dwin:=self.cwin 
+         dwin:=self.cwin
 
       #
       # Write the lines
@@ -1259,7 +1259,7 @@ end
 
 class EditableTextListDefaultEdit:EditableTextListEdit(s)
    method add_edit(other)
-      if is_instance(other, "gui__EditableTextListDefaultEdit") &
+      if is_instance(other, "gui::EditableTextListDefaultEdit") &
 	 (other.cursor_y = self.cursor_y) &
 	 (other.cursor_x = self.cursor_x + *s) then {
 	    s ||:= other.s
@@ -1294,7 +1294,7 @@ class EditableTextListReturnEdit:EditableTextListEdit()
       parent.contents[parent.cursor_y] := s[1:parent.cursor_x]
       parent.contents := parent.contents[1:parent.cursor_y + 1] ||| [s[parent.cursor_x:0]] ||| parent.contents[parent.cursor_y + 1:0]
       parent.update_view_list(parent.cursor_y, 1, 2)
-	
+
       if (\ (parent.mark_y) > parent.cursor_y) |
 	 (\ (parent.mark_y) = parent.cursor_y &
 	  \ (parent.mark_x) >= parent.cursor_x) then {

--- a/uni/gui/migration.icn
+++ b/uni/gui/migration.icn
@@ -46,7 +46,7 @@ procedure V2TOV1(ev)
          default: fail
       }
    }
-   else if member(c, "gui__TextField") then {
+   else if member(c, "gui::TextField") then {
       code := case ev.get_type() of {
          CONTENT_CHANGED_EVENT : 1
          ACTION_EVENT : 0

--- a/uni/gui/migration.icn
+++ b/uni/gui/migration.icn
@@ -34,9 +34,9 @@ procedure V2TOV1(ev)
    if ev.get_param() === -12 then
       fail
 
-   c := get_class_for_name( ev.get_source() ).get_implemented_classes()
+   c := get_class_for( ev.get_source() ).get_implemented_classes()
 
-   if member(c, "gui__Button") then {
+   if member(c, "gui::Button") then {
       code := case ev.get_type() of {
          BUTTON_PRESS_EVENT : 0
          BUTTON_RELEASE_EVENT : 1
@@ -53,14 +53,14 @@ procedure V2TOV1(ev)
          default: fail
       }
    }
-   else if member(c, "gui__ScrollBar") then {
+   else if member(c, "gui::ScrollBar") then {
       code := case ev.get_type() of {
          SCROLLBAR_PRESSED_EVENT : 0
          SCROLLBAR_DRAGGED_EVENT : 1
          default: fail
       }
    }
-   else if member(c, "gui__Tree") then {
+   else if member(c, "gui::Tree") then {
       code := case ev.get_type() of {
          CURSOR_MOVED_EVENT : 0
          SELECTION_CHANGED_EVENT : 1
@@ -68,14 +68,14 @@ procedure V2TOV1(ev)
          default: fail
       }
    }
-   else if member(c, "gui__SelectableScrollArea") then {
+   else if member(c, "gui::SelectableScrollArea") then {
       code := case ev.get_type() of {
          CURSOR_MOVED_EVENT : 0
          SELECTION_CHANGED_EVENT : 1
          default: fail
       }
    }
-   else if member(c, "gui__Table") then {
+   else if member(c, "gui::Table") then {
       code := case ev.get_type() of {
          MOUSE_RELEASE_EVENT : 0
          CURSOR_MOVED_EVENT : 0
@@ -83,7 +83,7 @@ procedure V2TOV1(ev)
          default: fail
       }
    }
-   else if member(c, "gui__EditableTextList") then {
+   else if member(c, "gui::EditableTextList") then {
       code := case ev.get_type() of {
          CURSOR_MOVED_EVENT |
          CONTENT_CHANGED_EVENT |
@@ -91,20 +91,20 @@ procedure V2TOV1(ev)
          default: fail
       }
    }
-   else if member(c, "gui__List") then {
+   else if member(c, "gui::List") then {
       code := case ev.get_type() of {
          SELECTION_CHANGED_EVENT : 0
          default: fail
       }
    }
-   else if member(c, "gui__EditList") then {
+   else if member(c, "gui::EditList") then {
       code := case ev.get_type() of {
          SELECTION_CHANGED_EVENT : 0
          CONTENT_CHANGED_EVENT : 2
          default: fail
       }
    }
-   else if member(c, "gui__MenuComponent") then {
+   else if member(c, "gui::MenuComponent") then {
       code := case ev.get_type() of {
          ACTION_EVENT : 0
          default: fail
@@ -118,7 +118,7 @@ procedure V2TOV1(ev)
    # field; so go down to the lowest level if needed.
    #
    p := ev.get_param()
-   while lang::is_instance(p, "util__Notification") do
+   while lang::is_instance(p, "util::Notification") do
       p := p.get_param()
 
    return _Event(p, ev.get_source(), code)

--- a/uni/gui/migration.icn
+++ b/uni/gui/migration.icn
@@ -25,7 +25,7 @@ end
 # Convert a V2 style Event to a V1 _Event.
 #
 procedure V2TOV1(ev)
-   local p, code, c, classnam
+   local p, code, c
 
    #
    # V1 didn't have mouse movement, so speed things up
@@ -34,8 +34,7 @@ procedure V2TOV1(ev)
    if ev.get_param() === -12 then
       fail
 
-   classnam := get_class_name(ev.get_source())
-   c := get_class_for_name( classnam ).get_implemented_classes()
+   c := get_class_for_name( ev.get_source() ).get_implemented_classes()
 
    if member(c, "gui__Button") then {
       code := case ev.get_type() of {

--- a/uni/gui/textfield.icn
+++ b/uni/gui/textfield.icn
@@ -39,14 +39,14 @@ $include "guih.icn"
 class TextField : Component(
    filter,                  # Cset for filtering characters
    printable,               # The printable characters
-   contents,                #                
+   contents,                #
    is_held,                 # True if dragging
    going_left,
-   cursor,                  #              
+   cursor,                  #
    mark,
-   leftmost,                #                
-   rightmost,               #                 
-   tx,                      #          
+   leftmost,                #
+   rightmost,               #
+   tx,                      #
    tw,                      #
    displaychar,             # char to print on screen
    undo_manager,
@@ -82,9 +82,9 @@ class TextField : Component(
    end
 
    method resize()
-      if \self.draw_border_flag then 
+      if \self.draw_border_flag then
          /self.h_spec := WAttrib(self.cwin, "fheight") + 2 * DEFAULT_TEXT_Y_SURROUND
-      else 
+      else
          /self.h_spec := WAttrib(self.cwin, "fheight")
       self.Component.resize()
 
@@ -145,14 +145,14 @@ class TextField : Component(
       #
       hr := has_region()
       if (/old_has_region & \hr) | (\old_has_region & /hr) |
-         (\hr & (\moved | \changed)) then 
+         (\hr & (\moved | \changed)) then
       {
          self.invalidate()
          fire(SELECTION_CHANGED_EVENT, e)
       }
    end
 
-   #      
+   #
    # Mouse click - compute new cursor position, re-display
    #
    # @p
@@ -386,7 +386,7 @@ class TextField : Component(
       local ce, ed
 
       start_handle(e)
-      # 
+      #
       # Add any printable character at cursor position
       #
       if type(e) == "string" & not(&control | &meta) & any(filter, e) then {
@@ -460,7 +460,7 @@ class TextField : Component(
       }
    end
 
-   method get_region() 
+   method get_region()
       if self.mark < self.cursor then {
          return self.contents[self.mark:self.cursor]
       } else {
@@ -522,7 +522,7 @@ class TextField : Component(
       if TextWidth(self.cwin, s[self.leftmost:self.rightmost]) <= self.tw then {
          while TextWidth(self.cwin, s[self.leftmost:self.rightmost + 1]) <= self.tw do
             self.rightmost +:= 1
-         while (self.leftmost > 1) & 
+         while (self.leftmost > 1) &
             TextWidth(self.cwin, s[self.leftmost - 1:self.rightmost]) <= self.tw do
             self.leftmost -:= 1
       } else {
@@ -535,7 +535,7 @@ class TextField : Component(
 
    method display(buffer_flag)
       local cp, fh, mp, np, off1, off2, cw, dwin, nocursor, mp2
-      
+
       fh := WAttrib(self.cwin, "fheight")
 
       if /self.transparent then{
@@ -545,8 +545,8 @@ class TextField : Component(
          #
          EraseRectangle(dwin, self.x, self.y, self.w, self.h)
 	}
-      else{ 
-         dwin := self.cwin 
+      else{
+         dwin := self.cwin
          }
 
       #
@@ -558,7 +558,7 @@ class TextField : Component(
          DrawSunkenRectangle(dwin, self.x, self.y, self.w, self.h)
 
       if has_region() then {
-         mp := self.mark - self.leftmost + 1 
+         mp := self.mark - self.leftmost + 1
          mp <:= 1
          mp >:= (*view_str + 1)
          if mp > cp then {
@@ -581,12 +581,12 @@ class TextField : Component(
 
 
 	    cw := Clone(dwin, "fg=blue")
-	    FillRectangle(cw, self.tx + off1, 
-                       1 + self.y + (self.h - fh) / 2, 
+	    FillRectangle(cw, self.tx + off1,
+                       1 + self.y + (self.h - fh) / 2,
                        off2 - off1, fh)
 
 	    WAttrib(cw, "fg=white")
-	    left_string(cw, self.tx+off1, self.y + self.h / 2 , view_str[mp2:np]) 
+	    left_string(cw, self.tx+off1, self.y + self.h / 2 , view_str[mp2:np])
 	    Uncouple(cw)
 
 	    left_string(dwin, self.tx+off2, self.y + self.h / 2 , view_str[np:0])
@@ -605,7 +605,7 @@ class TextField : Component(
 
          if \self.has_focus then {
             cw := Clone(dwin, "fg=black")
-            CursorLine(cw, self.tx + TextWidth(self.cwin, view_str[1:cp]), 
+            CursorLine(cw, self.tx + TextWidth(self.cwin, view_str[1:cp]),
                    1 + self.y + (self.h - fh) / 2, TextWidth(self.cwin, view_str[cp]), fh)
             Uncouple(cw)
             }
@@ -637,7 +637,7 @@ class TextField : Component(
 end
 
 class TextFieldEdit:UndoableEdit(parent,
-                                 cursor, 
+                                 cursor,
                                  mark)
    method redo()
       restore()
@@ -743,7 +743,7 @@ end
 
 class TextFieldDefaultEdit:TextFieldEdit(s)
    method add_edit(other)
-      if is_instance(other, "gui__TextFieldDefaultEdit") &
+      if is_instance(other, "gui::TextFieldDefaultEdit") &
          (other.cursor = self.cursor + *s) then {
             s ||:= other.s
             return

--- a/uni/lib/addressdb.icn
+++ b/uni/lib/addressdb.icn
@@ -38,7 +38,7 @@ record address(name, address, email, phone, company, misc, category)
 class Category : Struct()
 
 #<p>
-# <[param s 
+# <[param s
 # a string consisting of categories, each terminated with
 # a newline (<b>\n</b>).  (This string is how the set of
 # of categories is held in the address book database.) ]>
@@ -59,7 +59,7 @@ class ALines : Struct()
    #  <[returns <i>nothing useful</i>]>
    #</p>
    method addElement(e)
-      return put(struct, e)
+      return ::put(struct, e)
    end
 
    #<p>
@@ -231,9 +231,9 @@ class AddressView : Object(aList)
    method addRecord(rec)
       a := Address()
       a.fromRecord(rec)
-      put(aList, a)
+      ::put(aList, a)
    end
-       
+
    #<p>
    #  Add an address from a (GUI) record.
    #  <[param rec GUI record to load]>
@@ -241,7 +241,7 @@ class AddressView : Object(aList)
    method addIRecord(rec)
       a := Address()
       a.fromIRecord(rec)
-      put(aList, a)
+      ::put(aList, a)
    end
 
    #<p>
@@ -250,7 +250,7 @@ class AddressView : Object(aList)
    method gen()
       suspend !aList
    end
-       
+
 #<p>
 #  The constructor takes a list of (database) records and
 #    converts each into the internal model of an address.
@@ -272,13 +272,13 @@ end
 # with <b>PostgreSQL</b> to build the database table:
 #<pre>
 # SET search_path = public, pg_catalog;
-# 
+#
 # CREATE FUNCTION plpgsql_call_handler () RETURNS language_handler
 #     AS '/usr/lib/pgsql/plpgsql.so', 'plpgsql_call_handler'
 #        LANGUAGE c;
-# 
+#
 # CREATE TRUSTED PROCEDURAL LANGUAGE plpgsql HANDLER plpgsql_call_handler;
-# 
+#
 # CREATE TABLE addressbook (
 #     name character varying(64),
 #     address text,
@@ -288,7 +288,7 @@ end
 #     misc text,
 #     category character varying(128)
 #     );
-# 
+#
 # CREATE FUNCTION insertabook () RETURNS "trigger"
 #     AS '
 #         DECLARE a_rec record;
@@ -304,7 +304,7 @@ end
 #             END IF;
 #         END;'
 #     LANGUAGE plpgsql;
-# 
+#
 # CREATE TRIGGER trigger_insert
 #     BEFORE INSERT ON addressbook
 #     FOR EACH ROW
@@ -409,7 +409,7 @@ class AddressDB : Object(db, tablName, criteria, order)
    #</p>
    method setCatCondition(wc,cats,terminator:"\n")
       if *cats > 0 then {
-         every put(cList := [],"%"||(!cats)||terminator||"%")
+         every ::put(cList := [],"%"||(!cats)||terminator||"%")
          return DButils().addCondition(wc,"category","like",cList)
          }
    end

--- a/uni/lib/addressdb.icn
+++ b/uni/lib/addressdb.icn
@@ -91,7 +91,7 @@ class MLines : Struct()
    #</p>
    #</p>
    method addElement(e)
-      return put(struct, e)
+      return ::put(struct, e)
    end
 
    #<p>
@@ -345,7 +345,7 @@ class AddressDB : Object(db, tablName, criteria, order)
    #</p>
    method storeAddress(addr)
       a := addr.toRecord()
-      db.insert(addr.toRecord()) | write(&errout, "Store of address failed!")
+      db.insert(addr.toRecord()) | ::write(&errout, "Store of address failed!")
    end
 
    #<p>

--- a/uni/lib/args.icn
+++ b/uni/lib/args.icn
@@ -66,7 +66,7 @@ class Args : Object (optionMap, argList)
     #   <[generates the names of all the options in alphabetic order]>
     #</p>
     method genOptNames()
-        suspend (!sort(optionMap,1))[1]
+        suspend (!::sort(optionMap,1))[1]
     end
 
     #<p>
@@ -103,18 +103,18 @@ class Args : Object (optionMap, argList)
     #</p>
     initially (params # List of parametes
               )
-         optionMap := table()
+         optionMap := ::table()
          argList := []
          every param := !params do {
              if doneWithOpts := ("--" == param) then next
              param ? {
-                   if /doneWithOpts & tab(many('-')) then {
-                      oName := tab(upto('=')|0)
-                      oValue := (="=", tab(0)) | &null
+                   if /doneWithOpts & ::tab(::many('-')) then {
+                      oName := ::tab(::upto('=')|0)
+                      oValue := (="=", ::tab(0)) | &null
                       /optionMap[oName] := []
-                      put(optionMap[oName], \oValue)
+                      ::put(optionMap[oName], \oValue)
                       }
-                   else put(argList, param)
+                   else ::put(argList, param)
                    }
              }
         Args := create |self

--- a/uni/lib/base64handler.icn
+++ b/uni/lib/base64handler.icn
@@ -11,7 +11,7 @@ global base64_string, base64_cset
 #
 class Base64Handler:EncodingHandler()
    method can_handle(enc)
-      return map(enc) == "base64"
+      return ::map(enc) == "base64"
    end
 
    method decode_data(m, data)
@@ -19,32 +19,32 @@ class Base64Handler:EncodingHandler()
 
       static n64
       initial {
-         n64 := string(&cset)[1+:64]
+         n64 := ::string(&cset)[1+:64]
       }
 
       # Transform the data by stripping out all non base64 encoding chars.
       t := ""
       pad := 0
       data ? {
-         while tab(upto(base64_cset)) do
-            t ||:= tab(many(base64_cset))
-         while tab(upto('=')) do {
-            s := tab(many('='))
+         while ::tab(::upto(base64_cset)) do
+            t ||:= ::tab(::many(base64_cset))
+         while ::tab(::upto('=')) do {
+            s := ::tab(::many('='))
             pad +:= *s
-            t ||:= repl("\x00", *s)
+            t ||:= ::repl("\x00", *s)
          }
       }
 
-      if (pad > 2) | (*t % 4 ~= 0) then 
+      if (pad > 2) | (*t % 4 ~= 0) then
          return error("Badly formatted Base64 data")
 
-      t := map(t, base64_string, n64)
+      t := ::map(t, base64_string, n64)
 
       res := ""
-      t ? while ( w := ord(move(1)), x := ord(move(1)), y := ord(move(1)), z := ord(move(1)) ) do {
-         res ||:= char( ior( ishift(w,2), ishift(x,-4) ) )
-         res ||:= char( ior( iand(ishift(x,4),255), ishift(y,-2) ) )
-         res ||:= char( ior( iand(ishift(y,6),255), z ) )
+      t ? while ( w := ::ord(::move(1)), x := ::ord(::move(1)), y := ::ord(::move(1)), z := ::ord(::move(1)) ) do {
+         res ||:= ::char( ::ior( ::ishift(w,2), ::ishift(x,-4) ) )
+         res ||:= ::char( ::ior( ::iand(::ishift(x,4),255), ::ishift(y,-2) ) )
+         res ||:= ::char( ::ior( ::iand(::ishift(y,6),255), z ) )
       }
 
       res[0 -: pad] := ""
@@ -52,7 +52,7 @@ class Base64Handler:EncodingHandler()
       return res
    end
 
-   method encode_data(m, data) 
+   method encode_data(m, data)
       local i, j, k, pad, res, ll
 
       res := ""
@@ -62,18 +62,18 @@ class Base64Handler:EncodingHandler()
 
       data ||:= repl("\x00", pad)
 
-      data ? while (i := ord(move(1)), j := ord(move(1)), k := ord(move(1))) do {
-         res ||:= base64_string[ 1 + ishift(i,-2) ]
-         res ||:= base64_string[ 1 + ior( ishift(iand(i,3),4), ishift(j,-4) ) ]
-         res ||:= base64_string[ 1 + ior( ishift(iand(j,15),2), ishift(k,-6) ) ]
-         res ||:= base64_string[ 1 + iand(k,63) ]
+      data ? while (i := ::ord(::move(1)), j := ::ord(::move(1)), k := ::ord(::move(1))) do {
+         res ||:= base64_string[ 1 + ::ishift(i,-2) ]
+         res ||:= base64_string[ 1 + ::ior( ::ishift(::iand(i,3),4), ::ishift(j,-4) ) ]
+         res ||:= base64_string[ 1 + ::ior( ::ishift(::iand(j,15),2), ::ishift(k,-6) ) ]
+         res ||:= base64_string[ 1 + ::iand(k,63) ]
          ll +:= 1
          if ll = 19 then {
             res ||:= "\r\n"
             ll := 0
          }
       }
-      res[ 0 -: pad ] := repl("=", pad) || "\r\n"
+      res[ 0 -: pad ] := ::repl("=", pad) || "\r\n"
 
       return res
    end
@@ -81,6 +81,6 @@ class Base64Handler:EncodingHandler()
    initially()
       initial {
          base64_string := &ucase || &lcase || &digits || "+/"
-         base64_cset := cset(base64_string)
+         base64_cset := ::cset(base64_string)
       }
 end

--- a/uni/lib/base64handler.icn
+++ b/uni/lib/base64handler.icn
@@ -60,7 +60,7 @@ class Base64Handler:EncodingHandler()
 
       pad := (3 - (*data % 3)) % 3
 
-      data ||:= repl("\x00", pad)
+      data ||:= ::repl("\x00", pad)
 
       data ? while (i := ::ord(::move(1)), j := ::ord(::move(1)), k := ::ord(::move(1))) do {
          res ||:= base64_string[ 1 + ::ishift(i,-2) ]

--- a/uni/lib/basicclasscoding.icn
+++ b/uni/lib/basicclasscoding.icn
@@ -20,8 +20,8 @@ class BasicClassCoding : ClassCoding()
 
    method decode_obj(d)
       local i, n
-      n := integer(d.line_in()) | fail
-      every i := 1 to n do 
+      n := ::integer(d.line_in()) | fail
+      every i := 1 to n do
 	 self[i] := d.decode() | fail
       return
    end

--- a/uni/lib/blockread.icn
+++ b/uni/lib/blockread.icn
@@ -35,7 +35,7 @@ package util
 #and
 #<pre>
 #     import util
-#     
+#
 #     procedure main(args)
 #         bRead := BlockRead()
 #         i := 0
@@ -102,7 +102,7 @@ class BlockRead : Object (f, bSize, buffer)
    #</p>
    method readBlock(n)
       /n := bSize
-      if s := reads(f, n) then {
+      if s := ::reads(f, n) then {
 	 i := *s
 	 while (i > 0) & (s[i] ~== "\n") do {
 	    i -:= 1
@@ -172,9 +172,9 @@ initially (fileOrName, blockSize)
       f := &input
       }
    else {
-      if type(fileOrName) == "string" then {
-	 f := open(fileOrName) |
-	    stop("BlockRead: Cannot open '",fileOrName,"'!")
+      if ::type(fileOrName) == "string" then {
+	 f := ::open(fileOrName) |
+	    ::stop("BlockRead: Cannot open '",fileOrName,"'!")
 	 }
       else {
 	 f := fileOrName     # Assume it's a file

--- a/uni/lib/class.icn
+++ b/uni/lib/class.icn
@@ -12,17 +12,39 @@ global lang_class_table
 
 
 #
-# Get the Class corresponding to the given object
+# Get the Class corresponding to the given object or the class name
 #
 procedure get_class_for(obj)
    local x, name
    /lang_class_table := table()
-   name := ::classname(obj)
-
-   if not(x := \lang_class_table[name]) then {
-      x := Class(obj)
-      lang_class_table[name] := x
+   case get_type(obj) of {
+      "class" : {
+         #
+         # convert class name to the external form for storing in the table
+         #
+         name := mapPackageInt2Ext(::classname(obj))
+         #
+         # use the object supplied to be create a Class object and insert into
+         # the table with the key of the external class names#
+         if not(x := \lang_class_table[name]) then {
+            x := Class(obj)
+            lang_class_table[name] := x
+         }
       }
+      "string" : {
+         #
+         # make sure that the class name supplied is in external form
+         #
+         name := mapPackageInt2Ext(obj)
+         #
+         # if there is no key by the string value supplied, we need to raise failure
+         x := \lang_class_table[name] | fail
+      }
+      #
+      # any other kind of value is not a class or a class name, therefore we need to failure#
+      default : fail
+   }
+
    return x
 end
 

--- a/uni/lib/class.icn
+++ b/uni/lib/class.icn
@@ -16,7 +16,7 @@ global lang_class_table
 #
 procedure get_class_for(obj)
    local x, name
-   /lang_class_table := table()
+   /lang_class_table := ::table()
    case lang::get_type(obj) of {
       "class" : {
          #
@@ -79,7 +79,7 @@ class Class(name,
    # is no such method.
    #
    method get_method(s)
-      if member(methods_map, s) then
+      if ::member(methods_map, s) then
          return methods_map[s]
    end
 
@@ -108,7 +108,7 @@ class Class(name,
    end
 
 initially(obj)
-   local v, s, sa, m, cname, cmeths := table(), lm := []
+   local v, s, sa, m, cname, cmeths := ::table(), lm := []
 
    #
    # get the class name based on the object that we are looking at
@@ -121,8 +121,8 @@ initially(obj)
    #
    self.methods := []
    self.supers := []
-   self.methods_map := table()
-   self.implemented_classes := set(lang::mapPackageInt2Ext(self.name))
+   self.methods_map := ::table()
+   self.implemented_classes := ::set(lang::mapPackageInt2Ext(self.name))
    self.variables := []
    #
    # there are two variables in the class structure which are not of interest
@@ -130,9 +130,9 @@ initially(obj)
    # examine the names provided by the Unicon function membernames(), we will not
    # include these in the list of available variable names.
    #
-   every s := !membernames(obj) do {
+   every s := !::membernames(obj) do {
       if not (s == ("__s" | "__m")) then {
-         put(self.variables, s)
+         ::put(self.variables, s)
       }
    }
    #
@@ -141,7 +141,7 @@ initially(obj)
    #
    # the first entry will be the set of methods defined for the class
    #
-   cmeths[self.name] := set(::methods(self.name))
+   cmeths[self.name] := ::set(::methods(self.name))
    #
    # Get the oprec, the field names of this record will be the method names
    # defined directly in the class as well as the superclass names applicable
@@ -162,28 +162,28 @@ initially(obj)
          # and the name of the method. This will be used later to generate the
          # methods and the methods_map values.
          #
-         put(lm, [v, s])
+         ::put(lm, [v, s])
       } else {
          #
          # we place the super class name onto the end of the supers list and put
          # the applicable list of methods for that class into an apprporiate set
          # for creating the methods and methods_map values
          #
-         put(self.supers, sa)
-         cmeths[sa] := set(::methods(s))
+         ::put(self.supers, sa)
+         cmeths[sa] := ::set(::methods(s))
       }
    }
    #
    # we can now add the super class list to the set of implemented classes
    #
-   self.implemented_classes ++:= set(self.supers)
+   self.implemented_classes ++:= ::set(self.supers)
    #
    # this is where we finalise the methods list and the methods_map table
    #
    every v := !lm do {
-      every s := key(cmeths) do {
+      every s := ::key(cmeths) do {
          if ::member(cmeths[s], v[1]) then {
-            put(self.methods, m := Method(v[1], v[2], s))
+            ::put(self.methods, m := Method(v[1], v[2], s))
             methods_map[v[2]] := m
          }
       }

--- a/uni/lib/class.icn
+++ b/uni/lib/class.icn
@@ -10,16 +10,17 @@ package lang
 
 global lang_class_table
 
+
 #
-# Get the Class corresponding to the given class name
+# Get the Class corresponding to the given object
 #
-procedure get_class_for_name(name)
-   local x
+procedure get_class_for(obj)
+   local x, name
    /lang_class_table := table()
+   name := ::classname(obj)
 
    if not(x := \lang_class_table[name]) then {
-      x := Class()
-      x.init(name) | fail
+      x := Class(obj)
       lang_class_table[name] := x
       }
    return x
@@ -28,13 +29,13 @@ end
 #
 # This class provides information about a Unicon class.
 #
-class Class(name, 
-            methods, 
-            methods_map, 
-            variables, 
-            state_instance, 
-            oprec, 
-            supers, 
+class Class(name,
+            methods,
+            methods_map,
+            variables,
+            state_instance,
+            oprec,
+            supers,
             implemented_classes)
 
    #
@@ -84,54 +85,84 @@ class Class(name,
       return variables
    end
 
-   method init(n)
-      local i, v, s, p, m, imgv, cname
+initially(obj)
+   local v, s, m, cname, cmeths := table(), lm := []
 
-      self.name := n
-      self.methods := []
-      self.supers := []
-      self.methods_map := table()
-
-      #
-      # Initialize the class
-      #
-      p := proc(name || "initialize") | fail
-      p()
-
-      #
-      # Get the oprec
-      #
-      self.oprec := variable(name || "__oprec") | fail
-   
-      every i := 1 to *self.oprec do {
-	 ::name(self.oprec[i]) ? {
-	    tab(find(".")+1)
-	    s := tab(0)
-	    }
-         
-	 v := self.oprec[i]
-	 if type(v) == "procedure" then {
-	    imgv := image(v)
-	    cname := imgv[11+:*imgv-*s-11]
-	    m := Method(v, s, cname)
-	    put(methods, m)
-	    insert(methods_map, s, m)
-	    }
-	 else {
-	    put(supers, s)
-	    }
+   #
+   # get the class name based on the object that we are looking at
+   #
+   self.name := ::classname(obj)
+   #
+   # provide the initial values for the methods, supers, methods_map, variables
+   # and implemented_classes. These will be added to as we process the information
+   # available from the Unicon functions.
+   #
+   self.methods := []
+   self.supers := []
+   self.methods_map := table()
+   self.implemented_classes := set(self.name)
+   self.variables := []
+   #
+   # there are two variables in the class structure which are not of interest
+   # here as these are implementation related variables:- __s and __m. So as we
+   # examine the names provided by the Unicon function membernames(), we will not
+   # include these in the list of available variable names.
+   #
+   every s := !membernames(obj) do {
+      if not (s == ("__s" | "__m")) then {
+         put(self.variables, s)
       }
+   }
+   #
+   # the method values associated with the class or superclasses for this class
+   # will be stored in set associated with the key of the class name.
+   #
+   # the first entry will be the set of methods defined for the class
+   #
+   cmeths[self.name] := set(::methods(self.name))
+   #
+   # Get the oprec, the field names of this record will be the method names
+   # defined directly in the class as well as the superclass names applicable
+   # for this class.
+   #
+   # the field names for a method hold a procedure value, the super classes hold
+   # a record value. We use this distinction in values to determine what is a
+   # method name and what is a class name.
+   #
+   self.oprec := ::oprec(obj) | fail
 
-      p := proc(name || "__state") | fail
-      state_instance := p()
-      variables := []
-      every ::name(state_instance[1 to *state_instance]) ? {
-	 tab(find(".")+1)
-	 put(variables, tab(0))
-	 }
-
-      implemented_classes := set(supers)
-      insert(implemented_classes, name)
-      return
-   end
+   every s := ::fieldnames(self.oprec) do {
+      v := self.oprec[s]
+      if type(v) == "procedure" then {
+         #
+         # lm holds a list of lists where the internal list is the procedure value
+         # and the name of the method. This will be used later to generate the
+         # methods and the methods_map values.
+         #
+         put(lm, [v, s])
+      } else {
+         #
+         # we place the super class name onto the end of the supers list and put
+         # the applicable list of methods for that class into an apprporiate set
+         # for creating the methods and methods_map values
+         #
+         put(self.supers, s)
+         cmeths[s] := set(::methods(s))
+      }
+   }
+   #
+   # we can now add the super class list to the set of implemented classes
+   #
+   self.implemented_classes ++:= set(self.supers)
+   #
+   # this is where we finalise the methods list and the methods_map table
+   #
+   every v := !lm do {
+      every s := key(cmeths) do {
+         if ::member(cmeths[s], v[1]) then {
+            put(self.methods, m := Method(v[1], v[2], s))
+            methods_map[v[2]] := m
+         }
+      }
+   }
 end

--- a/uni/lib/class.icn
+++ b/uni/lib/class.icn
@@ -17,12 +17,12 @@ global lang_class_table
 procedure get_class_for(obj)
    local x, name
    /lang_class_table := table()
-   case get_type(obj) of {
+   case lang::get_type(obj) of {
       "class" : {
          #
          # convert class name to the external form for storing in the table
          #
-         name := mapPackageInt2Ext(::classname(obj))
+         name := lang::mapPackageInt2Ext(::classname(obj))
          #
          # use the object supplied to be create a Class object and insert into
          # the table with the key of the external class names#
@@ -35,7 +35,7 @@ procedure get_class_for(obj)
          #
          # make sure that the class name supplied is in external form
          #
-         name := mapPackageInt2Ext(obj)
+         name := lang::mapPackageInt2Ext(obj)
          #
          # if there is no key by the string value supplied, we need to raise failure
          x := \lang_class_table[name] | fail
@@ -108,12 +108,12 @@ class Class(name,
    end
 
 initially(obj)
-   local v, s, m, cname, cmeths := table(), lm := []
+   local v, s, sa, m, cname, cmeths := table(), lm := []
 
    #
    # get the class name based on the object that we are looking at
    #
-   self.name := ::classname(obj)
+   self.name := lang::mapPackageInt2Ext(::classname(obj))
    #
    # provide the initial values for the methods, supers, methods_map, variables
    # and implemented_classes. These will be added to as we process the information
@@ -122,7 +122,7 @@ initially(obj)
    self.methods := []
    self.supers := []
    self.methods_map := table()
-   self.implemented_classes := set(self.name)
+   self.implemented_classes := set(lang::mapPackageInt2Ext(self.name))
    self.variables := []
    #
    # there are two variables in the class structure which are not of interest
@@ -155,7 +155,8 @@ initially(obj)
 
    every s := ::fieldnames(self.oprec) do {
       v := self.oprec[s]
-      if type(v) == "procedure" then {
+      sa := lang::mapPackageInt2Ext(s)
+      if ::type(v) == "procedure" then {
          #
          # lm holds a list of lists where the internal list is the procedure value
          # and the name of the method. This will be used later to generate the
@@ -168,8 +169,8 @@ initially(obj)
          # the applicable list of methods for that class into an apprporiate set
          # for creating the methods and methods_map values
          #
-         put(self.supers, s)
-         cmeths[s] := set(::methods(s))
+         put(self.supers, sa)
+         cmeths[sa] := set(::methods(s))
       }
    }
    #

--- a/uni/lib/cltable.icn
+++ b/uni/lib/cltable.icn
@@ -11,21 +11,21 @@ import lang
 #
 class ClTable:Object(lookup, names)
    method insert(key, val)
-      ::insert(lookup, map(key), val)
-      ::insert(names, map(key), key)
+      ::insert(lookup, ::map(key), val)
+      ::insert(names, ::map(key), key)
    end
 
    method member(key)
-      return ::member(lookup, map(key))
+      return ::member(lookup, ::map(key))
    end
 
    method delete(key)
-      ::delete(lookup, map(key))
-      ::delete(names, map(key))
+      ::delete(lookup, ::map(key))
+      ::delete(names, ::map(key))
    end
-   
+
    method get(key)
-      return lookup[map(key)]
+      return lookup[::map(key)]
    end
 
    method sort()
@@ -61,7 +61,7 @@ class ClTable:Object(lookup, names)
    end
 
 initially()
-   lookup := table()
-   names := table()
+   lookup := ::table()
+   names := ::table()
 end
 

--- a/uni/lib/complex.icn
+++ b/uni/lib/complex.icn
@@ -112,7 +112,7 @@ class Complex:Object(r:0,i:0)
     #</p>
     method multInverse()
        n := conjugate()
-       d := real(r^2 + i^2)
+       d := ::real(r^2 + i^2)
        return Complex(n.r/d, n.i/d)
     end
 

--- a/uni/lib/complex.icn
+++ b/uni/lib/complex.icn
@@ -53,7 +53,7 @@ class Complex:Object(r:0,i:0)
        if x := convert(x) then {
           c := x.conjugate()
           n := self.mult(c)
-          d := real((x.mult(c)).r)
+          d := ::real((x.mult(c)).r)
           return Complex(n.r/d,n.i/d)
           }
     end
@@ -128,8 +128,8 @@ class Complex:Object(r:0,i:0)
     #  <i>Used internally.</i>
     #</p>
     method convert(x)
-       if type(x) == "math__Complex__state" then return x
-       return Complex(numeric(x),0)
+       if ::type(x) == "math__Complex__state" then return x
+       return Complex(::numeric(x),0)
     end
 
 end

--- a/uni/lib/compoundedit.icn
+++ b/uni/lib/compoundedit.icn
@@ -26,7 +26,7 @@ class CompoundEdit:UndoableEdit(l, closed)
    method add_edit(other)
       if \closed then
 	 fail
-      l[-1].add_edit(other) | put(l, other)
+      l[-1].add_edit(other) | ::put(l, other)
       return
    end
 

--- a/uni/lib/connectable.icn
+++ b/uni/lib/connectable.icn
@@ -23,7 +23,7 @@ package util
 #
 class Connectable(listeners)
    method genlisteners(typ)
-      case type(listeners) of {
+      case ::type(listeners) of {
 	 "table": suspend !\(listeners[typ])
 	 "list": every x := !listeners do
 		    if x.type === typ then suspend x
@@ -46,10 +46,10 @@ class Connectable(listeners)
 	    # list invocation here uses substitution rules per future UniLib
 	    # integration.  This probably won't work well until that happens.
 	    "list": {
-	       a := copy(l.obj)
-	       fcn := pop(a)
+	       a := ::copy(l.obj)
+	       fcn := ::pop(a)
 	       args := [self, typ, param]
-	       every i := 1 to *a do if a[i] === Arg then a[i] := pop(args)
+	       every i := 1 to *a do if a[i] === Arg then a[i] := ::pop(args)
 	       suspend fcn ! a
 	       }
 	    "co-expression": {
@@ -71,7 +71,7 @@ class Connectable(listeners)
    method connect(obj, meth, typ)
       local l, p, sum
 
-      p := lang::find_method(obj, meth) | stop("No such method ", meth)
+      p := lang::find_method(obj, meth) | ::stop("No such method ", meth)
 
       # omit duplicate requests
       every l := genlisteners(typ) do
@@ -82,30 +82,30 @@ class Connectable(listeners)
 
       if /listeners then return listeners := l
 
-      else if type(listeners) ~== "list" & type(listeners) ~== "table" then
+      else if ::type(listeners) ~== "list" & ::type(listeners) ~== "table" then
 	 listeners := [listeners] # promote to list and continue
 
-      if type(listeners) == "list" then {
+      if ::type(listeners) == "list" then {
 	 if (!listeners).type ~=== typ then {
-	    T := table()
+	    T := ::table()
 	    every x := !listeners do {
 	       /T[x.type] := []
-	       put(T[x.type], x)
+	       ::put(T[x.type], x)
 	       }
 	    listeners := T # promote to table and continue
 	    }
-	 else { put(listeners, l); return l }
+	 else { ::put(listeners, l); return l }
 	 }
 
       /listeners[typ] := []
-      put(listeners[typ], l)
+      ::put(listeners[typ], l)
 
       return l
    end
 
    method disconnect_fromlist(L, obj)
       local elem, newL := []
-      every elem := !L do if elem.obj ~=== obj then put(newL, elem)
+      every elem := !L do if elem.obj ~=== obj then ::put(newL, elem)
       return newL
    end
 
@@ -115,14 +115,14 @@ class Connectable(listeners)
    method disconnect_all(obj)
       local k, t, l
 
-      if type(listeners) == "table" then {
-	 every k := key(listeners) do
+      if ::type(listeners) == "table" then {
+	 every k := ::key(listeners) do
 	    listeners[k] := disconnect_fromlist(listeners[k], obj)
 	 }
-      else if type(listeners) == "list" then
+      else if ::type(listeners) == "list" then
 	 listeners := disconnect_fromlist(listeners, obj)
 
-      else if type(listeners) == "Subscription" then
+      else if ::type(listeners) == "Subscription" then
 	 if listeners.obj === obj then listeners := &null
 
    end
@@ -137,12 +137,12 @@ class Connectable(listeners)
 
       t := []
 
-      if type(listeners) == "list" then {
-	 every put(t, l ~=== !listeners)
+      if ::type(listeners) == "list" then {
+	 every ::put(t, l ~=== !listeners)
 	 listeners := t
 	 }
-      else if type(listeners) == "table" then {
-	 every put(t, l ~=== !listeners[k])
+      else if ::type(listeners) == "table" then {
+	 every ::put(t, l ~=== !listeners[k])
 	 listeners[k] := t
 	 }
    end

--- a/uni/lib/contentdisposition.icn
+++ b/uni/lib/contentdisposition.icn
@@ -33,12 +33,12 @@ class ContentDisposition:Error(type, parameters)
       local s
       parameters.member(key) | fail
       s := parameters.get(key)
-      if any('\"', s) then
+      if ::any('\"', s) then
          return s[2:-1]
       else
          return s
    end
-   
+
    #
    # Get the parameter for the given key.
    #
@@ -59,7 +59,7 @@ class ContentDisposition:Error(type, parameters)
    method parse(s)
       local p := mail::RFC822Parser()
       return p.parse_content_disposition(s, self) | error(p)
-   end   
+   end
 
    method rfc1521_parameters()
       local e, s := ""

--- a/uni/lib/cvsuser.icn
+++ b/uni/lib/cvsuser.icn
@@ -25,7 +25,7 @@ procedure get_cvs_user(name)
          if ::tab(::upto(':')) == name then {
             ::move(1)
             ::close(f)
-            return CvsUser(name, tab(0))
+            return CvsUser(name, ::tab(0))
          }
       }
    }

--- a/uni/lib/cvsuser.icn
+++ b/uni/lib/cvsuser.icn
@@ -17,19 +17,19 @@ end
 procedure get_cvs_user(name)
    local cvs_root, s, f
 
-   cvs_root := getenv("CVSROOT") | stop("Couldn't get CVS_ROOT")
-   f := open(cvs_root || "/CVSROOT/users") | stop("Couldn't open users file")
+   cvs_root := ::getenv("CVSROOT") | ::stop("Couldn't get CVS_ROOT")
+   f := ::open(cvs_root || "/CVSROOT/users") | ::stop("Couldn't open users file")
 
    every s := !f do {
       s ? {
-         if tab(upto(':')) == name then {
-            move(1)
-            close(f)
+         if ::tab(::upto(':')) == name then {
+            ::move(1)
+            ::close(f)
             return CvsUser(name, tab(0))
          }
       }
    }
 
-   close(f)
+   ::close(f)
 end
 

--- a/uni/lib/cvsutil.icn
+++ b/uni/lib/cvsutil.icn
@@ -9,14 +9,14 @@ import mail
 procedure get_from()
    local cvs_user, entry, mb, pwent
 
-   cvs_user := getenv("CVS_USER") | stop("Couldn't get CVS_USER")
+   cvs_user := ::getenv("CVS_USER") | ::stop("Couldn't get CVS_USER")
 
-   entry := get_cvs_user(cvs_user) | stop("Couldn't get user entry for " || cvs_user)
+   entry := get_cvs_user(cvs_user) | ::stop("Couldn't get user entry for " || cvs_user)
 
-   mb := Mailbox(entry.get_mail()) | stop("Invalid RFC822 address: " || entry.get_mail())
+   mb := Mailbox(entry.get_mail()) | ::stop("Invalid RFC822 address: " || entry.get_mail())
 
-   if (mb.get_phrase() == "") & (pwent := getpw(entry.get_user())) then
-      mb.set_phrase(image(pwent.gecos))
+   if (mb.get_phrase() == "") & (pwent := ::getpw(entry.get_user())) then
+      mb.set_phrase(::image(pwent.gecos))
 
    return mb
 end

--- a/uni/lib/database.icn
+++ b/uni/lib/database.icn
@@ -31,7 +31,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    method open(user,      # Valid database user id
 	       password)   # Password for that user.
       static real_open
-      initial real_open := proc("open")
+      initial real_open := ::proc("open")
       return \accessDb(real_open(dsn,"o",db_table,user,password))
    end
 
@@ -62,7 +62,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #  <[generates rows that have been selected from the database]>
    #</p>
    method fetch()
-      static real_fetch := proc("fetch")
+      static real_fetch := ::proc("fetch")
       suspend |real_fetch(\accessDb())
    end
 
@@ -72,7 +72,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #  <[fails if cannot close the database]>
    #</p>
    method close()
-      static real_close := proc("close")
+      static real_close := ::proc("close")
       return real_close(\accessDb())
    end
 
@@ -81,7 +81,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #   <[returns result of executing <tt>sqlstatement</tt>]>
    #</p>
    method sql(sqlstatement)  # Arbitrary SQL statement
-      static real_sql := proc("sql")
+      static real_sql := ::proc("sql")
       return real_sql(\accessDb(), sqlstatement)
    end
 
@@ -108,15 +108,15 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
                       #    entry is new field value) to update
                       # <i>(Can also be a record)</i>
       s := "INSERT INTO " || db_table || "("
-      every k := key(rec) do { s ||:= k; s||:= "," }
+      every k := ::key(rec) do { s ||:= k; s||:= "," }
       s := s[1:-1] # delete trailing comma?
       s ||:= ") VALUES ("
-      every k := key(rec) do { s ||:= "'"||dbu.escape(rec[k])||"'," }
+      every k := ::key(rec) do { s ||:= "'"||dbu.escape(rec[k])||"'," }
       s := s[1:-1] # delete trailing comma?
       s ||:= ")"
       return sql(s)
    end
-    
+
    #<p>
    # Select rows from the currently active database table.
    #   <[returns result of performing query]>
@@ -134,7 +134,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
          s ||:= " ORDER BY " || order
       return sql(s)
    end
-    
+
    #<p>
    # Update rows in the currently active database table.
    #  <[returns result of updating rows]>
@@ -146,7 +146,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
                                #    that identifies rows to modify
                  )
       s := "UPDATE " || db_table || " SET "
-      every k := key(rec) do {
+      every k := ::key(rec) do {
 	 s ||:= k ||"="||"'"||dbu.escape(rec[k])||"',"
 	 }
       s := s[1:-1]  # delete trailing comma?
@@ -159,7 +159,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #   <[returns database metadata record]>
    #</p>
    method product()
-      return dbproduct(accessDb())
+      return ::dbproduct(accessDb())
    end
 
    #<p>
@@ -167,7 +167,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #  <[returns database driver metadata record]>
    #</p>
    method driver()
-      return dbdriver(accessDb())
+      return ::dbdriver(accessDb())
    end
 
    #<p>
@@ -175,7 +175,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
    #  <[returns database limits]>
    #</p>
    method limits()
-      return dblimits(accessDb())
+      return ::dblimits(accessDb())
    end
 
    #<p>

--- a/uni/lib/db_util.icn
+++ b/uni/lib/db_util.icn
@@ -34,10 +34,10 @@ class DButils : Object ()
         local ns := ""
 
         s ? {
-            while ns ||:= tab(upto('\e\'')) do {
+            while ns ||:= ::tab(::upto('\e\'')) do {
                 ns ||:= if ="'" then "''" else "\e\e"
                 }
-            ns ||:= tab(0)
+            ns ||:= ::tab(0)
             }
         return ns
     end
@@ -49,7 +49,7 @@ class DButils : Object ()
                       )
         local cNames
 
-        every put(cNames := [], key(rec))
+        every ::put(cNames := [], ::key(rec))
         return cNames
     end
 
@@ -128,7 +128,7 @@ class DButils : Object ()
     method mapToSQL(field, test, values)
         local nc := ""
 
-        if (string|numeric)(values) then {
+        if (::string|::numeric)(values) then {
             nc := mapSQLExpr(field, test, values)
             }
         else {
@@ -151,14 +151,14 @@ class DButils : Object ()
     #</p>
     #<p><i>Internal use only.</i></p>
     method mapSQLExpr(field, op, value)
-        if type(value) == "string" then {
-            if (op == ("="|"~~")) & upto('*', value) then {
+        if ::type(value) == "string" then {
+            if (op == ("="|"~~")) & ::upto('*', value) then {
                 op    := "LIKE"
-                value := map(value, "*", "%")
+                value := ::map(value, "*", "%")
                 }
-            else if (op == "~~*") & upto('*', value) then {
+            else if (op == "~~*") & ::upto('*', value) then {
                 op    := "ILIKE"
-                value := map(value, "*", "%")
+                value := ::map(value, "*", "%")
                 }
             value := "'" || escape(value) || "'"
             }

--- a/uni/lib/decode.icn
+++ b/uni/lib/decode.icn
@@ -41,11 +41,11 @@ class Decode : Object(
       buff := StringBuff()
       s ? {
          repeat {
-            buff.add(tab(many(esc)))
-            if pos(0) then
+            buff.add(::tab(::many(esc)))
+            if ::pos(0) then
                return buff.get_string()
-            move(1)
-            buff.add(char(move(3)))
+            ::move(1)
+            buff.add(::char(::move(3)))
          }
       }
    end
@@ -53,9 +53,9 @@ class Decode : Object(
    method line_in()
       local s
       buff ? {
-         if s := tab(upto('|')) then {
-            move(1)
-            buff := tab(0)
+         if s := ::tab(::upto('|')) then {
+            ::move(1)
+            buff := ::tab(0)
             return s
          }
       }
@@ -64,12 +64,12 @@ class Decode : Object(
    method decode_record()
       local rname, n, res, i
       (rname := line_in() &
-       n := integer(line_in())) | fail
-      res := proc(rname)()
+       n := ::integer(line_in())) | fail
+      res := ::proc(rname)()
       seen[tag_count +:= 1] := res
       every i := 1 to n do
          res[i] := decode() | fail
-      
+
       return res
    end
 
@@ -78,7 +78,7 @@ class Decode : Object(
 
       t := line_in() | fail
 
-      if i := integer(t) then
+      if i := ::integer(t) then
          return \seen[i]
 
       case t of {
@@ -86,7 +86,7 @@ class Decode : Object(
             return
 
          "procedure" :
-            return proc(line_in())
+            return ::proc(line_in())
 
          "record" :
             return decode_record()
@@ -98,36 +98,36 @@ class Decode : Object(
             return decode_string(line_in())
 
          "integer" :
-            return integer(line_in())
+            return ::integer(line_in())
 
          "real" :
-            return real(line_in())
+            return ::real(line_in())
 
          "cset" :
-            return cset(decode_string(line_in()))
+            return ::cset(decode_string(line_in()))
 
          "list" : {
-            n := integer(line_in()) | fail
+            n := ::integer(line_in()) | fail
             res := []
             seen[tag_count +:= 1] := res
-            every 1 to n do 
-               put(res, decode()) | fail
+            every 1 to n do
+               ::put(res, decode()) | fail
             return res
          }
 
          "set" : {
-            n := integer(line_in()) | fail
-            res := set([])
+            n := ::integer(line_in()) | fail
+            res := ::set([])
             seen[tag_count +:= 1] := res
-            every 1 to n do 
-               insert(res, decode()) | fail
+            every 1 to n do
+               ::insert(res, decode()) | fail
             return res
          }
 
          "table" : {
             def := decode() | fail
-            res := table(def)
-            n := integer(line_in()) | fail
+            res := ::table(def)
+            n := ::integer(line_in()) | fail
             seen[tag_count +:= 1] := res
             every 1 to n do {
                (key := decode() &
@@ -135,11 +135,11 @@ class Decode : Object(
                res[key] := val
             }
             return res
-         }            
+         }
 
          default :
             return []
-      }            
+      }
    end
 
    method decode_class()
@@ -150,7 +150,7 @@ class Decode : Object(
       #
       # Create an instance
       #
-      p := proc(cname) | fail
+      p := ::proc(cname) | fail
       res := p()
       seen[tag_count +:= 1] := res
 
@@ -162,6 +162,6 @@ class Decode : Object(
 
    initially(s)
       tag_count := 0
-      seen := table()
+      seen := ::table()
       buff := s
 end

--- a/uni/lib/encode.icn
+++ b/uni/lib/encode.icn
@@ -59,17 +59,17 @@ class Encode : Object(
       local buff
       static printable
       initial
-         printable := cset(&ascii[33:128]) -- '|\\'
+         printable := ::cset(&ascii[33:128]) -- '|\\'
 
       buff := StringBuff()
       s ? {
          repeat {
-            buff.add(tab(many(printable)))
-            if pos(0) then
+            buff.add(::tab(::many(printable)))
+            if ::pos(0) then
                return buff.get_string()
-            buff.add("\\" || right(ord(move(1)), 3, "0"))
+            buff.add("\\" || ::right(::ord(::move(1)), 3, "0"))
          }
-      }	 
+      }
    end
 
    method encode_record(o)
@@ -122,12 +122,12 @@ class Encode : Object(
          "table" : {
             seen[o] := (tag_count +:= 1)
             encode(o[[]])
-            pairs := sort(o)
+            pairs := ::sort(o)
             line_out(*pairs)
             every encode(!!pairs)
          }
 
-         default : 
+         default :
             &null
 
       }
@@ -140,7 +140,7 @@ class Encode : Object(
    method encode_class(o)
       local cname, t, m, e
 
-      cname := lang::get_class_name(o) | stop("invalid class name")
+      cname := lang::get_class_name(o) | ::stop("invalid class name")
       line_out(cname)
       seen[o] := (tag_count +:= 1)
 
@@ -150,6 +150,6 @@ class Encode : Object(
 
    initially()
       tag_count := 0
-      seen := table()
+      seen := ::table()
       string_buff := StringBuff()
 end

--- a/uni/lib/error.icn
+++ b/uni/lib/error.icn
@@ -6,7 +6,7 @@ package util
 
 class Error(reason)
    method error(a)
-      if type(a) == "string" then
+      if ::type(a) == "string" then
          reason := a
       else
          reason := a.get_reason()

--- a/uni/lib/exception.icn
+++ b/uni/lib/exception.icn
@@ -61,17 +61,17 @@ class Try : Object (sources, exceptions, lastException)
                    # Only the first is used as the <i>try-clause</i>.
       local result
 
-      push(sources, &current)
-      push(exceptions, &null)     # placeholder
+      ::push(sources, &current)
+      ::push(exceptions, &null)     # placeholder
       #  Consider making this a generator!
       if result := (@L[1])\1 then {
-	 pop(sources)
-	 lastException := pop(exceptions) | &null
+	 ::pop(sources)
+	 lastException := ::pop(exceptions) | &null
 	 return result
 	 }
       else {
-	 pop(sources)
-	 lastException := pop(exceptions) | &null
+	 ::pop(sources)
+	 lastException := ::pop(exceptions) | &null
 	 fail
 	 }
     end
@@ -94,7 +94,7 @@ class Try : Object (sources, exceptions, lastException)
       #    If the exception is thrown inside a Try() that doesn't
       #    catch it, this code is never reached.  I.e. uncaught
       #    exceptions are ignored if any are tried to be caught.
-      stop("Exception thrown outside of Try call: ",
+      ::stop("Exception thrown outside of Try call: ",
 	   exception.getMessage(),":\n",exception.getLocation())
 
    end
@@ -147,7 +147,7 @@ initially ()
    exceptions := []    # Stack of thrown exceptions (probably always
 		       #   <= size 1) - this needs more thought!
    Try := create |self # Convert to a singleton object
-end        
+end
 
 #<p>
 # The <b>Exception</b> provides the basics.  It can be subclassed to
@@ -161,7 +161,7 @@ class Exception : Object (message, location)
    #</p>
    method show(outFile)
        /outFile := &errout
-       write(outFile, self.getMessage(), ":\n", self.getLocation())
+       ::write(outFile, self.getMessage(), ":\n", self.getLocation())
        return
    end
 
@@ -209,4 +209,4 @@ initially (aMessage)  # default message to attach to this exception.
    message := aMessage
    location := buildStackTrace(2) # allow getLocation() to work
                                         #   without a throw()
-end    
+end

--- a/uni/lib/fcn_util.icn
+++ b/uni/lib/fcn_util.icn
@@ -31,7 +31,7 @@ invocable all
 #<pre>
 #   sqrt(abs(integer(sqrt(ord("1")))))
 #</pre>
-#</p>   
+#</p>
 #<p>
 #Any Unicon entity that can be evaluated using
 #the standard single-argument function call syntax
@@ -43,9 +43,9 @@ invocable all
 #<pre>
 #   sqrt(2^3.5)
 #<pre>
-#</p>   
+#</p>
 procedure compose(fL[])
-   fL := reverse(fL)
+   fL := ::reverse(fL)
    return makeProc { {saveSource := &source
                        repeat {
                            x := (x@saveSource)[1]
@@ -54,7 +54,7 @@ procedure compose(fL[])
                            }
                       }
                     }
-end 
+end
 
 #<p>
 #  A closure binds some function parameters at definition time,
@@ -88,11 +88,11 @@ procedure closure(f,paramList[])
              argList := []
              every arg := !paramList do {
                 if arg === Arg then {   # Replace unbound parameter
-                    put(argList, get(x) | &null) #    with argument
+                    ::put(argList, ::get(x) | &null) #    with argument
                     }
-                else put(argList, arg)           # Use bound parameter
+                else ::put(argList, arg)           # Use bound parameter
                 }
-             every put(argList, !x)    # append extra arguments
+             every ::put(argList, !x)    # append extra arguments
 
              # Invoke the procedure
              x := f ! argList
@@ -127,11 +127,11 @@ class Closure : Object (fcn)
    method doInvocation(flist, args)
       local i
 
-      flist := copy(flist)
-      /args := list()
+      flist := ::copy(flist)
+      /args := ::list()
       every i := 2 to *flist do
 	 if flist[i] === Arg then
-	    flist[i] := pop(args) | &null
+	    flist[i] := ::pop(args) | &null
       suspend invokeFcn ! (flist ||| args)
    end
 
@@ -175,7 +175,7 @@ end
 #</pre>
 #</p>
 procedure makeProc(A)
-   if type(A) == "co-expression" then return (@A,A)    # Not called as PDCO!
+   if ::type(A) == "co-expression" then return (@A,A)    # Not called as PDCO!
    return (@A[1], A[1])
 end
 
@@ -214,17 +214,17 @@ end
 #</p>
 procedure invokeFcn(fcn, args[])
    local i
-   /args := list()
-   case type(fcn) of {
+   /args := ::list()
+   case ::type(fcn) of {
       "procedure" | "integer" | "string" : {
 	 suspend fcn!args
 	 }
       "list" : {
-	 fcn := copy(fcn)
-         f := pull(fcn)
+	 fcn := ::copy(fcn)
+         f := ::pull(fcn)
 	 every i := 1 to *fcn do {
 	    if fcn[i] === Arg then {
-	       fcn[i] := pop(args) | &null
+	       fcn[i] := ::pop(args) | &null
 	       }
 	    }
 	 suspend f!(fcn ||| args)

--- a/uni/lib/format.icn
+++ b/uni/lib/format.icn
@@ -18,9 +18,9 @@ procedure format_string_to_int(subject, base)
    /base := 16
    digs := "0123456789abcdef"[1:base + 1] | fail
 
-   s := string(subject) | fail
-   every c := !map(s) do
-      n := base * n + find(c, digs) - 1 | fail
+   s := ::string(subject) | fail
+   every c := !::map(s) do
+      n := base * n + ::find(c, digs) - 1 | fail
    return n
 end
 
@@ -36,7 +36,7 @@ procedure format_int_to_string(subject, base, p)
    s := ""
    /base := 16
    /p := 1
-   n := integer(subject) | fail
+   n := ::integer(subject) | fail
 
    digs := "0123456789ABCDEF"[1:base + 1] | fail
    while n > 0 do {
@@ -45,7 +45,7 @@ procedure format_int_to_string(subject, base, p)
    }
 
    if p > *s then
-      s := repl("0", p - *s) || s
+      s := ::repl("0", p - *s) || s
 
    return s
 end
@@ -59,72 +59,72 @@ end
 # @         are introduced into the non-fractional part of the number;
 # @         if c contains {'+'} then a leading + is added to positive
 # @         numbers.
-# @           
+# @
 #
 procedure format_numeric_to_string(subject, p, f)
    local n1, s, t, lim, d, zs, dig, i, n, sig_digs
 
    /f := ''
-   n := numeric(subject) | fail
+   n := ::numeric(subject) | fail
    sig_digs := 16 - 2
    /p := 4
-   n1 := abs(n)
-   if not any(f, "e") & type(n1) == "integer" then 
-      s := string(n1) || repl("0", p)
+   n1 := ::abs(n)
+   if not ::any(f, "e") & ::type(n1) == "integer" then
+      s := ::string(n1) || ::repl("0", p)
    else {
       t := format_norm(n1)
-      lim := if any(f, "e") then p else p + t[2]
+      lim := if ::any(f, "e") then p else p + t[2]
       if lim >= -1 then {
          s := ""
          d := t[1]
          if lim > sig_digs then {
-            zs := repl("0", lim - sig_digs)
+            zs := ::repl("0", lim - sig_digs)
             lim := sig_digs
          }
          every 0 to lim do {
-            s ||:= dig := integer(d)
+            s ||:= dig := ::integer(d)
             d := (d - dig) * 10.0
          }
-         if integer(d) >= 5 then {
+         if ::integer(d) >= 5 then {
             (every i := *s to 1 by -1 do
              if s[i] := 10 > s[i] + 1 then break
              else s[i] := 0
              ) | {          # need to add 1 to left of s
                 s := "1" || s
-                if any(f, "e") then {
+                if ::any(f, "e") then {
                    s[-1] := ""
                    t[2] +:= 1
                 }
              }
          }
          s ||:= \zs
-         s := repl("0", 0 < p + 1 - *s) || s
-      } 
-      else s := repl("0", p + 1)
+         s := ::repl("0", 0 < p + 1 - *s) || s
+      }
+      else s := ::repl("0", p + 1)
    }
 
-   if any(f, ",") then
+   if ::any(f, ",") then
       every s[*s - p - 3 to 1 by -3] ||:= ","
 
    if p > 0 then {
       s[-p - 1] ||:= "."
-      if any(f, "s"| "z") then {
-         "0" ~== s[i := *s to *s - p + 1 by -1]         
-         s[i + 1 : 0] := if any(f, "s") then
-            repl(" ", *s - i)
+      if ::any(f, "s"| "z") then {
+         "0" ~== s[i := *s to *s - p + 1 by -1]
+         s[i + 1 : 0] := if ::any(f, "s") then
+            ::repl(" ", *s - i)
          else ""
       }
    }
-   if n < 0 & upto('123456789', s) then
+   if n < 0 & ::upto('123456789', s) then
       s := "-" || s
    else
-      if any(f, "+") then 
+      if ::any(f, "+") then
          s := "+" || s
 
-   return if any(f, "e") then
-      s || "E" || (if t[2] < 0 then "-" else "+") || 
-      right(abs(t[2]), 3, "0")
-   else s   
+   return if ::any(f, "e") then
+      s || "E" || (if t[2] < 0 then "-" else "+") ||
+      ::right(::abs(t[2]), 3, "0")
+   else s
 end
 
 procedure format_norm(n)
@@ -144,7 +144,7 @@ procedure format_norm(n)
       ve -:= 1
    }
 
-   # invariant : 1 <= m < pwr[1 + ve] & m * 10 ^ e = m0 
+   # invariant : 1 <= m < pwr[1 + ve] & m * 10 ^ e = m0
    while m >= 10.0 do {
       if m /:= (m >= pwr[ve]) then
          e +:= 2 ^ (ve - 1)
@@ -153,7 +153,7 @@ procedure format_norm(n)
 
    if n < 1.0 then {
       e := -e
-      if m := 10.0 / (1.0 ~= m) then 
+      if m := 10.0 / (1.0 ~= m) then
          e -:= 1
    }
    return [m, e]
@@ -166,23 +166,23 @@ end
 procedure format_unescape(subject)
    local s, res, ch
 
-   s := string(subject) | fail
-   
+   s := ::string(subject) | fail
+
    res := ""
    s ? {
       repeat {
-         res ||:= tab(upto('\\') | 0)
-         if pos(0) then
+         res ||:= ::tab(::upto('\\') | 0)
+         if ::pos(0) then
             break
-         move(1)
-         if any('01234567') then
-            res ||:= char(format_string_to_int(move(3), 8))
+         ::move(1)
+         if ::any('01234567') then
+            res ||:= ::char(format_string_to_int(::move(3), 8))
          else if ="x" then
-            res ||:= char(format_string_to_int(move(2), 16))
+            res ||:= ::char(format_string_to_int(::move(2), 16))
          else if ="^" then
-            res ||:= char(map(move(1)) + 1 - ord("a"))
+            res ||:= ::char(::map(::move(1)) + 1 - ::ord("a"))
          else {
-            ch := move(1) | "\""
+            ch := ::move(1) | "\""
             res ||:= case ch of {
                "z" : ""
                "n" : "\n"
@@ -211,17 +211,17 @@ procedure format_escape(subject)
    local s, res, ch
    static printable
    initial
-      printable := cset(&ascii[33:128]) -- '\\'
+      printable := ::cset(&ascii[33:128]) -- '\\'
 
-   s := string(subject) | fail
-   
+   s := ::string(subject) | fail
+
    res := ""
    s ? {
       repeat {
-         res ||:= tab(many(printable))
-         if pos(0) then
+         res ||:= ::tab(::many(printable))
+         if ::pos(0) then
             break
-         ch := move(1)
+         ch := ::move(1)
          res ||:= case ch of {
             "\n" : "\\n"
             "\l" : "\\l"
@@ -233,7 +233,7 @@ procedure format_escape(subject)
             "\v" : "\\v"
             "\f" : "\\f"
             "\\" : "\\\\"
-            default  :  "\\x" || format_int_to_string(ord(ch), 16, 2)
+            default  :  "\\x" || format_int_to_string(::ord(ch), 16, 2)
          }
       }
    }
@@ -249,7 +249,7 @@ procedure format_int_to_words(subject)
 
    initial {
       small := ["One", "Two", "Three", "Four", "Five", "Six",
-                "Seven", "Eight", "Nine", "Ten", "Eleven", 
+                "Seven", "Eight", "Nine", "Ten", "Eleven",
                 "Twelve", "Thirteen", "Fourteen", "Fifteen",
                 "Sixteen", "Seventeen", "Eighteen", "Nineteen"]
 
@@ -261,7 +261,7 @@ procedure format_int_to_words(subject)
       pwr10num := [1000000, 1000, 100]
    }
 
-   n := integer(subject) | fail
+   n := ::integer(subject) | fail
 
    s := ""
 

--- a/uni/lib/group.icn
+++ b/uni/lib/group.icn
@@ -11,7 +11,7 @@ import util
 # zero or more mailboxes.
 #
 class Group : Address : Error(mailboxes, phrase)
-   method get_phrase() 
+   method get_phrase()
       return phrase
    end
 
@@ -19,7 +19,7 @@ class Group : Address : Error(mailboxes, phrase)
       phrase := x
    end
 
-   method get_mailboxes() 
+   method get_mailboxes()
       return mailboxes
    end
 
@@ -28,7 +28,7 @@ class Group : Address : Error(mailboxes, phrase)
    end
 
    method add_mailbox(x)
-      put(mailboxes, x)
+     ::put(mailboxes, x)
    end
 
    method to_rfc822()
@@ -48,7 +48,7 @@ class Group : Address : Error(mailboxes, phrase)
       local p
       p := mail::RFC822Parser()
       return p.parse_group(s, self) | error(p)
-   end   
+   end
 
    method generate_mailboxes()
       suspend !mailboxes

--- a/uni/lib/heap.icn
+++ b/uni/lib/heap.icn
@@ -46,7 +46,7 @@ class Heap : Object (L, f, p)
    #</p>
    method gen()
       local temp := Heap(,f,p)
-      temp.L := copy(L)
+      temp.L := ::copy(L)
       suspend |temp.get()
    end
 
@@ -73,7 +73,7 @@ class Heap : Object (L, f, p)
       initial call := invokeFcn
       if *L > 0 then {
          L[up:=1] :=: L[-1]
-	 result := pull(L)
+	 result := ::pull(L)
 	 while (down := 2*up) <= *L do {
 	    if call(p,call(f,L[down+1]), call(f,L[down])) then down +:= 1
 	    if call(p,call(f,L[down]),call(f,L[up])) then L[up]:=:L[down]
@@ -92,7 +92,7 @@ class Heap : Object (L, f, p)
       local i
       static call
       initial call := invokeFcn
-      put(L,a)
+      ::put(L,a)
       i := *L
       while call(p,call(f,L[i]), call(f,L[i/2])) do {
 	 L[i] :=: L[i/2]

--- a/uni/lib/httpclient.icn
+++ b/uni/lib/httpclient.icn
@@ -34,7 +34,7 @@ class HttpClient : NetClient(request,
                              http_error,
                              keep_alive_flag,
                              user_agent,
-                             redir_set, 
+                             redir_set,
                              auth_req_count,
                              auth_scheme,
                              basic_auth_header,
@@ -82,7 +82,7 @@ class HttpClient : NetClient(request,
    method write_request_headers()
       local e, v
       every e := !request.headers.sort() do {
-         e[1][1] := map(e[1][1], &lcase, &ucase)
+         e[1][1] := ::map(e[1][1], &lcase, &ucase)
          every v := !e[2] do
             write_line(e[1] || ": " || v) | fail
       }
@@ -105,19 +105,19 @@ class HttpClient : NetClient(request,
    method retrieve(request)
       self.request := request.clone()
       auth_req_count := 0
-      redir_set := set()
+      redir_set := ::set()
       repeat {
          http_error := &null
 
          retrieve_page() | fail
-         if find("200"|"206", result.get_status()) then
+         if ::find("200"|"206", result.get_status()) then
             return result
 
-         remove(\request.data_file)
+         ::remove(\request.data_file)
 
-         if find("401", result.get_status()) then
+         if ::find("401", result.get_status()) then
             handle_authentication() | fail
-         else if find("301"|"302"|"303"|"307", result.get_status()) then
+         else if ::find("301"|"302"|"303"|"307", result.get_status()) then
             handle_redirect() | fail
          else
             return on_http_error(result.get_status())
@@ -132,7 +132,7 @@ class HttpClient : NetClient(request,
       # A redirection, so extract the URL if possible.
       #
       l := result.get_first_header("Location") | return on_http_error("No Location in a redirect response")
-      if match("http://", l) then
+      if ::match("http://", l) then
          request.url := URL(l) | return on_http_error("Invalid Location in a redirect response:" || l)
       else
          #
@@ -140,11 +140,11 @@ class HttpClient : NetClient(request,
          # commonplace.
          #
          request.url.set_relative(l)
-      
+
       s := request.url.to_string()
-      if member(redir_set, s) then
+      if ::member(redir_set, s) then
          return on_http_error("Circular redirection detected:" || s)
-      insert(redir_set, s)
+      ::insert(redir_set, s)
 
       #
       # On a redirect, a POST becomes a GET.
@@ -170,15 +170,15 @@ class HttpClient : NetClient(request,
          return on_http_error("Failed to authenticate - correct username, password")
       auth_req_count +:= 1
 
-      s := result.get_first_header("www-authenticate") | 
+      s := result.get_first_header("www-authenticate") |
          return on_http_error("No WWW-Authenticate in a 401 response")
 
       t := parse_generic_header(s)
-      if member(t, "Basic") then {
+      if ::member(t, "Basic") then {
          auth_scheme := "Basic"
          return setup_basic_authentication()
       }
-      if member(t, "Digest") then {
+      if ::member(t, "Digest") then {
          auth_scheme := "Digest"
          return setup_digest_authentication()
       }
@@ -194,10 +194,10 @@ class HttpClient : NetClient(request,
       # Strip off any \r\n in result.
       s := ""
       b64h.encode_data(&null, request.username || ":" || request.password) ? repeat {
-         s ||:= tab(find("\r\n") | 0)
-         if pos(0) then
+         s ||:= ::tab(::find("\r\n") | 0)
+         if ::pos(0) then
             break
-         move(2)
+         ::move(2)
       }
       basic_auth_header := "Basic " || s
       return
@@ -208,22 +208,22 @@ class HttpClient : NetClient(request,
    method setup_digest_authentication(t)
       local algorithm, md5, qop_options
 
-      self.realm := \t["realm"] | 
+      self.realm := \t["realm"] |
          return on_http_error("WWW-Authenticate digest header didn't contain a realm")
-      self.nonce := \t["nonce"] | 
+      self.nonce := \t["nonce"] |
          return on_http_error("WWW-Authenticate digest header didn't contain a nonce")
-      self.opaque := t["opaque"] 
+      self.opaque := t["opaque"]
 
       algorithm := \t["algorithm"] | "MD5"
       self.nonce_count := 0
       self.cnonce := "0a4f113b"
-      
+
       #
       # Calculate HA1
       #
       md5 := MD5()
       md5.update(unq(request.username) || ":" || unq(realm) || ":" || request.password)
-      if map(unq(algorithm)) == "md5-sess" then {
+      if ::map(unq(algorithm)) == "md5-sess" then {
          md5.update(":" || unq(nonce) || ":" || unq(cnonce))
       }
       self.ha1 := md5.final_str()
@@ -231,12 +231,12 @@ class HttpClient : NetClient(request,
       #
       # Get the available qop values and select a qop.
       #
-      qop_options := set()
+      qop_options := ::set()
       \t["qop"] ? {
-         while(tab(upto(token_char))) do 
-            insert(qop_options, map(tab(many(token_char))))
+         while(::tab(::upto(token_char))) do
+            ::insert(qop_options, ::map(::tab(::many(token_char))))
       }
-      self.qop := member(qop_options, "auth-int" | "auth") | &null
+      self.qop := ::member(qop_options, "auth-int" | "auth") | &null
    end
 
    #
@@ -245,7 +245,7 @@ class HttpClient : NetClient(request,
       local md5, nc, h, t, hentity, ha2
 
       self.nonce_count +:= 1
-      nc := map(format_int_to_string(self.nonce_count, 16, 8))
+      nc := ::map(format_int_to_string(self.nonce_count, 16, 8))
       md5 := MD5()
       #
       # Calculate HA2
@@ -286,9 +286,9 @@ class HttpClient : NetClient(request,
    #
    # @p
    method unq(s)
-      if s[1] == "\"" then 
+      if s[1] == "\"" then
          s[1] := ""
-      if s[-1] == "\"" then 
+      if s[-1] == "\"" then
          s[-1] := ""
       return s
    end
@@ -298,18 +298,18 @@ class HttpClient : NetClient(request,
    method parse_generic_header(s)
       local t, k, v
 
-      t := table()
+      t := ::table()
       s ? repeat {
-         tab(upto(token_char)) | break
-         k := tab(many(token_char))
+         ::tab(::upto(token_char)) | break
+         k := ::tab(::many(token_char))
          if ="=" then {
-            if any('\"') then
+            if ::any('\"') then
                v := parse_quoted_string()
             else
-               v := tab(many(token_char)) | ""
+               v := ::tab(::many(token_char)) | ""
          } else
             v := &null
-         insert(t, k, v)
+         ::insert(t, k, v)
       }
       return t
    end
@@ -321,13 +321,13 @@ class HttpClient : NetClient(request,
       res := ""
       res ||:= ="\""
       repeat {
-         res ||:= tab(upto('\\\"') | 0)
-         if pos(0) then
+         res ||:= ::tab(::upto('\\\"') | 0)
+         if ::pos(0) then
             break
          if res ||:= ="\"" then
             break
-         if any('\\') then {
-            res ||:= move(2)
+         if ::any('\\') then {
+            res ||:= ::move(2)
          }
       }
       return res
@@ -358,13 +358,13 @@ class HttpClient : NetClient(request,
       local c, k, v, t
 
       s ? repeat {
-         tab(upto(token_char)) | break
-         k := tab(many(token_char))
+         ::tab(::upto(token_char)) | break
+         k := ::tab(::many(token_char))
          if ="=" then {
-            if any('\"') then
+            if ::any('\"') then
                v := parse_quoted_string()
             else
-               v := tab(upto(';') | 0)
+               v := ::tab(upto(';') | 0)
          } else
             v := &null
          if /c then {
@@ -372,7 +372,7 @@ class HttpClient : NetClient(request,
             c.name := k
             c.value := v
          } else {
-            case map(k) of {
+            case ::map(k) of {
                "expires" : {
                   t := Time()
                   if t.parse(v, "EEE, dd-MMM-yyyy hh:mm:ss zzz") then
@@ -396,21 +396,21 @@ class HttpClient : NetClient(request,
 
       every s := !result.get_headers("set-cookie") do {
          if c := parse_cookie_string(s) then {
-            domain := map(\c.domain | request.url.get_address())
-            if member(cookies, domain) then 
+            domain := ::map(\c.domain | request.url.get_address())
+            if ::member(cookies, domain) then
                paths := cookies[domain]
             else {
-               paths := table()
-               insert(cookies, domain, paths)
+               paths := ::table()
+               ::insert(cookies, domain, paths)
             }
 
             path := \c.path | request.url.get_file()
 
-            if member(paths, path) then
+            if ::member(paths, path) then
                vals := paths[path]
             else {
                vals := ClTable()
-               insert(paths, path, vals)
+               ::insert(paths, path, vals)
             }
             vals.insert(c.name, c)
          }
@@ -422,15 +422,15 @@ class HttpClient : NetClient(request,
    method create_cookie_header()
       local s, e, f, host, path, c, now
 
-      host := map(request.url.get_address())
+      host := ::map(request.url.get_address())
       path := request.url.get_file()
       now := Time()
       now.set_current_time()
       s := ""
-      every e := !sort(cookies) do {
+      every e := !::sort(cookies) do {
          if host[0-:*e[1]] == e[1] then {
-            every f := !reverse(sort(e[2])) do {
-               if match(f[1], path) then {
+            every f := !::reverse(::sort(e[2])) do {
+               if ::match(f[1], path) then {
                   every c := (!f[2].sort())[2] do {
                      if /c.expires | c.expires.after(now) then {
                         if *s > 0 then
@@ -453,10 +453,10 @@ class HttpClient : NetClient(request,
    # @p
    method dump_cookies()
       local c, e, f, g
-      every e := !sort(cookies) do {
-         write("domain:", e[1])
-         every f := !reverse(sort(e[2])) do {
-            write("\tpath:", f[1])
+      every e := !::sort(cookies) do {
+         ::write("domain:", e[1])
+         every f := !::reverse(::sort(e[2])) do {
+            ::write("\tpath:", f[1])
             every c := (!f[2].sort())[2] do {
                write("\t\t", c.to_string())
             }
@@ -485,7 +485,7 @@ class HttpClient : NetClient(request,
    # @p
    method maybe_open()
       if /connection | /open_url | open_url.get_address() ~== request.url.get_address() |
-         open_url.get_port() ~= request.url.get_port() then 
+         open_url.get_port() ~= request.url.get_port() then
       {
          close()
          set_server(request.url.get_address())
@@ -559,7 +559,7 @@ class HttpClient : NetClient(request,
          read_headers() | fail
 
          #
-         # A 100 ("Continue") result means go round again and get 
+         # A 100 ("Continue") result means go round again and get
          # the status/headers again - they follow immediately after
          # the end of the first headers.
          #
@@ -580,7 +580,7 @@ class HttpClient : NetClient(request,
       #
       # Close if told to do so.
       #
-      if map(result.get_first_header("connection")) == "close" then
+      if ::map(result.get_first_header("connection")) == "close" then
          close()
    end
 
@@ -601,7 +601,7 @@ class HttpClient : NetClient(request,
       else
          request.unset_header("range")
 
-      write_line(request.the_method || " " || request.url.get_file() || 
+      write_line(request.the_method || " " || request.url.get_file() ||
                  " HTTP/" || http_version) | fail
 
       if /request.post_data then {
@@ -635,14 +635,14 @@ class HttpClient : NetClient(request,
             #
             # A continuation line starts with a space or a tab.
             #
-            if any(' \t') then
-               val ||:= tab(0)
+            if ::any(' \t') then
+               val ||:= ::tab(0)
             else {
                # Add current header and start a new one.
                result.add_header(\key, val)
-               key := tab(upto(':') | 0)
+               key := ::tab(::upto(':') | 0)
                =": "
-               val := tab(0)
+               val := ::tab(0)
             }
          }
       }
@@ -658,7 +658,7 @@ class HttpClient : NetClient(request,
          # continue from the previous attempt.
          #
          if \request.data_file then
-            data_out := ::open(request.data_file, "a") | stop("Couldn't open ", request.data_file)
+            data_out := ::open(request.data_file, "a") | ::stop("Couldn't open ", request.data_file)
       } else {
          #
          # Set up either a new data file or a string buffer, and reset
@@ -667,9 +667,9 @@ class HttpClient : NetClient(request,
          if /request.data_file then
             string_buff := StringBuff()
          else
-            data_out := ::open(request.data_file, "w") | stop("Couldn't open ", request.data_file)
+            data_out := ::open(request.data_file, "w") | ::stop("Couldn't open ", request.data_file)
 
-         self.length := integer(result.get_first_header("content-length")) | &null
+         self.length := ::integer(result.get_first_header("content-length")) | &null
          self.read := 0
       }
 
@@ -682,7 +682,7 @@ class HttpClient : NetClient(request,
       #
       # Close the result
       #
-      if /request.data_file then 
+      if /request.data_file then
          result.set_data(string_buff.get_string())
       else {
          ::close(\data_out)
@@ -698,7 +698,7 @@ class HttpClient : NetClient(request,
       #
       # Read the data.
       #
-      if map(result.get_first_header("transfer-encoding")) == "chunked" then
+      if ::map(result.get_first_header("transfer-encoding")) == "chunked" then
          return read_chunked()
       else if /length then
          return read_to_eof()
@@ -713,13 +713,13 @@ class HttpClient : NetClient(request,
       repeat {
          l := read_line() | fail
          l ? {
-            chunk := integer("16r" || tab(many('0987654321abcdefABCDEF'))) |
+            chunk := ::integer("16r" || ::tab(::many('0987654321abcdefABCDEF'))) |
                return error("Expected chunk-length specifier; got " || l)
          }
          if chunk = 0 then
             break
          while chunk > 0 do {
-            s := read_str(min(1024, chunk)) | fail
+            s := read_str(::min(1024, chunk)) | fail
             add_some(s)
             chunk -:= *s
          }
@@ -804,7 +804,7 @@ class HttpClient : NetClient(request,
       if /request.data_file then
          string_buff.add(s)
       else
-         writes(data_out, s)
+         ::writes(data_out, s)
    end
 
    method set_one(attr, val)
@@ -827,7 +827,7 @@ class HttpClient : NetClient(request,
          token_char := &ascii[33:128] -- '()<>@,;:\\\"/[]?={} \t'
       }
       self.NetClient.initially()
-      cookies := table()
+      cookies := ::table()
       timeout := 12000
       keep_alive_flag := 1
       retries := 2

--- a/uni/lib/httpclient.icn
+++ b/uni/lib/httpclient.icn
@@ -364,7 +364,7 @@ class HttpClient : NetClient(request,
             if ::any('\"') then
                v := parse_quoted_string()
             else
-               v := ::tab(upto(';') | 0)
+               v := ::tab(::upto(';') | 0)
          } else
             v := &null
          if /c then {
@@ -458,7 +458,7 @@ class HttpClient : NetClient(request,
          every f := !::reverse(::sort(e[2])) do {
             ::write("\tpath:", f[1])
             every c := (!f[2].sort())[2] do {
-               write("\t\t", c.to_string())
+               ::write("\t\t", c.to_string())
             }
          }
       }
@@ -517,7 +517,7 @@ class HttpClient : NetClient(request,
          close()
 
          if (i -:= 1) < 0 then {
-            remove(\request.data_file)
+            ::remove(\request.data_file)
             fire("Failed")
             if retries = 0 then
                fail
@@ -563,7 +563,7 @@ class HttpClient : NetClient(request,
          # the status/headers again - they follow immediately after
          # the end of the first headers.
          #
-         find("100", result.get_status()) | break
+         ::find("100", result.get_status()) | break
       }
 
       if request.the_method ~=== "HEAD" then
@@ -652,7 +652,7 @@ class HttpClient : NetClient(request,
    #
    # @p
    method read_data()
-      if find("206", result.get_status()) then {
+      if ::find("206", result.get_status()) then {
          #
          # Continue a partial read.  The self.read and self.length values
          # continue from the previous attempt.

--- a/uni/lib/httprequest.icn
+++ b/uni/lib/httprequest.icn
@@ -39,18 +39,18 @@ class HttpRequest:SetFields:Object(url,
    end
 
    #
-   # Add a request header with the given key, after any existing ones 
+   # Add a request header with the given key, after any existing ones
    # with the same key
    #
    method add_header(key, val)
       if headers.member(key) then
-         put(headers.get(key), val)
+         ::put(headers.get(key), val)
       else
          headers.insert(key, [val])
    end
 
    #
-   # Set a request header with the given key; any existing headers with 
+   # Set a request header with the given key; any existing headers with
    # the same key are removed.
    #
    method set_header(key, val)
@@ -134,7 +134,7 @@ class HttpRequest:SetFields:Object(url,
       case attr of {
          "url": {
             s := string_val(attr, val)
-            u := URL(s) | stop("Bad URL:" || s)
+            u := URL(s) | ::stop("Bad URL:" || s)
             set_url(u)
          }
          "data_file": set_data_file(string_val(attr, val))

--- a/uni/lib/httpresponse.icn
+++ b/uni/lib/httpresponse.icn
@@ -41,16 +41,16 @@ class HttpResponse : Object(url, status, headers, data, data_file)
    # Succeed iff the status was an HTTP OK status.
    #
    method status_okay()
-      return find("200", status)
+      return ::find("200", status)
    end
 
    #
-   # Add a response header with the given key, after any existing ones 
+   # Add a response header with the given key, after any existing ones
    # with the same key
    #
    method add_header(key, val)
       if headers.member(key) then
-         put(headers.get(key), val)
+         ::put(headers.get(key), val)
       else
          headers.insert(key, [val])
    end
@@ -76,7 +76,7 @@ class HttpResponse : Object(url, status, headers, data, data_file)
    # Set the data of the response.
    #
    method set_data(s)
-      return data :=s 
+      return data :=s
    end
 
    #
@@ -114,12 +114,12 @@ class HttpResponse : Object(url, status, headers, data, data_file)
       local res, s
       res := []
       data ? {
-         while s := tab(upto('\n')) do {
-            put(res, s)
-            move(1)
+         while s := ::tab(::upto('\n')) do {
+            ::put(res, s)
+            ::move(1)
          }
-         if not(pos(0)) then
-            put(res, tab(0))
+         if not(::pos(0)) then
+            ::put(res, ::tab(0))
       }
       return res
    end

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -16,21 +16,11 @@ import util
 # Return the class name for the instance o
 #
 procedure get_class_name(o)
-local i
-   image(o) ? {
-      if ="object " then {
-	 # the last _ is the one to cut at
-	 every i := find("_")
-         return tab(\i) | stop("Not a class")
-      }
-      else if ="record " then {
-         return tab(find("__state")) | stop("Not a class")
-      }
-   }
+   return ::classname(o)
 end
 
 #
-# Get the Class object for this object  
+# Get the Class object for this object
 #
 procedure get_class(object)
    return lang::get_class_for_name(get_class_name(object))
@@ -41,19 +31,18 @@ end
 # this is the value returned by the {type()} function.  For records, it
 # is the string "record" and for classes it is the string "class".
 #
-procedure get_type(object) 
-   image(object) ? {
-      if ="record " then {
-         if find("__state") then
-            return "class"
-         else
+procedure get_type(object)
+   if ::classname(object) then {
+      return "class"
+   } else {
+      image(object) ? {
+         if ="record " then {
             return "record"
-	 }
-      else if ="object " then {
-	 return "class"
-	 }
-      else
-         return type(object)
+	    }
+         else {
+	    return type(object)
+	    }
+      }
    }
 end
 
@@ -65,15 +54,12 @@ end
 #
 procedure get_name(object)
    local s
-   image(object) ? {
-      if ="record " then {
-         if s := tab(find("__state")) then
-            return s
-         else
+   if s := ::classname(object) then {
+      return s
+   } else {
+      image(object) ? {
+         if ="record " then {
             return type(object)
-	 }
-      else if ="object " then {
-	 return get_class_name(object)
 	 }
       else if ="procedure " then
          return tab(0)
@@ -103,7 +89,7 @@ end
 #
 procedure get_id(object)
    image(object) ? {
-      while tab(find("_")) do 
+      while tab(find("_")) do
          move(1)
       return tab(find("("))
    }
@@ -275,7 +261,7 @@ procedure hash_string(s)
    local n
    n := *s
    every n +:= ord(!s \ 10)
-   return n 
+   return n
 end
 
 #
@@ -300,10 +286,10 @@ procedure hash_code(x, depth, seen)
 
    /seen := table()
    /depth := 3
-   
+
    if (depth = 0) | \seen[x] then
       return 0
-   
+
    n := 0
 
    case get_type(x) of {
@@ -330,10 +316,10 @@ procedure hash_code(x, depth, seen)
          n +:= hash_code(x[[]], depth - 1, seen)
          every n +:= hash_code(!sort(x) \ 10, depth - 1, seen)
       }
-      
+
       "string" :
          n +:= hash_string(x)
-      
+
       "cset" :
          n +:= hash_string(string(x))
 
@@ -416,7 +402,7 @@ procedure clone(o, seen)
          return res
       }
 
-      default : 
+      default :
          return o
    }
 end
@@ -495,7 +481,7 @@ procedure to_string(o, depth, seen)
 
          if is_instance(o, "lang__Object") then
             string_buff.add(o.to_string(depth, seen))
-         else 
+         else
             string_buff.add(object_to_string(o, depth, seen))
       }
 
@@ -504,10 +490,10 @@ procedure to_string(o, depth, seen)
 
       "null" :
          string_buff.add("&null")
-      
+
       "string" :
          string_buff.add("\"" || format_escape(o) || "\"")
-      
+
       "cset" :
          string_buff.add("\'" || format_escape(o) || "\'")
 
@@ -576,7 +562,7 @@ procedure to_string(o, depth, seen)
          string_buff.add(ty || "<" || get_id(o) || ">(" || get_name(o) || ")")
       }
 
-      default : 
+      default :
          string_buff.add("unknown type")
    }
 

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -15,6 +15,8 @@ import util
 #
 # Return the class name for the instance o
 #
+# <i>Deprecated in favor of function <tt>classname(o)</tt>.</i>
+#
 procedure get_class_name(o)
    return ::classname(o)
 end
@@ -76,8 +78,10 @@ end
 
 #
 # Return the id of the object, based on the string returned by {image()}.  For
-# types that do not produce such a value, this method will have undefined
-# results.
+# types that do not produce such a value, this method will fail for values that
+# do not have a serial number.
+#
+# <i>Deprecated in favor of function <tt>serial()</tt>.</i>
 #
 # @example
 # @ x := [1, 2 ,3]
@@ -93,38 +97,39 @@ procedure get_id(object)
 end
 
 #
-# Generate the record names for a record.  The results are undefined for a
-# non-record type of object.
+# Generate the record names for a record.  All other values/objects will cause
+# failure.
 #
 procedure generate_record_names(object)
-   local i
-   every i := 1 to *object do {
-      name(object[i]) ? {
-         tab(find("."))
-         move(1)
-         suspend tab(0)
+   if get_type(object) == "record" then {
+      suspend fieldnames(object)
+   }
+end
+
+#
+# Generate the names of the member variables of an object. All other values/objects
+# will cause failure.
+#
+procedure generate_member_names(object)
+   local l, el
+   if get_type(object) == "class" then {
+      l := membernames(object)
+      every el := !l do {
+         if el == ("__s" | "__m") then {
+            next
+         } else {
+            suspend el
+         }
       }
    }
 end
 
 #
-# Generate the names of the member variables of an object.  The results
-# are undefined for a non-class object.
-#
-procedure generate_member_names(object)
-   every name(object[1 to *object]) ? {
-      tab(find("."))
-      move(1)
-      suspend tab(0)
-   }
-end
-
-#
-# Generate the values of the member variables of an object.  The results
-# are undefined for a non-class object.
+# Generate the values of the member variables of an object.  All other values/objects
+# will cause failure.
 #
 procedure generate_class_members(object)
-   suspend object[1 to *object]
+   suspend object[generate_member_names(object)]
 end
 
 #

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -61,14 +61,15 @@ procedure get_name(object)
          if ="record " then {
             return type(object)
 	 }
-      else if ="procedure " then
-         return tab(0)
-      else if ="file(" then
-         return tab(-1)
-      else if ="window_" then {
-         tab(find("("))
-         move(1)
-         return tab(-1)
+         else if ="procedure " then
+            return tab(0)
+         else if ="file(" then
+            return tab(-1)
+         else if ="window_" then {
+            tab(find("("))
+            move(1)
+            return tab(-1)
+         }
       }
    }
 end
@@ -88,11 +89,7 @@ end
 # @ 5
 #
 procedure get_id(object)
-   image(object) ? {
-      while tab(find("_")) do
-         move(1)
-      return tab(find("("))
-   }
+   return ::serial(object)
 end
 
 #

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -166,7 +166,7 @@ end
 # Succeed iff the given object is an instance of the class with the given name.
 #
 procedure is_instance(obj, name)
-   return member(get_class_for(obj).get_implemented_classes(), name)
+   return ::member(lang::get_class_for(obj).get_implemented_classes(), lang::mapPackageInt2Ext(name))
 end
 
 #

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -210,7 +210,7 @@ procedure equals(x, y, seen)
          #
          # If x subclasses Object, use its .equals method.
          #
-         if is_instance(x, "lang__Object") then
+         if is_instance(x, "lang::Object") then
             return x.equals(y, seen)
          else
             return object_equals(x, y, seen)
@@ -298,7 +298,7 @@ procedure hash_code(x, depth, seen)
    case get_type(x) of {
       "class" : {
          seen[x] := 1
-         if is_instance(x, "lang__Object") then
+         if is_instance(x, "lang::Object") then
             return x.hash_code(depth, seen)
          else
             return object_hash_code(x, depth, seen)
@@ -367,7 +367,7 @@ procedure clone(o, seen)
 
    case ty of {
       "class" : {
-         if is_instance(o, "lang__Object") then {
+         if is_instance(o, "lang::Object") then {
             t := o.clone(seen)
             seen[o] := t
             return t
@@ -482,7 +482,7 @@ procedure to_string(o, depth, seen)
       "class" : {
          seen[o] := 1
 
-         if is_instance(o, "lang__Object") then
+         if is_instance(o, "lang::Object") then
             string_buff.add(o.to_string(depth, seen))
          else
             string_buff.add(object_to_string(o, depth, seen))

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -38,12 +38,12 @@ procedure get_type(object)
    if ::classname(object) then {
       return "class"
    } else {
-      image(object) ? {
+      ::image(object) ? {
          if ="record " then {
             return "record"
 	    }
          else {
-	    return type(object)
+	    return ::type(object)
 	    }
       }
    }
@@ -60,18 +60,18 @@ procedure get_name(object)
    if s := ::classname(object) then {
       return s
    } else {
-      image(object) ? {
+      ::image(object) ? {
          if ="record " then {
-            return type(object)
+            return ::type(object)
 	 }
          else if ="procedure " then
-            return tab(0)
+            return ::tab(0)
          else if ="file(" then
-            return tab(-1)
+            return ::tab(-1)
          else if ="window_" then {
-            tab(find("("))
-            move(1)
-            return tab(-1)
+            ::tab(::find("("))
+            ::move(1)
+            return ::tab(-1)
          }
       }
    }
@@ -86,7 +86,7 @@ end
 #
 # @example
 # @ x := [1, 2 ,3]
-# @ write(image(x))
+# @ write(::image(x))
 # @ write(get_id(x))
 # @
 # @ Output:
@@ -103,7 +103,7 @@ end
 #
 procedure generate_record_names(object)
    if get_type(object) == "record" then {
-      suspend fieldnames(object)
+      suspend ::fieldnames(object)
    }
 end
 
@@ -114,7 +114,7 @@ end
 procedure generate_member_names(object)
    local l, el
    if get_type(object) == "class" then {
-      l := membernames(object)
+      l := ::membernames(object)
       every el := !l do {
          if el == ("__s" | "__m") then {
             next
@@ -147,7 +147,7 @@ end
 procedure cast(object, other)
    local i, t, s
 
-   t := table()
+   t := ::table()
    i := 1
    every s := generate_member_names(other) do {
       t[s] := i
@@ -175,9 +175,9 @@ end
 procedure object_equals(obj, other, seen)
    local i
 
-   /seen := table()
-   /seen[obj] := set()
-   insert(seen[obj], other)
+   /seen := ::table()
+   /seen[obj] := ::set()
+   ::insert(seen[obj], other)
    get_type(other) == "class" | fail
    get_name(obj) == get_name(other) | fail
    if *obj ~= *other then
@@ -194,9 +194,9 @@ end
 procedure equals(x, y, seen)
    local cx, cy, i
 
-   /seen := table()
+   /seen := ::table()
 
-   if member(\seen[x], y) then
+   if ::member(\seen[x], y) then
       return
 
    if get_type(x) ~== get_type(y) then
@@ -204,8 +204,8 @@ procedure equals(x, y, seen)
 
    case get_type(x) of {
       "class" : {
-         /seen[x] := set()
-         insert(seen[x], y)
+         /seen[x] := ::set()
+         ::insert(seen[x], y)
 
          #
          # If x subclasses Object, use its .equals method.
@@ -217,8 +217,8 @@ procedure equals(x, y, seen)
       }
 
       "record" : {
-         /seen[x] := set()
-         insert(seen[x], y)
+         /seen[x] := ::set()
+         ::insert(seen[x], y)
          get_name(x) == get_name(y) | fail
          if *x ~= *y then
             fail
@@ -228,8 +228,8 @@ procedure equals(x, y, seen)
       }
 
       "list" : {
-         /seen[x] := set()
-         insert(seen[x], y)
+         /seen[x] := ::set()
+         ::insert(seen[x], y)
          if *x ~= *y then
             fail
          every i := 1 to *x do
@@ -238,18 +238,18 @@ procedure equals(x, y, seen)
       }
 
       "set" : {
-         /seen[x] := set()
-         insert(seen[x], y)
+         /seen[x] := ::set()
+         ::insert(seen[x], y)
          if *x ~= *y then
             fail
-         return equals(sort(x), sort(y), seen)
+         return equals(::sort(x), ::sort(y), seen)
       }
 
       "table" : {
-         /seen[x] := set()
-         insert(seen[x], y)
+         /seen[x] := ::set()
+         ::insert(seen[x], y)
          equals(x[[]], y[[]]) | fail
-         return equals(sort(x), sort(y), seen)
+         return equals(::sort(x), ::sort(y), seen)
       }
 
       default : {
@@ -263,7 +263,7 @@ end
 procedure hash_string(s)
    local n
    n := *s
-   every n +:= ord(!s \ 10)
+   every n +:= ::ord(!s \ 10)
    return n
 end
 
@@ -272,7 +272,7 @@ end
 #
 procedure object_hash_code(o, depth, seen)
    local n
-   /seen := table()
+   /seen := ::table()
    /depth := 3
    seen[o] := 1
    n := 0
@@ -287,7 +287,7 @@ end
 procedure hash_code(x, depth, seen)
    local cx, cy, i, n
 
-   /seen := table()
+   /seen := ::table()
    /depth := 3
 
    if (depth = 0) | \seen[x] then
@@ -311,26 +311,26 @@ procedure hash_code(x, depth, seen)
 
       "set" : {
          seen[x] := 1
-         every n +:= hash_code(!sort(x) \ 10, depth - 1, seen)
+         every n +:= hash_code(!::sort(x) \ 10, depth - 1, seen)
       }
 
       "table" : {
          seen[x] := 1
          n +:= hash_code(x[[]], depth - 1, seen)
-         every n +:= hash_code(!sort(x) \ 10, depth - 1, seen)
+         every n +:= hash_code(!::sort(x) \ 10, depth - 1, seen)
       }
 
       "string" :
          n +:= hash_string(x)
 
       "cset" :
-         n +:= hash_string(string(x))
+         n +:= hash_string(::string(x))
 
       "integer" :
-         n +:= abs(x)
+         n +:= ::abs(x)
 
       "real" :
-         n +:= hash_string(string(x))
+         n +:= hash_string(::string(x))
 
       default :
          n +:= hash_string(get_name(x))
@@ -344,8 +344,8 @@ end
 procedure object_clone(o, seen)
    local res, i
 
-   /seen := table()
-   res := proc(get_name(o))()
+   /seen := ::table()
+   res := ::proc(get_name(o))()
    seen[o] := res
    every i := 1 to *o do
       res[i] := clone(o[i], seen)
@@ -358,7 +358,7 @@ end
 procedure clone(o, seen)
    local c, e, ty, res, t, i
 
-   /seen := table()
+   /seen := ::table()
 
    if res := \seen[o] then
       return res
@@ -376,7 +376,7 @@ procedure clone(o, seen)
       }
 
       "record" : {
-         res := proc(get_name(o))()
+         res := ::proc(get_name(o))()
          seen[o] := res
          every i := 1 to *o do
             res[i] := clone(o[i], seen)
@@ -384,23 +384,23 @@ procedure clone(o, seen)
       }
 
       "set" : {
-         res := set([])
+         res := ::set([])
          seen[o] := res
-         every insert(res, clone(!o, seen))
+         every ::insert(res, clone(!o, seen))
          return res
       }
 
       "list" : {
          res := []
          seen[o] := res
-         every put(res, clone(!o, seen))
+         every ::put(res, clone(!o, seen))
          return res
       }
 
       "table" : {
-         res := table(clone(o[[]], seen))
+         res := ::table(clone(o[[]], seen))
          seen[o] := res
-         every e := !sort(o) do
+         every e := !::sort(o) do
             res[clone(e[1], seen)] := clone(e[2], seen)
          return res
       }
@@ -416,7 +416,7 @@ end
 procedure object_to_string(o, depth, seen)
    local i, s, string_buff
 
-   /seen := table()
+   /seen := ::table()
    /depth := -1
    seen[o] := 1
    string_buff := StringBuff()
@@ -447,7 +447,7 @@ end
 procedure to_string(o, depth, seen)
    local ty, string_buff, s, i, e, pairs
 
-   /seen := table()
+   /seen := ::table()
    /depth := -1
 
    if \seen[o] then {
@@ -540,7 +540,7 @@ procedure to_string(o, depth, seen)
          if depth ~= 0 then {
             string_buff.add("def=")
             string_buff.add(to_string(o[[]], depth - 1, seen))
-            pairs := sort(o)
+            pairs := ::sort(o)
             string_buff.add("[")
             every e := !pairs do {
                string_buff.add(to_string(e[1], depth - 1, seen))
@@ -601,8 +601,8 @@ procedure call_by_name(f_name, f_args[])
    /f_args := []
    intName := ""
    f_name ? {
-       while intName ||:= tab(find("::")) || (move(2),"__")
-       intName ||:= tab(0)
+       while intName ||:= ::tab(::find("::")) || (::move(2),"__")
+       intName ||:= ::tab(0)
        }
    return intName ! f_args
 end

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -5,6 +5,7 @@
 #
 # Author: Robert Parlett (parlett@dial.pipex.com)
 #   Addition of call_by_name by Steve Wampler (sbw@tapestry.tucson.az.us)
+#   Changes to use standard Unicon functions.
 #
 invocable all
 

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -423,7 +423,7 @@ procedure object_to_string(o, depth, seen)
    string_buff.add(get_type(o) || " " || get_name(o) || "<" || get_id(o) || ">")
    if depth ~= 0 then {
       string_buff.add("(")
-      i := 3
+      i := 1
       every s := generate_member_names(o) do {
          string_buff.add(s || "=")
          string_buff.add(to_string(o[i], depth - 1, seen))

--- a/uni/lib/langprocs.icn
+++ b/uni/lib/langprocs.icn
@@ -25,7 +25,7 @@ end
 # Get the Class object for this object
 #
 procedure get_class(object)
-   return lang::get_class_for_name(get_class_name(object))
+   return lang::get_class_for(object)
 end
 
 #
@@ -165,7 +165,7 @@ end
 # Succeed iff the given object is an instance of the class with the given name.
 #
 procedure is_instance(obj, name)
-   return member(get_class_for_name(get_class_name(obj)).get_implemented_classes(), name)
+   return member(get_class_for(obj).get_implemented_classes(), name)
 end
 
 #

--- a/uni/lib/mapbytes.icn
+++ b/uni/lib/mapbytes.icn
@@ -30,9 +30,9 @@ class MapBytes: Object (inM, inMap, outM, outMap, blkSize)
    method mapIn(s:"")
       local ns := ""
       s ? {
-	 while ns ||:= map(outMap, inMap, move(*inMap))
-	 while ns ||:= map(outM,   inM,   move(*inM))
-	 ns ||:= tab(0)
+	 while ns ||:= ::map(outMap, inMap, ::move(*inMap))
+	 while ns ||:= ::map(outM,   inM,   ::move(*inM))
+	 ns ||:= ::tab(0)
 	 }
       return ns
    end
@@ -45,9 +45,9 @@ class MapBytes: Object (inM, inMap, outM, outMap, blkSize)
    method mapOut(s:"")
       local ns := ""
       s ? {
-	 while ns ||:= map(inMap, outMap, move(*outMap))
-	 while ns ||:= map(inM,   outM,   move(*outM))
-	 ns ||:= tab(0)
+	 while ns ||:= ::map(inMap, outMap, ::move(*outMap))
+	 while ns ||:= ::map(inM,   outM,   ::move(*outM))
+	 ns ||:= ::tab(0)
 	 }
       return ns
    end
@@ -60,7 +60,7 @@ class MapBytes: Object (inM, inMap, outM, outMap, blkSize)
 		    blockSize  # If present, overrides class' blkSize
                     )
       blockSize := adjBlockSize(blockSize)
-      while writes(outFile, mapIn(reads(inFile, blockSize)))
+      while ::writes(outFile, mapIn(::reads(inFile, blockSize)))
    end
 
    #<p>
@@ -71,7 +71,7 @@ class MapBytes: Object (inM, inMap, outM, outMap, blkSize)
 		     blockSize  # If present, overrides class' blkSize
                      )
       blockSize := adjBlockSize(blockSize)
-      while writes(outFile, mapOut(reads(inFile, blockSize)))
+      while ::writes(outFile, mapOut(::reads(inFile, blockSize)))
    end
 
    #<p>
@@ -101,8 +101,8 @@ initially(in,        # Arrangement of bytes found in input string
    blkSize := adjBlockSize(blockSize)
 
    # bootStrap to longest possible transposition strings...
-   inMap := string(&cset)
+   inMap := ::string(&cset)
    inMap := inMap[1+:(*inMap - (*inMap % (*inM)))]
    outMap := ""
-   inMap ? while(outMap ||:= map(outM, inM, move(*inM)))
+   inMap ? while(outMap ||:= ::map(outM, inM, ::move(*inM)))
 end

--- a/uni/lib/matrix_util.icn
+++ b/uni/lib/matrix_util.icn
@@ -111,7 +111,7 @@ end
 #</p>
 procedure m_binop(M1, M1, op)
    local R, i, j
-   /op := proc("+", 2)
+   /op := ::proc("+", 2)
 
    if (*M1 ~= *M2) | (*M1[1] ~= *M2[1]) then
       ::runerr(500, "nonequal matrix dimensions to m_binop")
@@ -153,7 +153,7 @@ end
 #<p>
 procedure m_unaryop(M, op)
    local R, i, j
-   /op := proc("-", 1)
+   /op := ::proc("-", 1)
 
    R = m_constant(*M, *M[1])
    every (i := 1 to *M, j := 1 to *M[1]) do
@@ -166,7 +166,7 @@ end
 #  <[returns <tt>-M</tt>]>
 #</p>
 procedure m_negative(M)
-   return m_unaryop(M, proc("-", 1))
+   return m_unaryop(M, ::proc("-", 1))
 end
 
 #<p>
@@ -311,7 +311,7 @@ procedure m_divide(M1,M2,addfun,subfun,mulfun,divfun,
    every i := 1 to n do {
       x := m_linearSolve(M2,m_col(M1, i),addfun,subfun,mulfun,divfun,
 			 addident,mulident,invertMetric) | fail
-      put(X, x)
+      ::put(X, x)
       }
    return m_transpose(X)
 end

--- a/uni/lib/matrix_util.icn
+++ b/uni/lib/matrix_util.icn
@@ -9,7 +9,7 @@
 #<p>
 # <i>This file is in the public domain.</i>
 #</p>
-   
+
 package util
 
 import lang
@@ -19,9 +19,9 @@ import lang
 #  <[returns a copy of matrix <tt>M</tt>]>
 #</p>
 procedure m_copy(M)
-   local i, R := list(*M)
+   local i, R := ::list(*M)
    every i := 1 to *R do
-      R[i] := copy(M[i])
+      R[i] := ::copy(M[i])
    return R
 end
 
@@ -34,9 +34,9 @@ end
 procedure m_constant(m,n,x:0.0)
    local A
    /n := m
-    
-   A := list(m)
-   every !A := list(n,x)
+
+   A := ::list(m)
+   every !A := ::list(n,x)
    return A
 end
 
@@ -51,7 +51,7 @@ end
 procedure m_identity(m,n, zero:0.0,one:1.0)
    local A, i
    /n := m
-    
+
    A := m_constant(m,n,zero)
    every i := 1 to m > n | m do A[i,i] := one
    return A
@@ -75,7 +75,7 @@ end
 #</p>
 procedure m_colswap(M,a,b)
    local i
-    
+
    every i := 1 to *M do {
       M[i,a] :=: M[i,b]
       }
@@ -114,7 +114,7 @@ procedure m_binop(M1, M1, op)
    /op := proc("+", 2)
 
    if (*M1 ~= *M2) | (*M1[1] ~= *M2[1]) then
-      runerr(500, "nonequal matrix dimensions to m_binop")
+      ::runerr(500, "nonequal matrix dimensions to m_binop")
 
    R = m_constant(*M1, *M1[1])
    every (i := 1 to *M1, j := 1 to *M1[1]) do
@@ -129,7 +129,7 @@ end
 #</p>
 procedure m_add(M1, M2)
    if (*M1 ~= *M2) | (*M1[1] ~= *M2[1]) then
-      runerr(500, "nonequal matrix dimensions to m_add")
+      ::runerr(500, "nonequal matrix dimensions to m_add")
    return m_binop(M1,M2,proc("+",2))
 end
 
@@ -140,7 +140,7 @@ end
 #</p>
 procedure m_subtract(M1, M2)
    if (*M1 ~= *M2) | (*M1[1] ~= *M2[1]) then
-      runerr(500, "nonequal matrix dimensions to m_subtract")
+      ::runerr(500, "nonequal matrix dimensions to m_subtract")
    return m_binop(M1,M2,proc("-",2))
 end
 
@@ -179,16 +179,16 @@ end
 #</p>
 procedure m_multiply(M1, M2, addident:0, addfcn, mulfcn)
    local R, i, j, k
-   /addfcn := proc("+", 2)
-   /mulfcn := proc("*", 2)
+   /addfcn := ::proc("+", 2)
+   /mulfcn := ::proc("*", 2)
 
    if (*M1[1] ~= *M2) then
-      runerr(500, "incompatible matrix dimensions to m_multiply")
+      ::runerr(500, "incompatible matrix dimensions to m_multiply")
 
    R := m_constant(*M1, *M2[1])
    every (i := 1 to *R, j := 1 to *R[1]) do {
       R[i,j] := addident
-      every k := 1 to *M2 do 
+      every k := 1 to *M2 do
          R[i,j] := invokeFcn(addfcn, R[i,j], invokeFcn(mulfcn, M1[i,k],M2[k,j]))
       }
    return R
@@ -206,20 +206,20 @@ end
 procedure m_lupDecomposition(M, subfcn, mulfcn, divfcn,
                              invertMetric, addident:0.0, mulident:1.0)
    local n, i, b, k, k2, p, j, L, U
-   /subfcn := proc("-", 2)
-   /mulfcn := proc("*", 2)
-   /divfcn := proc("/", 2)
-   /invertMetric := proc("abs", 1)
+   /subfcn := ::proc("-", 2)
+   /mulfcn := ::proc("*", 2)
+   /divfcn := ::proc("/", 2)
+   /invertMetric := ::proc("abs", 1)
 
    M := m_copy(M)
    n := *M
-   b := list(n)
+   b := ::list(n)
    every i := 1 to n do b[i] := i
    every k := 1 to n do {
       p := 0
       every i := k to n do
          if invokeFcn(invertMetric, M[i,k]) > p then {
-            p := abs(M[i,k])
+            p := ::abs(M[i,k])
             k2 := i
 	    }
       if p = 0 then fail
@@ -254,14 +254,14 @@ end
 #</p>
 procedure m_lupSolve(L,U,p,b,addfun,subfun,mulfun,divfun,addident:0.0)
    local n, i, j, y, x
-   /addfun := proc("+", 2)
-   /subfun := proc("-", 2)
-   /mulfun := proc("*", 2)
-   /divfun := proc("/", 2)
+   /addfun := ::proc("+", 2)
+   /subfun := ::proc("-", 2)
+   /mulfun := ::proc("*", 2)
+   /divfun := ::proc("/", 2)
 
    n := *L
-   y := list(n)
-   x := list(n)
+   y := ::list(n)
+   x := ::list(n)
    every i := 1 to n do {
       s := addident
       every j := 1 to i-1 do
@@ -307,7 +307,7 @@ procedure m_divide(M1,M2,addfun,subfun,mulfun,divfun,
                    addident,mulident,invertMetric)
    local X, i, n, x
    n := *M1
-   X := list()
+   X := ::list()
    every i := 1 to n do {
       x := m_linearSolve(M2,m_col(M1, i),addfun,subfun,mulfun,divfun,
 			 addident,mulident,invertMetric) | fail
@@ -342,17 +342,17 @@ end
 procedure m_write(args[])   # Matrices and output files
    local i, outfile
    outfile := &output
-   while arg := get(args) do {
-      case type(arg) of {
+   while arg := ::get(args) do {
+      case ::type(arg) of {
 	 "file": outfile := arg
 	 "list": {    # Assume it's a matrix!
 	    every i := !M do {
-	       every writes(outfile, !i," ")
-	       write(outfile)
+	       every ::writes(outfile, !i," ")
+	       ::write(outfile)
 	       }
 	    }
-	 default: writes(outfile, arg)
+	 default: ::writes(outfile, arg)
 	 }
       }
-   write(outfile)
+   ::write(outfile)
 end

--- a/uni/lib/md5.icn
+++ b/uni/lib/md5.icn
@@ -32,51 +32,51 @@ $define BIT32 16rffffffff
 # @ s := m.final()
 #
 # This will leave s containing a 16 char string, being the
-# digest.   
+# digest.
 #
 class MD5(a, b, c, d, bit_count, buffer)
    method F(x, y, z)
-      return ior(iand(x, y), iand(icom(x), z));
+      return ::ior(::iand(x, y), ::iand(::icom(x), z));
    end
 
    method G(x, y, z)
-      return ior(iand(x, z), iand(y, icom(z)))
+      return ::ior(::iand(x, z), ::iand(y, ::icom(z)))
    end
 
    method H(x, y, z)
-      return ixor(ixor(x, y), z)
+      return ::ixor(::ixor(x, y), z)
    end
 
    method I(x, y, z)
-      return ixor(y, ior(x, icom(z)))
+      return ::ixor(y, ::ior(x, ::icom(z)))
    end
 
    method rotate_left(x, n)
-      return ior(ishift(x, n), ishift(iand(x, BIT32), -(32 - n)))
+      return ::ior(::ishift(x, n), ::ishift(::iand(x, BIT32), -(32 - n)))
    end
 
    method FF(a, b, c, d, x, s, ac)
       a +:= F(b, c, d) + x + ac
       a := rotate_left(a, s) + b
-      return iand(a, BIT32)
+      return ::iand(a, BIT32)
    end
 
    method GG(a, b, c, d, x, s, ac)
       a +:= G(b, c, d) + x + ac
       a := rotate_left(a, s) + b
-      return iand(a, BIT32)
+      return ::iand(a, BIT32)
    end
 
    method HH(a, b, c, d, x, s, ac)
       a +:= H(b, c, d) + x + ac
       a := rotate_left(a, s) + b
-      return iand(a, BIT32)
+      return ::iand(a, BIT32)
    end
 
    method II(a, b, c, d, x, s, ac)
       a +:= I(b, c, d) + x + ac
       a := rotate_left(a, s) + b
-      return iand(a, BIT32)
+      return ::iand(a, BIT32)
    end
 
    #
@@ -91,9 +91,9 @@ class MD5(a, b, c, d, bit_count, buffer)
 
       buffer ||:= input
       buffer ? {
-         while block := move(64) do
+         while block := ::move(64) do
             transform(block)
-         buffer := tab(0)
+         buffer := ::tab(0)
       }
    end
 
@@ -104,8 +104,8 @@ class MD5(a, b, c, d, bit_count, buffer)
    method final_str()
       local s
       s := ""
-      every s ||:= format_int_to_string(ord(!final()), 16, 2)
-      return map(s)
+      every s ||:= format_int_to_string(::ord(!final()), 16, 2)
+      return ::map(s)
    end
 
    #
@@ -115,15 +115,15 @@ class MD5(a, b, c, d, bit_count, buffer)
    method final()
       local bits, pad_len, s, padding
 
-      bits := encode(iand(bit_count, BIT32)) ||
-         encode(iand(ishift(bit_count, -32), BIT32))
+      bits := encode(::iand(bit_count, BIT32)) ||
+         encode(::iand(::ishift(bit_count, -32), BIT32))
 
       if *buffer < 56 then
          pad_len := 56 - *buffer
       else
          pad_len := 120 - *buffer
-      padding := char(16r80) || repl(char(0), pad_len - 1)
-      
+      padding := ::char(16r80) || ::repl(char(0), pad_len - 1)
+
       update(padding)
       update(bits)
 
@@ -212,20 +212,20 @@ class MD5(a, b, c, d, bit_count, buffer)
       c := II (c, d, a, b, x[ 3], S43, 16r2ad7d2bb)
       b := II (b, c, d, a, x[10], S44, 16reb86d391)
 
-      self.a := iand(self.a + a, BIT32)
-      self.b := iand(self.b + b, BIT32)
-      self.c := iand(self.c + c, BIT32)
-      self.d := iand(self.d + d, BIT32)
+      self.a := ::iand(self.a + a, BIT32)
+      self.b := ::iand(self.b + b, BIT32)
+      self.c := ::iand(self.c + c, BIT32)
+      self.d := ::iand(self.d + d, BIT32)
    end
 
    #
    # Transform a 32 bit number to 4 corresponding bytes
    # @p
    method encode(n)
-      return char(iand(n, 16rff)) ||
-         char(iand(ishift(n, -8), 16rff)) ||
-         char(iand(ishift(n, -16), 16rff)) ||
-         char(iand(ishift(n, -24), 16rff))
+      return ::char(::iand(n, 16rff)) ||
+         ::char(::iand(::ishift(n, -8), 16rff)) ||
+         ::char(::iand(::ishift(n, -16), 16rff)) ||
+         ::char(::iand(::ishift(n, -24), 16rff))
    end
 
    #
@@ -236,9 +236,9 @@ class MD5(a, b, c, d, bit_count, buffer)
       l := []
       block ? {
          repeat {
-            s := move(4) | break
-            put(l, ord(s[1]) + ishift(ord(s[2]), 8) +
-                ishift(ord(s[3]), 16) + ishift(ord(s[4]), 24))
+            s := ::move(4) | break
+            ::put(l, ::ord(s[1]) + ::ishift(::ord(s[2]), 8) +
+                ::ishift(::ord(s[3]), 16) + ::ishift(::ord(s[4]), 24))
          }
       }
       return l

--- a/uni/lib/message.icn
+++ b/uni/lib/message.icn
@@ -188,7 +188,7 @@ class Message:Error(headers, content, parser)
             # Not too big, so continue this line.
             l ||:= t
          }
-         if pos(0) then {
+         if ::pos(0) then {
             # Add any remainder.
             return fold1(res, l)
          }
@@ -212,7 +212,7 @@ class Message:Error(headers, content, parser)
    #
    method show_headers()
       local h
-      every h := !sort(headers) do {
+      every h := !::sort(headers) do {
          every ::write(h[1], ": ", !h[2])
       }
    end
@@ -294,7 +294,7 @@ class Message:Error(headers, content, parser)
    # @p
    method catenate_addresses(a, delim)
       local s, e
-      if type(a) == "list" then {
+      if ::type(a) == "list" then {
          s := ""
          every e := !a do {
             if *s > 0 then

--- a/uni/lib/message.icn
+++ b/uni/lib/message.icn
@@ -144,7 +144,7 @@ class Message:Error(headers, content, parser)
 
    #
    # Return a string representation of the message in RFC822 format.
-   # 
+   #
    method to_rfc822()
       local s, h
       s := ""
@@ -163,7 +163,7 @@ class Message:Error(headers, content, parser)
       local res, l, t
 
       # Drop trailing w/s
-      while any(' \t', s[-1]) do
+      while ::any(' \t', s[-1]) do
          s[-1] := ""
 
       # Check for simple quick case
@@ -178,8 +178,8 @@ class Message:Error(headers, content, parser)
          # Get a block of text being w/s followed by non-ws eg
          #             "   here"
          #
-         t := tab(many(' \t')) | ""
-         t ||:= tab(upto(' \t') | 0)
+         t := ::tab(::many(' \t')) | ""
+         t ||:= ::tab(::upto(' \t') | 0)
          if *l + *t > 78 then {
             # Too big, so start a new line.
             res := fold1(res, l)
@@ -213,7 +213,7 @@ class Message:Error(headers, content, parser)
    method show_headers()
       local h
       every h := !sort(headers) do {
-         every write(h[1], ": ", !h[2])
+         every ::write(h[1], ": ", !h[2])
       }
    end
 
@@ -222,8 +222,8 @@ class Message:Error(headers, content, parser)
    #
    method show_message()
       show_headers()
-      write()
-      write(content)
+      ::write()
+      ::write(content)
    end
 
    #
@@ -232,15 +232,15 @@ class Message:Error(headers, content, parser)
    method parse(data)
       local s
       data ? {
-         while s := tab(find("\r\n")) do {
-            move(2)
-            while any(' \t') do {
-               s ||:= tab(many(' \t'))
-               s ||:= tab(find("\r\n")) | return error("Unexpected end of message")
-               move(2)
+         while s := ::tab(::find("\r\n")) do {
+            ::move(2)
+            while ::any(' \t') do {
+               s ||:= ::tab(::many(' \t'))
+               s ||:= ::tab(::find("\r\n")) | return error("Unexpected end of message")
+               ::move(2)
             }
             if *s = 0 then {
-               content := tab(0)
+               content := ::tab(0)
                return
             }
             parser.parse_field(s, self) | return error(parser)
@@ -280,7 +280,7 @@ class Message:Error(headers, content, parser)
 
       s := ""
       every e := !l do {
-         if *s > 0 then 
+         if *s > 0 then
             s ||:= delim
          s ||:= e
       }
@@ -297,7 +297,7 @@ class Message:Error(headers, content, parser)
       if type(a) == "list" then {
          s := ""
          every e := !a do {
-            if *s > 0 then 
+            if *s > 0 then
                s ||:= delim
             s ||:= e
          }
@@ -313,7 +313,7 @@ class Message:Error(headers, content, parser)
    #
    method add_header(key, val)
       if headers.member(key) then
-         put(headers.get(key), val)
+         ::put(headers.get(key), val)
       else
          headers.insert(key, [val])
    end
@@ -362,7 +362,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "To" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "To" header is absent or cannot be parsed as a 
+   # @fail if the "To" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_to()
@@ -393,7 +393,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Reply-To" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "Reply-To" header is absent or cannot be parsed as a 
+   # @fail if the "Reply-To" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_reply_to()
@@ -424,7 +424,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Resent-To" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "Resent-To" header is absent or cannot be parsed as a 
+   # @fail if the "Resent-To" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_resent_to()
@@ -455,7 +455,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "cc" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "bcc" header is absent or cannot be parsed as a 
+   # @fail if the "bcc" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_cc()
@@ -486,7 +486,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Resent-cc" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "Resent-cc" header is absent or cannot be parsed as a 
+   # @fail if the "Resent-cc" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_resent_cc()
@@ -517,7 +517,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "bcc" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "bcc" header is absent or cannot be parsed as a 
+   # @fail if the "bcc" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_bcc()
@@ -548,7 +548,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Resent-bcc" header(s) as a list of {Address} instances.
    # @return a list of {Address} instances
-   # @fail if the "Reset-bcc" header is absent or cannot be parsed as a 
+   # @fail if the "Reset-bcc" header is absent or cannot be parsed as a
    # @     list of {Address}es
    #
    method get_resent_bcc()
@@ -579,7 +579,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "From" header(s) as a list of {Mailbox} instances.
    # @return a list of {Mailbox} instances
-   # @fail if the "From" header is absent or cannot be parsed as a 
+   # @fail if the "From" header is absent or cannot be parsed as a
    # @     list of {Mailbox}es
    #
    method get_from()
@@ -610,7 +610,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Sender" header as a {Mailbox} instance.
    # @return a {Mailbox}
-   # @fail if the "Sender" header is absent or cannot be parsed as a 
+   # @fail if the "Sender" header is absent or cannot be parsed as a
    # @     {Mailbox}
    #
    method get_sender()
@@ -660,7 +660,7 @@ class Message:Error(headers, content, parser)
    #
    # Get the "Resent-Sender" header as a {Mailbox} instance.
    # @return a {Mailbox}
-   # @fail if the "Resent-Sender" header is absent or cannot be parsed as a 
+   # @fail if the "Resent-Sender" header is absent or cannot be parsed as a
    # @     {Mailbox}
    #
    method get_resent_sender()
@@ -779,6 +779,6 @@ end
 procedure get_all_mailboxes(l)
    local res
    res := []
-   every put(res, (!l).generate_mailboxes())
+   every ::put(res, (!l).generate_mailboxes())
    return res
 end

--- a/uni/lib/messagehandler.icn
+++ b/uni/lib/messagehandler.icn
@@ -6,7 +6,7 @@ package mail
 
 class MessageHandler : TypeHandler()
    method can_handle(ct)
-      return (map(ct.get_type()) == "message") & (map(ct.get_subtype()) == "rfc822")
+      return (::map(ct.get_type()) == "message") & (::map(ct.get_subtype()) == "rfc822")
    end
 
    method convert_to_object(m,  data)

--- a/uni/lib/method.icn
+++ b/uni/lib/method.icn
@@ -16,9 +16,9 @@ class Method(as_proc, method_name, defining_class)
    # Get the procedure name, ec "Mypackage__Myclass_mymethod"
    #
    method get_procedure_name()
-      image(as_proc) ? {
+      ::image(as_proc) ? {
          ="procedure "
-         return tab(0)
+         return ::tab(0)
       }
    end
 

--- a/uni/lib/misc_util.icn
+++ b/uni/lib/misc_util.icn
@@ -21,7 +21,7 @@ package util
 # Unicon now initializes the seed by default, so this is largely moot.
 #</p>
 procedure initRandom()
-   return &random := integer(map("smhSMH","Hh:Mm:Ss",&clock))
+   return &random := ::integer(::map("smhSMH","Hh:Mm:Ss",&clock))
 end
 
 #<p>
@@ -30,8 +30,8 @@ end
 # <[returns a copy of the inverted table <tt>tbl</tt>]>
 #</p>
 procedure invertTable(tbl)   # Table to invert
-   local nTbl := table(), k
-   every k := key(tbl) do {
+   local nTbl := ::table(), k
+   every k := ::key(tbl) do {
       nTbl[tbl[k]] := k
       }
    return nTbl
@@ -55,22 +55,22 @@ end
 procedure deepcopy(A, cache)
    local k
 
-   /cache := table()       # used to handle multireferenced objects
+   /cache := ::table()       # used to handle multireferenced objects
    if \cache[A] then return cache[A]
 
-   case type(A) of {
+   case ::type(A) of {
       "table"|"list": {
-	 cache[A] := copy(A)
-	 every cache[A][k := key(A)] := deepcopy(A[k], cache)
+	 cache[A] := ::copy(A)
+	 every cache[A][k := ::key(A)] := deepcopy(A[k], cache)
 	 }
       "set": {
-	 cache[A] := set()
-	 every insert(cache[A], deepcopy(!A, cache))
+	 cache[A] := ::set()
+	 every ::insert(cache[A], deepcopy(!A, cache))
 	 }
       default: {
-	 cache[A] := copy(A)
-	 if match("record ",image(A)) then {
-	    every cache[A][k := key(A)] := deepcopy(A[k], cache)
+	 cache[A] := ::copy(A)
+	 if ::match("record ",::image(A)) then {
+	    every cache[A][k := ::key(A)] := deepcopy(A[k], cache)
 	    }
 	 }
       }
@@ -96,12 +96,12 @@ procedure breadthwalk(root,        # node of graph to start walk at
    local node, child, queue, visited
    /getChildren := defaultGenChildren
    queue := [root]
-   visited := set([root])
-   while node := get(queue) do {
+   visited := ::set([root])
+   while node := ::get(queue) do {
       every child := getChildren(node) do {
-	 if not member(visited, child) then {
-	    insert(visited, child)
-	    put(queue, child)
+	 if not ::member(visited, child) then {
+	    ::insert(visited, child)
+	    ::put(queue, child)
 	    }
 	 }
       suspend node
@@ -130,9 +130,9 @@ procedure depthwalk(root,        # node of graph to start walk at
 		    getChildren, # function that generates a node's children
 		    visited)     # ignore, <i>used internally.</i>
    /getChildren := defaultGenChildren
-   /visited := set()
-   if not member(visited, root) then {
-      insert(visited, root)
+   /visited := ::set()
+   if not ::member(visited, root) then {
+      ::insert(visited, root)
       suspend root | depthwalk(getChildren(root), getChildren, visited)
       }
 end
@@ -254,9 +254,9 @@ end
 # <[returns method named <tt>s</tt>]>
 #</p>
 procedure getMethod(c, s:string)
-   local L := list()
+   local L := ::list()
    c := c["__m"]
-   every put(L, genFieldsOne(s, '.'))
+   every ::put(L, genFieldsOne(s, '.'))
    every c := c[L[1 to *L-1]]
    return c[L[-1]]
 end
@@ -286,10 +286,10 @@ procedure buildStackTrace(n:0,  # starting distance from this call
    local L := []
    /ce := &current
    n -:= 1
-   while pName := image(proc(ce, n+:=1)) do {
-      fName := keyword("&file",ce, n) | "no file name"
-      fLine := keyword("&line",ce, n) | "no line number"
-      put(L, pName||" ["||fName||":"||fLine||"]" )
+   while pName := ::image(::proc(ce, n+:=1)) do {
+      fName := ::keyword("&file",ce, n) | "no file name"
+      fLine := ::keyword("&line",ce, n) | "no line number"
+      ::put(L, pName||" ["||fName||":"||fLine||"]" )
       }
    return L
 end

--- a/uni/lib/money.icn
+++ b/uni/lib/money.icn
@@ -18,7 +18,7 @@ class Money : Error : Object(units)
    # Return a string representation
    #
    method to_string()
-      return self.units / 100 || "." || right(abs(self.units % 100), 2, "0")
+      return self.units / 100 || "." || ::right(::abs(self.units % 100), 2, "0")
    end
 
    #
@@ -27,7 +27,7 @@ class Money : Error : Object(units)
    #
    method to_right_string(w)
       /w := 9
-      return right(self.to_string(), w)
+      return ::right(self.to_string(), w)
    end
 
    #
@@ -50,10 +50,10 @@ class Money : Error : Object(units)
    method parse(s)
       local pounds, r
       s ? {
-         if pounds := tab(upto('.')) then
-            r := integer(pounds) * 100 + integer(2(move(1), tab(0))) 
+         if pounds := ::tab(::upto('.')) then
+            r := ::integer(pounds) * 100 + ::integer(2(::move(1), ::tab(0)))
          else
-            r := integer(tab(0)) * 100
+            r := ::integer(::tab(0)) * 100
       }
       return set_units(\r)
    end

--- a/uni/lib/msg.icn
+++ b/uni/lib/msg.icn
@@ -29,7 +29,7 @@ class Msg(id)
    method send(o)
       static f
       initial {
-         f := loadfunc(LIB, "msg_send")
+         f := ::loadfunc(LIB, "msg_send")
       }
       f(id, lang::encode(o))
    end
@@ -40,7 +40,7 @@ class Msg(id)
    method receive()
       static f
       initial {
-         f := loadfunc(LIB, "msg_receive")
+         f := ::loadfunc(LIB, "msg_receive")
       }
       return lang::decode(f(id))
    end
@@ -52,7 +52,7 @@ class Msg(id)
    method attempt()
       static f
       initial {
-         f := loadfunc(LIB, "msg_receive_nowait")
+         f := ::loadfunc(LIB, "msg_receive_nowait")
       }
       return lang::decode(f(id))
    end
@@ -80,7 +80,7 @@ class Msg(id)
    method remove()
       static f
       initial {
-         f := loadfunc(LIB, "msg_remove")
+         f := ::loadfunc(LIB, "msg_remove")
       }
       f(id)
    end
@@ -100,7 +100,7 @@ end
 procedure open_public_msg(key)
    static f
    initial {
-      f := loadfunc(LIB, "msg_open_public")
+      f := ::loadfunc(LIB, "msg_open_public")
    }
    return Msg(f(key))
 end
@@ -111,7 +111,7 @@ end
 procedure create_public_msg(key)
    static f
    initial {
-      f := loadfunc(LIB, "msg_create_public")
+      f := ::loadfunc(LIB, "msg_create_public")
    }
    return Msg(f(key))
 end
@@ -122,7 +122,7 @@ end
 procedure create_private_msg()
    static f
    initial {
-      f := loadfunc(LIB, "msg_create_private")
+      f := ::loadfunc(LIB, "msg_create_private")
    }
    return Msg(f())
 end

--- a/uni/lib/multipart.icn
+++ b/uni/lib/multipart.icn
@@ -43,7 +43,7 @@ class Multipart : Error(preamble, parts, epilogue)
    end
 
    method add_part(m)
-      put(parts, m)
+      ::put(parts, m)
    end
 
    initially(a[])

--- a/uni/lib/multiparthandler.icn
+++ b/uni/lib/multiparthandler.icn
@@ -21,7 +21,7 @@ class MultipartHandler : TypeHandler()
          return error("Missing boundary parameter")
 
       data ? {
-         s := tab(find(b)) | return error("Missing boundary")
+         s := ::tab(::find(b)) | return error("Missing boundary")
          res.set_preamble(b)
          =b
          repeat {
@@ -36,7 +36,7 @@ class MultipartHandler : TypeHandler()
             sm.parse(data) | return error(sm)
             res.add_part(sm)
          }
-         res.set_epilogue(tab(0))
+         res.set_epilogue(::tab(0))
       }
 
       return res

--- a/uni/lib/multiparthandler.icn
+++ b/uni/lib/multiparthandler.icn
@@ -6,9 +6,9 @@ package mail
 
 class MultipartHandler : TypeHandler()
    method can_handle(ct)
-      return map(ct.get_type()) == "multipart"
+      return ::map(ct.get_type()) == "multipart"
    end
-   
+
    method convert_to_object(m, data)
       local s, res, b, ct, sm
 
@@ -30,7 +30,7 @@ class MultipartHandler : TypeHandler()
 
             ="\r\n" | return error("Unexpected char after boundary")
 
-            data := tab(find(b)) | return error("Boundary not found")
+            data := ::tab(::find(b)) | return error("Boundary not found")
             =b
             sm := Message()
             sm.parse(data) | return error(sm)
@@ -46,7 +46,7 @@ class MultipartHandler : TypeHandler()
       local b, s, ct, e
 
       b := generate_boundary(obj.get_parts())
-      
+
       ct := m.get_content_type()
 
       #
@@ -72,7 +72,7 @@ class MultipartHandler : TypeHandler()
 
       repeat {
          b := "boundary" || id
-         if find(b, (!l).get_content()) then
+         if ::find(b, (!l).get_content()) then
             id +:= 1
          else
             return b

--- a/uni/lib/netclient.icn
+++ b/uni/lib/netclient.icn
@@ -14,7 +14,7 @@ $include "posix.icn"
 # server and communicates using CRLF-terminated lines.
 #
 class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, timeout)
-   # 
+   #
    # Fail and set the error code, and close the connection.
    # @p
    method error_and_close(a)
@@ -86,7 +86,7 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
       if /timeout | (timeout = 0) then
          return syswrite(connection, s)
 
-      fcntl(connection, "F", "d")
+      ::fcntl(connection, "F", "d")
       t := milliseconds()
       while *s > 0 do {
          if i := syswrite(connection, s) then {
@@ -105,7 +105,7 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
 
    #
    # Get an error string based on &errno
-   # 
+   #
    method strerror()
       return sys_errstr(&errno) | ("&errno=" || &errno)
    end
@@ -116,7 +116,7 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
       local l
 
       if \timeout > 0 then {
-         l := select(connection, timeout) | return error("Failed to select:" || strerror())
+         l := ::select(connection, timeout) | return error("Failed to select:" || strerror())
          if *l = 0 then
             return error("Failed to select (timeout)")
       }
@@ -137,7 +137,7 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
    method write_line(s)
       /s := ""
       fire("Sending line", s)
-      return send(s || "\r\n") 
+      return send(s || "\r\n")
    end
 
    #
@@ -151,9 +151,9 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
          # Look for a line and if found return it.
          #
          sbuff ? {
-            if line := tab(find("\r\n")) then {
-               move(2)
-               sbuff := tab(0)
+            if line := ::tab(::find("\r\n")) then {
+               ::move(2)
+               sbuff := ::tab(0)
                fire("Read line", line)
                return line
             }
@@ -172,8 +172,8 @@ class NetClient:Connectable:Error:SetFields(server, port, connection, sbuff, tim
       #
       if *sbuff > 0 then {
          sbuff ? {
-            t := move(len) | tab(0)
-            sbuff := tab(0)
+            t := ::move(len) | ::tab(0)
+            sbuff := ::tab(0)
          }
       } else {
          t := recv(len) | fail

--- a/uni/lib/noophandler.icn
+++ b/uni/lib/noophandler.icn
@@ -9,14 +9,14 @@ package mail
 #
 class NoOpHandler:EncodingHandler()
    method can_handle(enc)
-      return map(enc) == ("7bit" | "8bit" | "binary")
+      return ::map(enc) == ("7bit" | "8bit" | "binary")
    end
 
    method decode_data(m, data)
       return data
    end
 
-   method encode_data(m, data) 
+   method encode_data(m, data)
       return data
   end
 end

--- a/uni/lib/notifier.icn
+++ b/uni/lib/notifier.icn
@@ -70,12 +70,12 @@ class Notifier:Object(listeners)
    #</p>
    method addListener(listener, typ:"default", methodname:"callback")
       if lang::isClass(listener) then connect(listener, methodname, typ)
-      else if type(listener) == ("procedure"|"co-expression"|"string") then {
+      else if ::type(listener) == ("procedure"|"co-expression"|"string") then {
          l := Subscription(listener,&null,typ)
          addToListeners(l)
          }
       else {
-         write(&errout, "Not ready to handle ",lang::Type(listener),
+         ::write(&errout, "Not ready to handle ",lang::Type(listener),
               " listeners yet.")
          fail
          }
@@ -93,7 +93,7 @@ class Notifier:Object(listeners)
    method removeListener(listener, typ:"default", methodname:"callback")
       every l := genListeners(typ) do {
          if lang::Type(l.obj)\1 == "string" then {   # Special case
-            if proc(l.obj) === listener then disconnect(l)
+            if ::proc(l.obj) === listener then disconnect(l)
             }
 	 else if (l.obj === listener) then {
             if lang::isClass(listener) &
@@ -148,7 +148,7 @@ class Notifier:Object(listeners)
       local l, p, sum
 
       p := lang::find_method(obj,meth_name) | {
-          write(&errout, "Connect: No such method '",meth_name,"'")
+          ::write(&errout, "Connect: No such method '",meth_name,"'")
           fail
           }
       # omit duplicate requests
@@ -168,7 +168,7 @@ class Notifier:Object(listeners)
    #</p>
    method addToListeners(l)
       /listeners[l.type] := []
-      put(listeners[l.type], l)
+      ::put(listeners[l.type], l)
 
       return l
    end
@@ -182,7 +182,7 @@ class Notifier:Object(listeners)
       local k := l.type, t
 
       t := []
-      every put(t, l ~=== !listeners[k])
+      every ::put(t, l ~=== !listeners[k])
       listeners[k] := t
    end
 
@@ -193,16 +193,16 @@ class Notifier:Object(listeners)
    #  <[param message message to pass to listener's callback]>
    #</p>
    method notify1(l, message)
-      case type(l.obj) of {
+      case ::type(l.obj) of {
 	 "procedure" | "string" : l.obj(lang::Type(self)\1, l.type, message)
 	 "co-expression" : [lang::Type(self)\1, l.type , message] @ l.obj
 	 # list invocation here uses substitution rules per future UniLib
 	 # integration.  This probably won't work well until that happens.
 	 "list": {
-             a := copy(l.obj)
-	     fcn := pop(a)
+             a := ::copy(l.obj)
+	     fcn := ::pop(a)
 	     args := [lang::Type(self)\1, l.type, param]
-	     every i := 1 to *a do if a[i] === Arg then a[i] := pop(args)
+	     every i := 1 to *a do if a[i] === Arg then a[i] := ::pop(args)
 	     suspend fcn ! a
 	     }
 	 default: if lang::isClass(l.obj) then notifyClass(l, message)
@@ -224,5 +224,5 @@ class Notifier:Object(listeners)
    end
 
 initially
-   listeners := table()
+   listeners := ::table()
 end

--- a/uni/lib/notifier.icn
+++ b/uni/lib/notifier.icn
@@ -112,7 +112,7 @@ class Notifier:Object(listeners)
    #  <[param typ event type (defaults to "default")]>
    #</p>
    method removeListeners(typ:"default")
-      delete(listeners, typ)
+      ::delete(listeners, typ)
    end
 
    #<p>

--- a/uni/lib/object.icn
+++ b/uni/lib/object.icn
@@ -102,7 +102,7 @@ class Object()
    method invoke(mName,    # Name of method to call
 		 args[])   # Remaining arguments are arguments to call
       if hasMethod(mName) then {
-	 suspend (self.__m[mName]) ! push(args, self)
+	 suspend (self.__m[mName]) ! ::push(args, self)
 	 }
    end
 

--- a/uni/lib/object.icn
+++ b/uni/lib/object.icn
@@ -53,7 +53,7 @@ class Object()
    end
 
    #
-   # Get the Class object for this object  
+   # Get the Class object for this object
    #
    method get_class()
       return lang::get_class(self)
@@ -91,7 +91,7 @@ class Object()
    # <[returns the classname for the current class in package::class format]>
    # </p>
    method className()
-      return Type()
+      return mapPackageInt2Ext(::classname(self))
    end
 
    # <p>
@@ -138,21 +138,23 @@ class Object()
    end
 
    #<p>
-   #   <[generates the names of all fields]>
+   #   <[generates the names of all fieldsmof an object]>
+   #   This now depends on lang::generate_member_names procedure which is no
+   #   longer dependent on the implementation details, but uses one of the
+   #   Unicon functions membernames().
    #</p>
    method fieldNames()
-      every ::name(self[1 to *self]) ? {
-	 &pos := upto('.')+1
-	 suspend tab(0)
-	 }
+      suspend lang::generate_member_names(self)
    end
 
    # <p>
    # What methods are available for this class?
    #    <[generates the names of all methods]>
+   #    remove implementation dependency and instead use Unicon function for this
+   #    information.
    # </p>
    method genMethods()
-      suspend fieldnames(self.__m)
+      suspend !::methodnames(self)
    end
 
    # <p>

--- a/uni/lib/pdb_util.icn
+++ b/uni/lib/pdb_util.icn
@@ -38,7 +38,7 @@ class PropertyUtil: Object(pdbTableName, dbu)
    #</p>
    method getTableFieldsDesc()
        local t
-       t := table()
+       t := ::table()
        t["propertyname"]  := "varchar(256)"
        t["propertyvalue"] := "text"
        return t

--- a/uni/lib/popclient.icn
+++ b/uni/lib/popclient.icn
@@ -91,28 +91,28 @@ class PopClient:NetClient(username, password)
    method list(n)
       local l, r, num, size, s
 
-      r := table()
-      
+      r := ::table()
+
       if /n then {
          send_command("LIST") | fail
          l := read_multi_lines() | fail
          every s := !l do {
             s ? {
-               num := integer(tab(many(&digits))) | return error("Bad list: " || s)
+               num := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
                =" "
-               size := integer(tab(many(&digits))) | return error("Bad list: " || s)
+               size := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
             }
-            insert(r, num, size)
+            ::insert(r, num, size)
          }
       }
       else {
          s := send_command("LIST " || n) | fail
          s ? {
-            num := integer(tab(many(&digits))) | return error("Bad list: " || s)
+            num := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
             =" "
-            size := integer(tab(many(&digits))) | return error("Bad list: " || s)
+            size := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
          }
-         insert(r, num, size)
+         ::insert(r, num, size)
       }
 
       return r
@@ -127,28 +127,28 @@ class PopClient:NetClient(username, password)
    method uidl(n)
       local l, r, num, id, s
 
-      r := table()
-      
+      r := ::table()
+
       if /n then {
          send_command("UIDL") | fail
          l := read_multi_lines() | fail
          every s := !l do {
             s ? {
-               num := integer(tab(many(&digits))) | return error("Bad list: " || s)
+               num := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
                =" "
-               id := tab(0)
+               id := ::tab(0)
             }
-            insert(r, num, id)
+            ::insert(r, num, id)
          }
       }
       else {
          s := send_command("UIDL " || n) | fail
          s ? {
-            num := integer(tab(many(&digits))) | return error("Bad list: " || s)
+            num := ::integer(::tab(::many(&digits))) | return error("Bad list: " || s)
             =" "
-            id := tab(0)
+            id := ::tab(0)
          }
-         insert(r, num, id)
+         ::insert(r, num, id)
       }
 
       return r
@@ -166,7 +166,7 @@ class PopClient:NetClient(username, password)
             s[1:3] := "."
          if s == "." then
             break
-         put(l, s)
+         ::put(l, s)
       }
       return l
    end
@@ -188,9 +188,9 @@ class PopClient:NetClient(username, password)
 
       s := send_command("STAT") | fail
       s ? {
-         num_messages := integer(tab(many(&digits))) | return error("Bad stat listing: " || s)
+         num_messages := ::integer(::tab(::many(&digits))) | return error("Bad stat listing: " || s)
          =" "
-         total_size := integer(tab(many(&digits))) | return error("Bad stat listing: " || s)
+         total_size := ::integer(::tab(::many(&digits))) | return error("Bad stat listing: " || s)
       }
 
       return [num_messages, total_size]
@@ -207,12 +207,12 @@ class PopClient:NetClient(username, password)
       s ? {
          if ="+OK" then {
             =" "
-            return tab(0)
+            return ::tab(0)
          }
 
          if ="-ERR" then {
             =" "
-            return error_and_close("Got an error: " || tab(0))
+            return error_and_close("Got an error: " || ::tab(0))
          }
       }
 

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -36,7 +36,7 @@ end
 #              Unicon type if <tt>var</tt> is not a class]>
 #</p>
 #<p>
-#   <p>Note:</b> For all entiries defined in packages, returns user-level
+#   <p>Note:</b> For all entities defined in packages, returns user-level
 #      form of name, e.g.: "package::class" instead of the internal form
 #      of name, e.g.: "package__class".
 #</p>

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -65,6 +65,8 @@ procedure mapPackageInt2Ext(s)
       if not find("::") then {
          ns ||:= tab(find("__")) || (move(2),"::")
          ns ||:= tab(0)
+      } else {
+         ns := s
       }
    }
    return ns

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -48,7 +48,7 @@ procedure Type(var)      # Object to examine
    if isClass(var) then {
       suspend mapPackageInt2Ext(!get_class(var).get_supers())
       }
-   else return mapPackageInt2Ext(type(var))
+   else return mapPackageInt2Ext(::type(var))
 end
 
 #<p>
@@ -62,9 +62,9 @@ end
 procedure mapPackageInt2Ext(s)
    local ns := ""
    s ? {
-      if not find("::") then {
-         ns ||:= tab(find("__")) || (move(2),"::")
-         ns ||:= tab(0)
+      if not ::find("::") then {
+         ns ||:= ::tab(::find("__")) || (::move(2),"::")
+         ns ||:= ::tab(0)
       } else {
          ns := s
       }
@@ -104,9 +104,9 @@ procedure istype(x,         # Object to examine
                  s)         # Type to check against
    local ss
 
-   if ss := string(s) then {
+   if ss := ::string(s) then {
       if ss == "numeric" then {
-         return numeric(x) & x
+         return ::numeric(x) & x
       } else {
          return ss == get_type(x) & x
       }

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -5,7 +5,9 @@
 #       Kevin Wampler
 #       Steve Wampler (<i>sbw@tapestry.tucson.az.us</i>)
 #</pre>
-#   This is one of several files contributing to the lang package.
+#   This is one of several files contributing to the lang package. Changes have
+#   been made to rationalise the code to use Unicon functions to avoid implementation
+#   dependencies.
 #</p>
 #<p>
 #  This file is in the <i>public domain</i>.
@@ -14,13 +16,15 @@
 package lang
 
 #<p>
-# How to tell if something is a class.
+# How to tell if something is a class. We now use the langprocs procedure instead
+# of implementation dependent code.
 # <i>This can be tricked, but only by evil people.</i>
+#
 # <[returns <tt>var</tt> if it's a class]>
 # <[fails if <tt>var</tt> is not a class]>
 #</p>
 procedure isClass(var)       # Object to examine
-   return (match("__state", type(var), -7), var)
+   return get_type(var) == "class" & var
 end
 
 #<p>
@@ -32,23 +36,26 @@ end
 #              Unicon type if <tt>var</tt> is not a class]>
 #</p>
 #<p>
-#   <p>Note:</b> For classes and records in packages, returns user-level
-#      form of name, e.g.: "package::class".
+#   <p>Note:</b> For all entiries defined in packages, returns user-level
+#      form of name, e.g.: "package::class" instead of the internal form
+#      of name, e.g.: "package__class".
 #</p>
 #<p>
+# We now use the langprocs procedure instead of implementation dependent code.
 #   <i>As with <tt>isClass()</tt>, this can be tricked by evil people.</i>
 #</p>
 procedure Type(var)      # Object to examine
    if isClass(var) then {
-      suspend mapPackageInt2Ext(util::zapSuffix(type(var), "__state") |
-				util::zapSuffix(type(!var.__m), "__methods"))
+      suspend mapPackageInt2Ext(!get_class(var).get_supers())
       }
    else return mapPackageInt2Ext(type(var))
 end
 
 #<p>
 #  <i>Intended for internal use only.</i>
-#  Map "package__object" into "package::object"
+#  Map "package__object" into "package::object". This is implementation dependent
+#  code and at present there is no Unicon function that returns the package
+#  information for any defined value.
 #</p>
 procedure mapPackageInt2Ext(s)
    local ns := ""
@@ -89,14 +96,20 @@ end
 #</p>
 procedure istype(x,         # Object to examine
                  s)         # Type to check against
-   case string(s) of {
-      "class"  : return isClass(x)
-      "record" : return isRecord(x)
-      "numeric": return 2(numeric(x), x)
-      default  : return 2(string(s) == Type(x), x )
+   local ss
+
+   if ss := string(s) then {
+      if ss == "numeric" then {
+         return numeric(x) & x
+      } else {
+         return ss == get_type(x) & x
       }
-   # Last gasp, maybe s is really a class instead of a classname
-   return 2(Type(s)\1 == Type(x), x )
+   } else {
+      #
+      # Last gasp, maybe s is really a class/object instead of a classname
+      #
+      return get_type(s) == Type(x) & x
+   }
 end
 
 #<p>
@@ -128,12 +141,13 @@ end
 
 #<p>
 # Is x a record?
-#   A class is NOT a record!
+#   A class is NOT a record! Use get_type(o) which returns "record" for all not
+#   object/class values that are records.
 #   <[returns <tt>x</tt> if <tt>x</tt> is a record]>
 #   <[fails if <tt>x</tt> is not a record]>
 #</p>
 procedure isRecord(x)        # Object to examine
-   return 3(image(x)[1:7] == "record", not isClass(x), x)
+   return (get_type(x) == "record" & x)
 end
 
 #<p>

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -55,14 +55,18 @@ end
 #  <i>Intended for internal use only.</i>
 #  Map "package__object" into "package::object". This is implementation dependent
 #  code and at present there is no Unicon function that returns the package
-#  information for any defined value.
+#  information for any defined value. It also checks that the name is not in
+#  external format first and if it finds it is then it will return it unchanged.
+#  This allows "__" to be used in external names.
 #</p>
 procedure mapPackageInt2Ext(s)
    local ns := ""
    s ? {
-      ns ||:= tab(find("__")) || (move(2),"::")
-      ns ||:= tab(0)
+      if not find("::") then {
+         ns ||:= tab(find("__")) || (move(2),"::")
+         ns ||:= tab(0)
       }
+   }
    return ns
 end
 

--- a/uni/lib/process.icn
+++ b/uni/lib/process.icn
@@ -22,19 +22,19 @@ class Process : Runnable(
    # Called by the parent process to start the child
    #
    method start()
-      pid := fork() | stop("Couldn't fork")
+      pid := ::fork() | ::stop("Couldn't fork")
       if pid = 0 then {
          invoke_run()
-         exit(0)
+         ::exit(0)
       }
    end
-   
+
    #
    # Called by the parent.  The method waits for the child to terminate,
    # and then closes the pipes.
    #
    method join()
-      wait(pid)
+      ::wait(pid)
       return
    end
 
@@ -42,7 +42,7 @@ class Process : Runnable(
    # Called by the parent to kill the child.  Then the {join} method is invoked.
    #
    method stop()
-      kill(pid, "SIGTERM")
+      ::kill(pid, "SIGTERM")
       join()
    end
 
@@ -50,7 +50,7 @@ class Process : Runnable(
    # Sleep for n milliseconds.
    #
    method sleep(n)
-      return delay(\n)
+      return ::delay(\n)
    end
 
    #
@@ -64,7 +64,7 @@ class Process : Runnable(
          self.runnable.run()
    end
 
-   ## 
+   ##
    # Set the runnable object as the code body of the process.
    #
    # @p

--- a/uni/lib/property.icn
+++ b/uni/lib/property.icn
@@ -43,7 +43,7 @@ package lang
 #        t["a"] := "hello"
 #        t["b"] := "world"
 #        Property().setP("B", t)
-#    
+#
 #        # Now, get the values
 #        write("A is ",Property().getP("A"))
 #        write("B is ",ximage(Property().getP("B")))
@@ -86,8 +86,8 @@ class SProperty : Object (pTable)
    #</p>
    method getAllNames()
       local k
-      k := set()
-      every insert(k, key(pTable))
+      k := ::set()
+      every ::insert(k, ::key(pTable))
       return k
    end
 
@@ -106,7 +106,7 @@ class SProperty : Object (pTable)
    # <[param value value for the named property]>
    # </p>
    method setP(name, value)
-      /pTable := table()
+      /pTable := ::table()
       pTable[name] := value
    end
 
@@ -114,7 +114,7 @@ class SProperty : Object (pTable)
    # Remove all properties from the database
    #</p>
    method clearAll()
-      pTable := table()
+      pTable := ::table()
    end
 
    #<p>
@@ -122,7 +122,7 @@ class SProperty : Object (pTable)
    # <[param pName name of property to remove]>
    #</p>
    method removeP(pName)
-      delete(pTable, pName)
+      ::delete(pTable, pName)
    end
 
    # <p>
@@ -131,7 +131,7 @@ class SProperty : Object (pTable)
    # <[return the current value of the named property]>
    # </p>
    method getP(pName)
-      /pTable := table()
+      /pTable := ::table()
       return pTable[pName]
    end
 
@@ -209,7 +209,7 @@ class Property : Object (pdb)
    method getAllProperties()
       local t, k
       t := pdb.fetchAll()
-      every k := key(t) do t[k] := Union().decode(t[k])
+      every k := ::key(t) do t[k] := Union().decode(t[k])
       return t
    end
 
@@ -283,5 +283,5 @@ class Property : Object (pdb)
 initially(user, passwd:"", dsn, tabl, uClass)
    if pdb := PropertyDB(user,passwd,dsn,tabl,uClass) then
        Property := create |self
-   else stop("Cannot open PropertyDB")
+   else ::stop("Cannot open PropertyDB")
 end

--- a/uni/lib/propertydb.icn
+++ b/uni/lib/propertydb.icn
@@ -33,10 +33,10 @@ class PropertyDB:Object(db, utils)
    method fetchAllNames()
       local nSet, row
       db.sql(utils.fetchAllNamesSQL())
-      nSet := set()
+      nSet := ::set()
       while row := db.fetch() do {
-         insert(nSet, row.propertyname)
-         } 
+         ::insert(nSet, row.propertyname)
+         }
       return nSet
    end
 
@@ -49,7 +49,7 @@ class PropertyDB:Object(db, utils)
    method fetchAll()
       local tabl, row
       db.sql(utils.fetchAllSQL())
-      tabl := table()
+      tabl := ::table()
       while row := db.fetch() do {
           tabl[row.propertyname] := row.propertyvalue
           }

--- a/uni/lib/pushback.icn
+++ b/uni/lib/pushback.icn
@@ -29,14 +29,14 @@ class PushBack : Object(f,        # Input file (defaults to <tt>&input</tt>)
    #   before reading a line from the file.
    #</p>
    method read()
-      return pop(pbBuffer) | reader(f)
+      return ::pop(pbBuffer) | reader(f)
    end
 
    #<p>
    #   Push a line back onto the input stream.
    #</p>
    method pushback(line)  # line to push back onto input stream
-      push(pbBuffer, line)
+      ::push(pbBuffer, line)
    end
 
 #<p>
@@ -46,5 +46,5 @@ initially (aFile) # File to read from
    /aFile := &input
    f := aFile
    pbBuffer := []
-   reader := proc("read")
+   reader := ::proc("read")
 end

--- a/uni/lib/quotedprintablehandler.icn
+++ b/uni/lib/quotedprintablehandler.icn
@@ -11,32 +11,32 @@ import util
 #
 class QuotedPrintableHandler:EncodingHandler(res, ll)
    method can_handle(enc)
-      return map(enc) == "quoted-printable"
+      return ::map(enc) == "quoted-printable"
    end
 
    method encode_data(m, data)
       local s
       static quotable_chars
       initial {
-         quotable_chars := cset(&ascii[33:62] || &ascii[63:128])
+         quotable_chars := ::cset(&ascii[33:62] || &ascii[63:128])
       }
 
       res := ""
       ll := 0
 
       data ? {
-         while not pos(0) do {
-            if s := tab(many(quotable_chars)) then {
-               if pos(0) & any(' \t', s[-1]) then {
-                  put(s[1:-1])
+         while not ::pos(0) do {
+            if s := ::tab(::many(quotable_chars)) then {
+               if ::pos(0) & ::any(' \t', s[-1]) then {
+                  ::put(s[1:-1])
                   escape(s[-1])
                } else {
-                  put(s)
+                  ::put(s)
                }
             } else if ="\r\n" then {
                nl()
             } else {
-               escape(move(1))
+               escape(::move(1))
             }
          }
       }
@@ -81,18 +81,18 @@ class QuotedPrintableHandler:EncodingHandler(res, ll)
       }
    end
 
-   method decode_data(m, data) 
+   method decode_data(m, data)
       local res
       res := ""
       data ? repeat {
-         res ||:= tab(upto('\r=') | 0)
-         if pos(0) then
+         res ||:= ::tab(::upto('\r=') | 0)
+         if ::pos(0) then
             break
-         if any('=') then {
-            move(1)
+         if ::any('=') then {
+            ::move(1)
             # If not a soft line break, then unescape the =XX format.
             if not ="\r\n" then {
-               res ||:= char(format_string_to_int(move(2))) | return error("Bad quoted-printable data")
+               res ||:= ::char(format_string_to_int(::move(2))) | return error("Bad quoted-printable data")
             }
          } else
             res ||:= ="\r\n" | return error("Bad quoted-printable data")

--- a/uni/lib/rfc822parser.icn
+++ b/uni/lib/rfc822parser.icn
@@ -45,7 +45,7 @@ class RFC822Parser : Error()
    end
 
    #
-   # qtext = <any CHAR excepting <">, "\" & CR, and including 
+   # qtext = <any CHAR excepting <">, "\" & CR, and including
    #         linear-white-space>
    # quoted-pair =  "\" CHAR
    # quoted-string = <"> *(qtext/quoted-pair) <">
@@ -55,14 +55,14 @@ class RFC822Parser : Error()
    method parse_quoted_string()
       local res
 
-      res := move(1)
+      res := ::move(1)
       repeat {
          if any('\\') then {
-            res ||:= move(2) | return parse_error("Unterminated quoted string")
-         } else if any(qtext_char) then
-            res ||:= tab(many(qtext_char))
-         else if any('\"') then {
-            return res || move(1)
+            res ||:= ::move(2) | return parse_error("Unterminated quoted string")
+         } else if ::any(qtext_char) then
+            res ||:= ::tab(::many(qtext_char))
+         else if ::any('\"') then {
+            return res || ::move(1)
          } else
             # Missing closing quote or illegal char
             return parse_error("Missing closing quote or illegal char")
@@ -76,7 +76,7 @@ class RFC822Parser : Error()
    # Must be preceded by a call to next_token()
    #
    method parse_atom()
-      return tab(many(atom_char))
+      return ::tab(::many(atom_char))
    end
 
    #
@@ -87,13 +87,13 @@ class RFC822Parser : Error()
    #
    method parse_domain_literal()
       local res
-      res := move(1)
+      res := ::move(1)
       repeat {
-         if any('\\') then
-            res ||:= move(2) | return parse_error("Premature end of field")
-         else if any(dtext_char) then
-            res ||:= tab(many(dtext_char))
-         else if any(']') then 
+         if ::any('\\') then
+            res ||:= ::move(2) | return parse_error("Premature end of field")
+         else if ::any(dtext_char) then
+            res ||:= ::tab(::many(dtext_char))
+         else if ::any(']') then
             return res || move(1)
          else
             # Missing closing ] or illegal char
@@ -106,16 +106,16 @@ class RFC822Parser : Error()
    #
    method parse_comment()
       local res
-      res := move(1)
+      res := ::move(1)
       repeat {
-         if any('\\') then
-            res ||:= move(2) | return parse_error("Premature end of field")
-         else if any(ctext_char) then
-            res ||:= tab(many(ctext_char))
-         else if any('(') then
+         if ::any('\\') then
+            res ||:= ::move(2) | return parse_error("Premature end of field")
+         else if ::any(ctext_char) then
+            res ||:= ::tab(::many(ctext_char))
+         else if ::any('(') then
             res ||:= parse_comment() | fail
-         else if any(')') then 
-            return res || move(1)
+         else if ::any(')') then
+            return res || ::move(1)
          else
             # Missing closing ) or illegal char
             return parse_error("Missing closing ) or illegal char")
@@ -124,8 +124,8 @@ class RFC822Parser : Error()
 
    method next_token()
       repeat {
-         tab(many(lwsp_char))
-         if any('(') then
+         ::tab(::many(lwsp_char))
+         if ::any('(') then
             parse_comment() | fail
          else
             return
@@ -135,22 +135,22 @@ class RFC822Parser : Error()
    #
    # word =  atom / quoted-string
    #
-   method parse_word() 
+   method parse_word()
       next_token() | fail
-      if any('\"') then
+      if ::any('\"') then
          return parse_quoted_string()
       else
          return parse_atom()
    end
 
    #
-   # local-part  =  word *("." word)             
+   # local-part  =  word *("." word)
    #
    method parse_local_part()
       local res
 
       res := parse_word() | fail
-      
+
       while res ||:= ="." do
          res ||:= parse_word() | fail
 
@@ -177,7 +177,7 @@ class RFC822Parser : Error()
    #
    method parse_sub_domain()
       next_token() | fail
-      if any('[') then
+      if ::any('[') then
          return parse_domain_literal()
       else
          return parse_atom()
@@ -185,7 +185,7 @@ class RFC822Parser : Error()
 
    #
    # phrase =  1*word
-   # 
+   #
    # In fact this is parsed as just "*word".  This allows
    # parsing of mailboxes such as, for example "<rparlett@xyz.com>" and
    # groups such as :joe@soap.com;
@@ -194,7 +194,7 @@ class RFC822Parser : Error()
       local res
       res := ""
       next_token() | fail
-      while any('\"' | atom_char) do {
+      while ::any('\"' | atom_char) do {
          # Single spaces between words
          if *res > 0 then
             res ||:= " "
@@ -221,15 +221,15 @@ class RFC822Parser : Error()
    end
 
    #
-   # route       =  1#("@" domain) ":" 
-   # where 1#X means '(X *("," X))' 
+   # route       =  1#("@" domain) ":"
+   # where 1#X means '(X *("," X))'
    #
    method parse_route(mb)
       mb.route := []
       repeat {
          next_token() | fail
          ="@" | return parse_error("@ expected")
-         put(mb.route, parse_domain()) | fail
+         ::put(mb.route, parse_domain()) | fail
          next_token() | fail
          ="," | break
          next_token() | fail
@@ -245,7 +245,7 @@ class RFC822Parser : Error()
    method parse_route_addr(mb)
       ="<" | return parse_error("< expected")
       next_token() | fail
-      if any('@') then
+      if ::any('@') then
          parse_route(mb) | fail
       else
          mb.route := []
@@ -271,7 +271,7 @@ class RFC822Parser : Error()
          mb.phrase := ""
          mb.route := []
       } else {
-         tab(x)
+         ::tab(x)
          mb.phrase := parse_phrase() | fail
          parse_route_addr(mb) | fail
       }
@@ -282,7 +282,7 @@ class RFC822Parser : Error()
    #
    # group =  phrase ":" [#mailbox] ";"
    # #X means empty or X,X,X...
-   #    
+   #
    method parse_group_impl(group)
       local mb
 
@@ -293,12 +293,12 @@ class RFC822Parser : Error()
       =":" | return parse_error(": expected")
 
       next_token() | fail
-      if any(';') then # empty group
-         move(1)
+      if ::any(';') then # empty group
+         ::move(1)
       else {
          repeat {
             mb := parse_mailbox_impl() | fail
-            put(group.mailboxes, mb)
+            ::put(group.mailboxes, mb)
             next_token() | fail
             ="," | break
          }
@@ -314,7 +314,7 @@ class RFC822Parser : Error()
       x := &pos
       if a := parse_mailbox_impl() then
          return a
-      tab(x)
+      ::tab(x)
 
       return parse_group_impl()
    end
@@ -325,12 +325,12 @@ class RFC822Parser : Error()
 
       if \can_be_empty then {
          next_token() | fail
-         if pos(0) then
+         if ::pos(0) then
             return l
       }
 
       repeat {
-         put(l, parse_mailbox_or_group()) | fail
+         ::put(l, parse_mailbox_or_group()) | fail
          next_token() | fail
          ="," | return l
       }
@@ -342,19 +342,19 @@ class RFC822Parser : Error()
 
       if \can_be_empty then {
          next_token() | fail
-         if pos(0) then
+         if ::pos(0) then
             return l
       }
 
       repeat {
-         put(l, parse_mailbox_impl()) | fail
+         ::put(l, parse_mailbox_impl()) | fail
          next_token() | fail
          ="," | return l
       }
    end
 
    #
-   # month =  "Jan"  /  "Feb" /  "Mar"  /  "Apr" /  "May"  /  "Jun" /  
+   # month =  "Jan"  /  "Feb" /  "Mar"  /  "Apr" /  "May"  /  "Jun" /
    #         "Jul"  /  "Aug" /  "Sep"  /  "Oct" /  "Nov"  /  "Dec"
    #
    method parse_month()
@@ -368,41 +368,41 @@ class RFC822Parser : Error()
    method parse_day()
       local s
       next_token() | fail
-      s := tab(many(&digits)) | return parse_error("digit expected")
+      s := ::tab(::many(&digits)) | return parse_error("digit expected")
       if *s <= 2 then
-         return integer(s)
+         return ::integer(s)
       return parse_error("invalid day: " || s)
    end
 
    method parse_year()
       local s
       next_token() | fail
-      s := tab(many(&digits)) | return parse_error("digit expected")
+      s := ::tab(::many(&digits)) | return parse_error("digit expected")
       if *s = (2 | 4) then
-         return integer(s)
+         return ::integer(s)
       return parse_error("invalid year: " || s)
    end
 
    method parse_2dig()
       local s
       next_token() | fail
-      s := tab(many(&digits)) | return parse_error("digit expected")
+      s := ::tab(::many(&digits)) | return parse_error("digit expected")
       if *s = 2 then
-         return integer(s)
+         return ::integer(s)
       return parse_error("2 digit field expected")
    end
 
    method parse_zone()
       next_token() | fail
-      tab(upto(tz_chars)) | return parse_error("Expected tz char")
-      return tab(many(tz_chars)) | return parse_error("Expected tz char")
+      ::tab(::upto(tz_chars)) | return parse_error("Expected tz char")
+      return ::tab(::many(tz_chars)) | return parse_error("Expected tz char")
    end
 
    #
    # date-time = [ day "," ] date time
    # day =  "Mon"  / "Tue" /  "Wed"  / "Thu"/  "Fri"  / "Sat" /  "Sun"
-   # date =  1*2DIGIT month 2DIGIT        
-   # time =  hour zone                    
+   # date =  1*2DIGIT month 2DIGIT
+   # time =  hour zone
    # hour =  2DIGIT ":" 2DIGIT [":" 2DIGIT]
    #
    method parse_date_time_impl()
@@ -424,8 +424,8 @@ class RFC822Parser : Error()
       =":" | return parse_error(": expected")
       mm := parse_2dig() | fail
       next_token() | fail
-      if any(':') then {
-         move(1)
+      if ::any(':') then {
+         ::move(1)
          ss := parse_2dig() | fail
       } else
          ss := 0
@@ -446,11 +446,11 @@ class RFC822Parser : Error()
    method parse_field_impl(message)
       local f, v
       next_token() | fail
-      f := tab(many(field_name_chars)) | return parse_error("Expect fieldname chars")
+      f := ::tab(::many(field_name_chars)) | return parse_error("Expect fieldname chars")
       next_token() | fail
       =":" | return parse_error(": expected")
       next_token() | fail
-      v := tab(0)
+      v := ::tab(0)
       message.add_header(f, v)
       return
    end
@@ -468,11 +468,11 @@ class RFC822Parser : Error()
    method parse_content_transfer_encoding_impl()
       local s
 
-      if s := tab(matchcl("7bit"|"quoted-printable"|"base64"|"8bit"|"binary")) then {
+      if s := ::tab(matchcl("7bit"|"quoted-printable"|"base64"|"8bit"|"binary")) then {
          return s
       }
 
-      if match("X-"|"x-") then
+      if ::match("X-"|"x-") then
          return parse_extension_token()
 
       return parse_error("Unknown encoding")
@@ -488,11 +488,11 @@ class RFC822Parser : Error()
    method parse_type()
       local s
 
-      if s := tab(matchcl("application"|"audio"|"image"|"message"|"multipart"|"text"|"video")) then {
+      if s := ::tab(matchcl("application"|"audio"|"image"|"message"|"multipart"|"text"|"video")) then {
          return s
       }
 
-      if match("X-"|"x-") then
+      if ::match("X-"|"x-") then
          return parse_extension_token()
 
       return parse_error("Unknown type")
@@ -506,11 +506,11 @@ class RFC822Parser : Error()
    method parse_disposition_type()
       local s
 
-      if s := tab(matchcl("inline"|"attachment")) then {
+      if s := ::tab(matchcl("inline"|"attachment")) then {
          return s
       }
 
-      if match("X-"|"x-") then
+      if ::match("X-"|"x-") then
          return parse_extension_token()
 
       return parse_error("Unknown Content-disposition type")
@@ -543,7 +543,7 @@ class RFC822Parser : Error()
    #            ; to use within parameter values
    #
    method parse_token_1521()
-      return tab(many(atom_char_1521))
+      return ::tab(::many(atom_char_1521))
    end
 
    #
@@ -580,7 +580,7 @@ class RFC822Parser : Error()
          next_token() | fail
          ="=" | return parse_error("= expected")
          next_token() | fail
-         if any('\"') then
+         if ::any('\"') then
             val :=  parse_quoted_string() | fail
          else
             val := parse_token_1521() | fail
@@ -624,7 +624,7 @@ class RFC822Parser : Error()
          next_token() | fail
          ="=" | return parse_error("= expected")
          next_token() | fail
-         if any('\"') then
+         if ::any('\"') then
             val :=  parse_quoted_string() | fail
          else
             val := parse_token_1521() | fail

--- a/uni/lib/rfc822parser.icn
+++ b/uni/lib/rfc822parser.icn
@@ -57,7 +57,7 @@ class RFC822Parser : Error()
 
       res := ::move(1)
       repeat {
-         if any('\\') then {
+         if ::any('\\') then {
             res ||:= ::move(2) | return parse_error("Unterminated quoted string")
          } else if ::any(qtext_char) then
             res ||:= ::tab(::many(qtext_char))
@@ -94,7 +94,7 @@ class RFC822Parser : Error()
          else if ::any(dtext_char) then
             res ||:= ::tab(::many(dtext_char))
          else if ::any(']') then
-            return res || move(1)
+            return res || ::move(1)
          else
             # Missing closing ] or illegal char
             return parse_error("Missing closing ] or illegal char")

--- a/uni/lib/rfc822pr.icn
+++ b/uni/lib/rfc822pr.icn
@@ -53,7 +53,7 @@ end
 #
 
 #
-# qtext = <any CHAR excepting <">, "\" & CR, and including 
+# qtext = <any CHAR excepting <">, "\" & CR, and including
 #         linear-white-space>
 # quoted-pair =  "\" CHAR
 # quoted-string = <"> *(qtext/quoted-pair) <">
@@ -63,14 +63,14 @@ end
 procedure parse_quoted_string()
    local res
 
-   res := move(1)
+   res := ::move(1)
    repeat {
-      if any('\\') then {
-         res ||:= move(2) | fail
-      } else if any(qtext_char) then
-         res ||:= tab(many(qtext_char))
-      else if any('\"') then {
-         return res || move(1)
+      if ::any('\\') then {
+         res ||:= ::move(2) | fail
+      } else if ::any(qtext_char) then
+         res ||:= ::tab(::many(qtext_char))
+      else if ::any('\"') then {
+         return res || ::move(1)
       } else
          # Missing closing quote or illegal char
          fail
@@ -84,7 +84,7 @@ end
 # Must be preceded by a call to next_token()
 #
 procedure parse_atom()
-   return tab(many(atom_char))
+   return ::tab(::many(atom_char))
 end
 
 #
@@ -95,14 +95,14 @@ end
 #
 procedure parse_domain_literal()
    local res
-   res := move(1)
+   res := ::move(1)
    repeat {
-      if any('\\') then
-         res ||:= move(2) | fail
-      else if any(dtext_char) then
-         res ||:= tab(many(dtext_char))
-      else if any(']') then 
-         return res || move(1)
+      if ::any('\\') then
+         res ||:= ::move(2) | fail
+      else if ::any(dtext_char) then
+         res ||:= ::tab(::many(dtext_char))
+      else if ::any(']') then
+         return res || ::move(1)
       else
          # Missing closing ] or illegal char
          fail
@@ -114,15 +114,15 @@ end
 #
 procedure parse_comment()
    local res
-   res := move(1)
+   res := ::move(1)
    repeat {
-      if any('\\') then
-         res ||:= move(2) | fail
-      else if any(ctext_char) then
-         res ||:= tab(many(ctext_char))
-      else if any('(') then
+      if ::any('\\') then
+         res ||:= ::move(2) | fail
+      else if ::any(ctext_char) then
+         res ||:= ::tab(::many(ctext_char))
+      else if ::any('(') then
          res ||:= parse_comment() | fail
-      else if any(')') then 
+      else if ::any(')') then
          return res || move(1)
       else
          # Missing closing ) or illegal char
@@ -132,8 +132,8 @@ end
 
 procedure next_token()
    repeat {
-      tab(many(lwsp_char))
-      if any('(') then
+      ::tab(::many(lwsp_char))
+      if ::any('(') then
          parse_comment() | fail
       else
          return
@@ -143,22 +143,22 @@ end
 #
 # word =  atom / quoted-string
 #
-procedure parse_word() 
+procedure parse_word()
    next_token() | fail
-   if any('\"') then
+   if ::any('\"') then
       return parse_quoted_string()
    else
       return parse_atom()
 end
 
 #
-# local-part  =  word *("." word)             
+# local-part  =  word *("." word)
 #
 procedure parse_local_part()
    local res
 
    res := parse_word() | fail
-   
+
    while res ||:= ="." do
       res ||:= parse_word() | fail
 
@@ -185,7 +185,7 @@ end
 #
 procedure parse_sub_domain()
    next_token() | fail
-   if any('[') then
+   if ::any('[') then
       return parse_domain_literal()
    else
       return parse_atom()
@@ -193,7 +193,7 @@ end
 
 #
 # phrase =  1*word
-# 
+#
 # In fact this is parsed as just "*word".  This allows
 # parsing of mailboxes such as, for example "<rparlett@xyz.com>" and
 # groups such as :joe@soap.com;
@@ -202,7 +202,7 @@ procedure parse_phrase()
    local res
    res := ""
    next_token() | fail
-   while any('\"' | atom_char) do {
+   while ::any('\"' | atom_char) do {
       # Single spaces between words
       if *res > 0 then
          res ||:= " "
@@ -229,8 +229,8 @@ procedure parse_addr_spec(mb)
 end
 
 #
-# route       =  1#("@" domain) ":" 
-# where 1#X means '(X *("," X))' 
+# route       =  1#("@" domain) ":"
+# where 1#X means '(X *("," X))'
 #
 procedure parse_route(mb)
    mb.route := []
@@ -253,7 +253,7 @@ end
 procedure parse_route_addr(mb)
    ="<" | fail
    next_token() | fail
-   if any('@') then
+   if ::any('@') then
       parse_route(mb) | fail
    else
       mb.route := []
@@ -282,7 +282,7 @@ procedure parse_mailbox(mb)
       mb.phrase := ""
       mb.route := []
    } else {
-      tab(x)
+      ::tab(x)
       mb.phrase := parse_phrase() | fail
       parse_route_addr(mb) | fail
    }
@@ -293,7 +293,7 @@ end
 #
 # group =  phrase ":" [#mailbox] ";"
 # #X means empty or X,X,X...
-#    
+#
 procedure parse_group(group)
    local mb
 
@@ -308,12 +308,12 @@ procedure parse_group(group)
    =":" | fail
 
    next_token() | fail
-   if any(';') then # empty group
+   if ::any(';') then # empty group
       move(1)
    else {
       repeat {
          mb := parse_mailbox() | fail
-         put(group.mailboxes, mb)
+         ::put(group.mailboxes, mb)
          next_token() | fail
          ="," | break
       }
@@ -329,7 +329,7 @@ procedure parse_mailbox_or_group()
    x := &pos
    if a := parse_mailbox() then
       return a
-   tab(x)
+   ::tab(x)
 
    return parse_group()
 end
@@ -340,7 +340,7 @@ procedure parse_address_list(can_be_empty)
 
    if \can_be_empty then {
       next_token() | fail
-      if pos(0) then
+      if ::pos(0) then
          return l
    }
 
@@ -357,19 +357,19 @@ procedure parse_mailbox_list(can_be_empty)
 
    if \can_be_empty then {
       next_token() | fail
-      if pos(0) then
+      if ::pos(0) then
          return l
    }
 
    repeat {
-      put(l, parse_mailbox()) | fail
+      ::put(l, parse_mailbox()) | fail
       next_token() | fail
       ="," | return l
    }
 end
 
 #
-# month =  "Jan"  /  "Feb" /  "Mar"  /  "Apr" /  "May"  /  "Jun" /  
+# month =  "Jan"  /  "Feb" /  "Mar"  /  "Apr" /  "May"  /  "Jun" /
 #         "Jul"  /  "Aug" /  "Sep"  /  "Oct" /  "Nov"  /  "Dec"
 #
 procedure parse_month()
@@ -383,41 +383,41 @@ end
 procedure parse_day()
    local s
    next_token() | fail
-   s := tab(many(&digits)) | fail
+   s := ::tab(::many(&digits)) | fail
    if *s <= 2 then
-      return integer(s)
+      return ::integer(s)
    fail
 end
 
 procedure parse_year()
    local s
    next_token() | fail
-   s := tab(many(&digits)) | fail
+   s := ::tab(::many(&digits)) | fail
    if *s = (2 | 4) then
-      return integer(s)
+      return ::integer(s)
    fail
 end
 
 procedure parse_2dig()
    local s
    next_token() | fail
-   s := tab(many(&digits)) | fail
+   s := ::tab(::many(&digits)) | fail
    if *s = 2 then
-      return integer(s)
+      return ::integer(s)
    fail
 end
 
 procedure parse_zone()
    next_token() | fail
-   tab(upto(tz_chars)) | fail
-   return tab(many(tz_chars)) | fail
+   ::tab(::upto(tz_chars)) | fail
+   return ::tab(::many(tz_chars)) | fail
 end
 
 #
 # date-time = [ day "," ] date time
 # day =  "Mon"  / "Tue" /  "Wed"  / "Thu"/  "Fri"  / "Sat" /  "Sun"
-# date =  1*2DIGIT month 2DIGIT        
-# time =  hour zone                    
+# date =  1*2DIGIT month 2DIGIT
+# time =  hour zone
 # hour =  2DIGIT ":" 2DIGIT [":" 2DIGIT]
 #
 procedure parse_date_time()
@@ -443,7 +443,7 @@ procedure parse_date_time()
    =":" | fail
    mm := parse_2dig() | fail
    next_token() | fail
-   if any(':') then {
+   if ::any(':') then {
       move(1)
       ss := parse_2dig() | fail
    } else
@@ -465,11 +465,11 @@ end
 procedure parse_field(message)
    local f, v
    next_token() | fail
-   f := tab(many(field_name_chars)) | fail
+   f := ::tab(::many(field_name_chars)) | fail
    next_token() | fail
    =":" | fail
    next_token() | fail
-   v := tab(0)
+   v := ::tab(0)
    message.add_header(f, v)
    return
 end

--- a/uni/lib/rfc822pr.icn
+++ b/uni/lib/rfc822pr.icn
@@ -123,7 +123,7 @@ procedure parse_comment()
       else if ::any('(') then
          res ||:= parse_comment() | fail
       else if ::any(')') then
-         return res || move(1)
+         return res || ::move(1)
       else
          # Missing closing ) or illegal char
          fail
@@ -237,7 +237,7 @@ procedure parse_route(mb)
    repeat {
       next_token() | fail
       ="@" | fail
-      put(mb.route, parse_domain()) | fail
+      ::put(mb.route, parse_domain()) | fail
       next_token() | fail
       ="," | break
       next_token() | fail
@@ -309,7 +309,7 @@ procedure parse_group(group)
 
    next_token() | fail
    if ::any(';') then # empty group
-      move(1)
+      ::move(1)
    else {
       repeat {
          mb := parse_mailbox() | fail
@@ -345,7 +345,7 @@ procedure parse_address_list(can_be_empty)
    }
 
    repeat {
-      put(l, parse_mailbox_or_group()) | fail
+      ::put(l, parse_mailbox_or_group()) | fail
       next_token() | fail
       ="," | return l
    }
@@ -444,7 +444,7 @@ procedure parse_date_time()
    mm := parse_2dig() | fail
    next_token() | fail
    if ::any(':') then {
-      move(1)
+      ::move(1)
       ss := parse_2dig() | fail
    } else
       ss := 0

--- a/uni/lib/scan_util.icn
+++ b/uni/lib/scan_util.icn
@@ -21,8 +21,8 @@ import lang
 #   <[returns an empty string, corresponding to a <tt>move(0)</tt>]>
 #</p>
 procedure snapshot(prefix:"")   # Precedes any output (default is "")
-   write(prefix, "'",&subject,"'")
-   write(prefix, " ",repl(" ",&pos-1),"^")
+   ::write(prefix, "'",&subject,"'")
+   ::write(prefix, " ",repl(" ",&pos-1),"^")
    return ""   # Makes this a matching procedure!
 end
 
@@ -38,8 +38,8 @@ procedure scanlocus(prefix:"", # Precedes any output (default is "")
 
    p1 := if &pos < n then 1 else &pos-(n/2)
    p2 := if (p1+n) > *&subject then 0 else p1+n
-   write(&errout, prefix, &subject[p1:p2])
-   write(&errout, prefix, repl(" ",&pos-p1), "^ ", &pos)
+   ::write(&errout, prefix, &subject[p1:p2])
+   ::write(&errout, prefix, ::repl(" ",&pos-p1), "^ ", &pos)
 
    return ""
 end
@@ -51,7 +51,7 @@ end
 #    <[returns tabbed over portion, omitting skipped substring]>
 #</p>
 procedure tabSkip(s)     # substring to tab up to and skip over
-   suspend 1(tab(find(s)),move(*s))
+   suspend 1(::tab(::find(s)),::move(*s))
 end
 
 #<p>
@@ -62,7 +62,7 @@ end
 #</p>
 procedure WS()
    static WS := ' \t'
-   suspend tab(many(WS))
+   suspend ::tab(::many(WS))
 end
 
 #<p>
@@ -82,7 +82,7 @@ end
 procedure matchVar()
    static fc := &letters ++ '_',
           wc := fc ++ &digits
-   suspend tab(any(fc)) || (tab(many(wc))|"")
+   suspend ::tab(::any(fc)) || (::tab(::many(wc))|"")
 end
 
 #<p>
@@ -91,7 +91,7 @@ end
 # <i>The list of strings is searched in order.  To locate the longest
 # substring first, sort the list in reverse order, as in:</i>
 # <pre>
-#     findFirst(reverse(sort(a)))
+#     findFirst(::reverse(::sort(a)))
 # </pre>
 #</p>
 #<p>
@@ -100,7 +100,7 @@ end
 procedure findFirst(a)   # List of strings to look for.
    local fc := '', p
    every fc ++:= (!a)[1]
-   suspend 1(p := upto(fc), match(!a,,p))
+   suspend 1(p := ::upto(fc), ::match(!a,,p))
 end
 
 #<p>
@@ -134,8 +134,8 @@ class FindFirst : Object(fchars,cMaps,subs,lastMatch)
       /i := &pos
       /j := 0
       if *\s > 0 then {
-	 suspend 1(p := upto(fchars,s,i,j),
-		   match(lastMatch <- !cMaps[s[p]],s,p,j))
+	 suspend 1(p := ::upto(fchars,s,i,j),
+		   ::match(lastMatch <- !cMaps[s[p]],s,p,j))
 	 }
    end
 
@@ -173,7 +173,7 @@ class FindFirst : Object(fchars,cMaps,subs,lastMatch)
       local k
 
       subs := a
-      cMaps := table()
+      cMaps := ::table()
       fchars := ''
       every k := !subs do {
 	 fchars ++:= k[1]
@@ -196,8 +196,8 @@ end
 procedure tabPast(cs)    # cset of characters to tab past.
    local sPos := &pos
    s := ""
-   while s ||:= isEscapeSeq(tab(upto(cs))) || move(1)
-   suspend s ||:= tab(upto(cs))\1 || move(1)
+   while s ||:= isEscapeSeq(::tab(::upto(cs))) || ::move(1)
+   suspend s ||:= ::tab(::upto(cs))\1 || ::move(1)
    &pos := sPos
 end
 
@@ -239,7 +239,7 @@ end
 procedure isEscapeSeq(s,        # String to examine
                       esc:'\\'  # Escape character (defaults to <tt>\</tt>)
                      )
-   reverse(s) ? if *tab(many(esc)) % 2 = 1 then return s
+   reverse(s) ? if *::tab(::many(esc)) % 2 = 1 then return s
 end
 
 #<p>
@@ -294,20 +294,20 @@ end
 procedure sbal(keyStrings)
    local startStrings, stopStrings, allStrings, w, ff, bCount
 
-   every insert(startStrings := set(), key(keyStrings))
-   every insert(stopStrings  := set(), !keyStrings)
-   every put(allStrings := [], !(startStrings|stopStrings))
+   every ::insert(startStrings := ::set(), ::key(keyStrings))
+   every ::insert(stopStrings  := ::set(), !keyStrings)
+   every ::put(allStrings := [], !(startStrings|stopStrings))
 
    ff := FindFirst(allStrings)
    inside := 0
-    
-   while tab(ff.locate()) do {
+
+   while ::tab(ff.locate()) do {
       p1 := &pos
       w := ff.moveMatch()
-      if member(startStrings, w) then {
+      if ::member(startStrings, w) then {
 	 if (inside +:= 1) = 1 then sPos := p1
 	 }
-      else if member(stopStrings, w) then {
+      else if ::member(stopStrings, w) then {
 	 if (inside -:= 1) = 0 then {
 	    suspend .&subject[sPos:&pos]
 	    }

--- a/uni/lib/scan_util.icn
+++ b/uni/lib/scan_util.icn
@@ -178,7 +178,7 @@ class FindFirst : Object(fchars,cMaps,subs,lastMatch)
       every k := !subs do {
 	 fchars ++:= k[1]
 	 /cMaps[k[1]] := []
-	 put(cMaps[k[1]], k)
+	 ::put(cMaps[k[1]], k)
 	 }
       lastMatch := &null
    end
@@ -239,7 +239,7 @@ end
 procedure isEscapeSeq(s,        # String to examine
                       esc:'\\'  # Escape character (defaults to <tt>\</tt>)
                      )
-   reverse(s) ? if *::tab(::many(esc)) % 2 = 1 then return s
+   ::reverse(s) ? if *::tab(::many(esc)) % 2 = 1 then return s
 end
 
 #<p>

--- a/uni/lib/selectiveclasscoding.icn
+++ b/uni/lib/selectiveclasscoding.icn
@@ -46,7 +46,7 @@ class SelectiveClassCoding : ClassCoding()
    method decode_obj(e)
       local n, t, m, x, v, f
 
-      n := integer(e.line_in()) | fail
+      n := ::integer(e.line_in()) | fail
       t := self.load_template()
       m := self.load_map()
 
@@ -72,23 +72,23 @@ class SelectiveClassCoding : ClassCoding()
       local t, class_name, i
       static template_cache
       initial {
-         template_cache := table()
+         template_cache := ::table()
       }
 
       class_name := lang::get_class_name(self)
 
-      if member(template_cache, class_name) then
+      if ::member(template_cache, class_name) then
          return template_cache[class_name]
 
       t := get_template()
 
       # Convert any single string elements to pairs.
       every i := 1 to *t do {
-         if type(t[i]) == "string" then
+         if ::type(t[i]) == "string" then
             t[i] := [t[i], t[i]]
       }
 
-      insert(template_cache, class_name, t)
+      ::insert(template_cache, class_name, t)
 
       return t
    end
@@ -101,18 +101,18 @@ class SelectiveClassCoding : ClassCoding()
       local i, fields, e, class_name, map, s, t
       static map_cache
       initial {
-         map_cache := table()
+         map_cache := ::table()
       }
 
       class_name := lang::get_class_name(self)
 
-      if member(map_cache, class_name) then
+      if ::member(map_cache, class_name) then
          return map_cache[class_name]
 
       #
       # Create a table mapping class member names to record indices.
       #
-      fields := table()
+      fields := ::table()
       i := 1
       every s := lang::generate_member_names(self) do {
          fields[s] := i
@@ -123,12 +123,12 @@ class SelectiveClassCoding : ClassCoding()
       # Create a table mapping field names to record indices.  Check
       # for duplicate names and non-existent variable names.
       #
-      map := table()
+      map := ::table()
       t := self.load_template()
       every e := !t do
-         /map[e[1]] := \fields[e[2]] | stop("invalid template")
+         /map[e[1]] := \fields[e[2]] | ::stop("invalid template")
 
-      insert(map_cache, class_name, map)
+      ::insert(map_cache, class_name, map)
 
       return map
    end

--- a/uni/lib/sem.icn
+++ b/uni/lib/sem.icn
@@ -26,7 +26,7 @@ class Sem(id)
    method set_value(x)
       static f
       initial {
-         f := loadfunc(LIB, "sem_set_value")
+         f := ::loadfunc(LIB, "sem_set_value")
       }
       f(id, x)
    end
@@ -37,7 +37,7 @@ class Sem(id)
    method get_value()
       static f
       initial {
-         f := loadfunc(LIB, "sem_get_value")
+         f := ::loadfunc(LIB, "sem_get_value")
       }
       return f(id)
    end
@@ -72,24 +72,24 @@ class Sem(id)
    method semop(n)
       static f
       initial {
-         f := loadfunc(LIB, "sem_semop")
+         f := ::loadfunc(LIB, "sem_semop")
       }
       f(id, n)
    end
 
-   # 
+   #
    # Peform a semop with the IPC_NOWAIT flag set.  This is the same as
    # {semop()}, but instead of suspending the call will fail.
    #
    method semop_nowait(n)
       static f
       initial {
-         f := loadfunc(LIB, "sem_semop_nowait")
+         f := ::loadfunc(LIB, "sem_semop_nowait")
       }
       return f(id, n)
    end
 
-   # 
+   #
    # Repeatedly peform {semop_nowait()}, sleeping for a short period between each try
    # until t milliseconds or {semop_nowait()} succeeds.  Fails on a timeout; otherwise
    # succeeds.
@@ -101,7 +101,7 @@ class Sem(id)
       c := util::milliseconds()
       repeat {
          if semop_nowait(n) then
-            return 
+            return
          if util::milliseconds() - c > t then
             fail
          util::sleep(50)
@@ -115,7 +115,7 @@ class Sem(id)
    method remove()
       static f
       initial {
-         f := loadfunc(LIB, "sem_remove")
+         f := ::loadfunc(LIB, "sem_remove")
       }
       f(id)
    end
@@ -135,7 +135,7 @@ end
 procedure open_public_sem(key)
    static f
    initial {
-      f := loadfunc(LIB, "sem_open_public")
+      f := ::loadfunc(LIB, "sem_open_public")
    }
    return Sem(f(key))
 end
@@ -146,7 +146,7 @@ end
 procedure create_public_sem(key, val)
    static f
    initial {
-      f := loadfunc(LIB, "sem_create_public")
+      f := ::loadfunc(LIB, "sem_create_public")
    }
    /val := 1
    return Sem(f(key, val))
@@ -158,7 +158,7 @@ end
 procedure create_private_sem(val)
    static f
    initial {
-      f := loadfunc(LIB, "sem_create_private")
+      f := ::loadfunc(LIB, "sem_create_private")
    }
    /val := 1
    return Sem(f(val))

--- a/uni/lib/setfields.icn
+++ b/uni/lib/setfields.icn
@@ -8,18 +8,18 @@ import lang
 
 class SetFields()
    method test_flag(attr, val)
-      if map(val[1]) == ("y" | "yes" | "t" | "true") then
+      if ::map(val[1]) == ("y" | "yes" | "t" | "true") then
          return
-      if map(val[1]) == ("n" | "no" | "f" | "false") then
+      if ::map(val[1]) == ("n" | "no" | "f" | "false") then
          fail
       field_error("Attribute " || attr || " needs a single boolean parameter")
    end
 
-   method as_attrib(attr, val) 
+   method as_attrib(attr, val)
       local s, e
       s := ""
       every e := !val do {
-         if *s > 0 then 
+         if *s > 0 then
             s ||:= ","
          s ||:= e
       }
@@ -27,7 +27,7 @@ class SetFields()
    end
 
    method int_val(attr, val)
-      return /val[1] | integer(val[1]) | field_error("Attribute " || attr || " needs a single integer parameter")
+      return /val[1] | ::integer(val[1]) | field_error("Attribute " || attr || " needs a single integer parameter")
    end
 
    method int_vals(attr, val, n)
@@ -35,13 +35,13 @@ class SetFields()
       if *val < \n then
          field_error("Attribute " || attr || " needs " || n || " parameters")
       every i := 1 to *val do {
-         val[i] := /val[i] | integer(val[i]) | field_error("Attribute " || attr || " needs integer parameters")
+         val[i] := /val[i] | ::integer(val[i]) | field_error("Attribute " || attr || " needs integer parameters")
       }
       return val
    end
 
    method numeric_val(attr, val)
-      return /val[1] | numeric(val[1]) | field_error("Attribute " || attr || " needs a single numeric parameter")
+      return /val[1] | ::numeric(val[1]) | field_error("Attribute " || attr || " needs a single numeric parameter")
    end
 
    method numeric_vals(attr, val, n)
@@ -49,13 +49,13 @@ class SetFields()
       if *val < \n then
          field_error("Attribute " || attr || " needs " || n || " parameters")
       every i := 1 to *val do {
-         val[i] := /val[i] | numeric(val[i]) | field_error("Attribute " || attr || " needs numeric parameters")
+         val[i] := /val[i] | ::numeric(val[i]) | field_error("Attribute " || attr || " needs numeric parameters")
       }
       return val
    end
 
    method cset_val(attr, val)
-      return /val[1] | cset(val[1]) | field_error("Attribute " || attr || " needs a single cset parameter")
+      return /val[1] | ::cset(val[1]) | field_error("Attribute " || attr || " needs a single cset parameter")
    end
 
    method string_val(attr, val)
@@ -76,22 +76,22 @@ class SetFields()
       local s, t, attr, val, vals
       every s := !l do {
          s ? {
-            if attr := tab(find("=")) then {
+            if attr := ::tab(::find("=")) then {
                ="="
                vals := []
                tab(0) ? {
-                  while t := tab(find(",")) do {
+                  while t := ::tab(::find(",")) do {
                      if *t = 0 then
-                        put(vals, &null)
+                        ::put(vals, &null)
                      else
-                        put(vals,t )
-                     move(1)
+                        ::put(vals,t )
+                     ::move(1)
                   }
-                  t := tab(0)
+                  t := ::tab(0)
                   if *t = 0 then
-                     put(vals, &null)
+                     ::put(vals, &null)
                   else
-                     put(vals,t )
+                     ::put(vals,t )
                }
             } else {
                attr := s
@@ -115,6 +115,6 @@ class SetFields()
    # @param s the error message
    #
    method field_error(s)
-      stop("setfields : error in " || lang::get_class_name(self) || " : " || s)
+      ::stop("setfields : error in " || lang::get_class_name(self) || " : " || s)
    end
 end

--- a/uni/lib/shm.icn
+++ b/uni/lib/shm.icn
@@ -29,7 +29,7 @@ class Shm(id)
    method set_value(o)
       static f
       initial {
-         f := loadfunc(LIB, "shm_set_value")
+         f := ::loadfunc(LIB, "shm_set_value")
       }
       f(id, lang::encode(o))
    end
@@ -40,7 +40,7 @@ class Shm(id)
    method get_value()
       static f
       initial {
-         f := loadfunc(LIB, "shm_get_value")
+         f := ::loadfunc(LIB, "shm_get_value")
       }
       return lang::decode(f(id))
    end
@@ -52,7 +52,7 @@ class Shm(id)
    method remove()
       static f
       initial {
-         f := loadfunc(LIB, "shm_remove")
+         f := ::loadfunc(LIB, "shm_remove")
       }
       f(id)
    end
@@ -72,7 +72,7 @@ end
 procedure open_public_shm(key)
    static f
    initial {
-      f := loadfunc(LIB, "shm_open_public")
+      f := ::loadfunc(LIB, "shm_open_public")
    }
    return Shm(f(key))
 end
@@ -83,7 +83,7 @@ end
 procedure create_public_shm(key, o)
    static f
    initial {
-      f := loadfunc(LIB, "shm_create_public")
+      f := ::loadfunc(LIB, "shm_create_public")
    }
    return Shm(f(key, lang::encode(o)))
 end
@@ -94,7 +94,7 @@ end
 procedure create_private_shm(o)
    static f
    initial {
-      f := loadfunc(LIB, "shm_create_private")
+      f := ::loadfunc(LIB, "shm_create_private")
    }
    return Shm(f(lang::encode(o)))
 end

--- a/uni/lib/smtpclient.icn
+++ b/uni/lib/smtpclient.icn
@@ -145,7 +145,7 @@ class SmtpClient:NetClient(hostname, sent_helo)
       send_first_header(m, "Encrypted")
 
       every x := ::map(m.headers.keys()) do {
-         if not member(rfc822_headers, x) then
+         if not ::member(rfc822_headers, x) then
             send_headers_list(m, x)
       }
 

--- a/uni/lib/smtpclient.icn
+++ b/uni/lib/smtpclient.icn
@@ -44,7 +44,7 @@ class SmtpClient:NetClient(hostname, sent_helo)
       l := get_all_mailboxes(m.get_to()) | return error("Invalid To address in message")
       if *l = 0 then
          return error("No To address in message")
-      every mb := !l do 
+      every mb := !l do
          send_command("RCPT TO: " || smtp_address(mb), 250)  | fail
 
       send_command("DATA", 354) | fail
@@ -58,11 +58,11 @@ class SmtpClient:NetClient(hostname, sent_helo)
          if ="." then {
             s ||:= ".."
          }
-         while s ||:= tab(find("\r\n.")) do {
-            move(3)
+         while s ||:= ::tab(::find("\r\n.")) do {
+            ::move(3)
             s ||:= "\r\n.."
          }
-         s ||:= tab(0)
+         s ||:= ::tab(0)
       }
       write_line(s)
       send_command(".", 250) | fail
@@ -80,7 +80,7 @@ class SmtpClient:NetClient(hostname, sent_helo)
 
       s := read_response() | fail
 
-      rc := integer(s[1:4]) | return error("Couldn't get return code")
+      rc := ::integer(s[1:4]) | return error("Couldn't get return code")
       return (rc = reply) | error("Server responded " || s)
    end
 
@@ -95,7 +95,7 @@ class SmtpClient:NetClient(hostname, sent_helo)
 
          if not(s[4] == "-") then
             return t
-      }         
+      }
    end
 
    # Output the first header with the key only
@@ -120,7 +120,7 @@ class SmtpClient:NetClient(hostname, sent_helo)
       local x
       static rfc822_headers
       initial {
-         rfc822_headers := set(["date", "resent-date", "return-path", "received", "sender", "from", "reply-to", "resent-sender", "resent-from", "resent-reply-to", "to", "resent-to", "cc", "resent-cc", "bcc", "resent-bcc", "message-id", "resent-message-id", "in-reply-to", "references", "keywords", "subject", "comments", "encrypted"])
+         rfc822_headers := ::set(["date", "resent-date", "return-path", "received", "sender", "from", "reply-to", "resent-sender", "resent-from", "resent-reply-to", "to", "resent-to", "cc", "resent-cc", "bcc", "resent-bcc", "message-id", "resent-message-id", "in-reply-to", "references", "keywords", "subject", "comments", "encrypted"])
       }
 
       send_first_header(m, "Resent-Date")
@@ -144,8 +144,8 @@ class SmtpClient:NetClient(hostname, sent_helo)
       send_first_header(m, "Comments")
       send_first_header(m, "Encrypted")
 
-      every x := map(m.headers.keys()) do {
-         if not member(rfc822_headers, x) then 
+      every x := ::map(m.headers.keys()) do {
+         if not member(rfc822_headers, x) then
             send_headers_list(m, x)
       }
 

--- a/uni/lib/soap_util.icn
+++ b/uni/lib/soap_util.icn
@@ -42,7 +42,7 @@ procedure soapHead()
                  "\"http://schemas.xmlsoap.org/soap/encoding/\">\n"
    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"||s
 end
-    
+
 #<p>
 # Build the tail of the SOAP envelope: All the boiler-plate stuff for the
 #    end of the envelope.
@@ -65,7 +65,7 @@ procedure getNonWSChildren(x)
 
    every e := !x.get_children() do {
       if ::type(e) ~== "string" then {
-	 put(a, e)
+	 ::put(a, e)
 	 }
       }
    return a
@@ -82,7 +82,7 @@ procedure encode(x,                     # Message element
                 i, label)
    local s := prefix
 
-   /i := create seq()
+   /i := create ::seq()
    /label := "value"||@i
 
    if lang::istype(x, "string"|"cset"|"numeric") then {
@@ -93,7 +93,7 @@ procedure encode(x,                     # Message element
       }
    else if lang::istype(x, "table"|"record") then {
       s := "\n"||prefix||"<"||label||">\n"
-      every k := key(x) do {
+      every k := ::key(x) do {
 	 s ||:= prefix||"  "||encode(x[k], prefix,i,k)||"\n"
 	 }
       s ||:= prefix||"</"||label||">\n"
@@ -105,7 +105,7 @@ procedure encode(x,                     # Message element
       s ||:= prefix||"</"||label||">\n"
       }
    return s
-end  
+end
 
 #<p>
 # Internal procedure to help construct SOAP tags.
@@ -115,7 +115,7 @@ procedure mkTag(label, x)
    local s
    static typeMap
    initial {
-      typeMap := table("")
+      typeMap := ::table("")
       typeMap["string"]  := " xsi:type=\"xsd:string\""
       typeMap["integer"] := " xsi:type=\"xsd:int\""
       typeMap["real"]    := " xsi:type=\"xsd:decimal\""
@@ -136,15 +136,15 @@ procedure decode(x)
 
    case getElementType(x) of {
       "string"  : return x.get_children()[1]
-      "real"    : return real(x.get_children()[1])
-      "integer" : return integer(x.get_children()[1])
+      "real"    : return ::real(x.get_children()[1])
+      "integer" : return ::integer(x.get_children()[1])
       "null"    : return &null
       "list"    : {
-	 every put(a := [], decode(!getNonWSChildren(x)))
+	 every ::put(a := [], decode(!getNonWSChildren(x)))
 	 return a
 	 }
       "table"   : {
-	 a := table()
+	 a := ::table()
 	 every child := !getNonWSChildren(x) do {
 	    a[child.get_name()] := decode(child)
 	    }
@@ -165,7 +165,7 @@ procedure getElementType(x)
    local a, k
    static typeMap
    initial {       # no doubt very incomplete!
-      typeMap := table()
+      typeMap := ::table()
       typeMap["string"] := "string"
       typeMap["int"]    := "integer"
       typeMap["decimal"]:= "real"
@@ -174,14 +174,14 @@ procedure getElementType(x)
       }
 
    a := x.get_attributes()
-   every k := key(a) do {
+   every k := ::key(a) do {
       k ? {
-	 &pos := upto(':')+1                     # skip any namespace id
-	 if ="type" & pos(0) then {
+	 &pos := ::upto(':')+1                     # skip any namespace id
+	 if ="type" & ::pos(0) then {
 	    a[k] ? {
-	       &pos := any('\'"')
-	       &pos := upto(':')+1             # skip any namespace id
-	       return typeMap[map(tab(upto('\'"')|0))]
+	       &pos := ::any('\'"')
+	       &pos := ::upto(':')+1             # skip any namespace id
+	       return typeMap[::map(::tab(::upto('\'"')|0))]
 	       }
 	    }
 	 }
@@ -222,9 +222,9 @@ class ErrHandler : xml::DefaultErrorHandler (out_file)
    #  <[stack stack trace]>
    #</p>
    method fatal_error(msg:"", stack)
-      writes(\out_file, "Fatal error: " || msg)
+      ::writes(\out_file, "Fatal error: " || msg)
       if \stack then {
-	 write(\out_file, " at:")
+	 ::write(\out_file, " at:")
 	 show_stack(stack)
 	 }
    end
@@ -255,8 +255,8 @@ class ErrHandler : xml::DefaultErrorHandler (out_file)
 	 if \x.id then {
 	    t := x.subject[1:x.pos]
 	    i := 1
-	    every find("\n", t) do i +:= 1
-	    write(\out_file, x.id || ": "||i)
+	    every ::find("\n", t) do i +:= 1
+	    ::write(\out_file, x.id || ": "||i)
 	    }
 	 }
     end

--- a/uni/lib/soapclient.icn
+++ b/uni/lib/soapclient.icn
@@ -20,7 +20,7 @@ import xml          # From Robert Parlett's class library
 
 #<p>
 # A simple SoapClient.  Really meant to be subclassed.  Only handles
-#   procedure calls.  
+#   procedure calls.
 #</p>
 #<p>
 # Here is a sample client based on this class.  The URI and
@@ -28,16 +28,16 @@ import xml          # From Robert Parlett's class library
 #</p>
 #<pre>
 # import soap
-# 
+#
 # procedure main()
 #     soap := SoapClient(URI_GOES_HERE, PROXY_GOES_HERE)
 #     result := soap.call("query","*","host = 'weaver'","date DESC")
-# 
+#
 #     every row := !result do {
 #         write("  ",row["host"],"  ",row["percent"],"  ",
 #                    row["date"],"  ",row["filesys"])
 #         }
-# end    
+# end
 #</pre>
 class SoapClient : Object (uri, proxy, port, debugFile)
 
@@ -48,7 +48,7 @@ class SoapClient : Object (uri, proxy, port, debugFile)
    #</p>
    method setDebugFile(f)
       if ::type(f) == "string" then {
-	 f := open(f, "w") | fail
+	 f := ::open(f, "w") | fail
 	 }
       debugFile := f
    end
@@ -60,7 +60,7 @@ class SoapClient : Object (uri, proxy, port, debugFile)
    #</p>
    #<p><i>Internal use only.</i></p>
    method debugMsg(msg[])
-      write ! push(msg, \debugFile)
+      ::write ! ::push(msg, \debugFile)
    end
 
    #<p>
@@ -75,14 +75,14 @@ class SoapClient : Object (uri, proxy, port, debugFile)
       msg := mkHttpMesgForm(msg)
       debugMsg("Sending: \n",msg)
 
-      host := getHost() | stop("Cannot figure out host!")
-      svc := open(host||":"||port, "n") |
-	 stop("Cannot get '",host,"' connection: ", &errortext)
+      host := getHost() | ::stop("Cannot figure out host!")
+      svc := ::open(host||":"||port, "n") |
+	 ::stop("Cannot get '",host,"' connection: ", &errortext)
 
-      write(svc, msg) | stop("Cannot send msg: ",&errortext)
+      ::write(svc, msg) | ::stop("Cannot send msg: ",&errortext)
       result := ""
-      while result ||:= reads(svc, 8192)
-      close(svc)
+      while result ||:= ::reads(svc, 8192)
+      ::close(svc)
       debugMsg("\n\n\nGot: \n",result)
 
       result := convertRawMsg(result)
@@ -103,8 +103,8 @@ class SoapClient : Object (uri, proxy, port, debugFile)
       static parser
       initial parser := soap::getXmlParser()
 
-      map(result) ? {
-	 if p := find("<soap-env:envelope") then {
+      ::map(result) ? {
+	 if p := ::find("<soap-env:envelope") then {
 	    result := result[p:0]
 	    }
 	 }
@@ -123,7 +123,7 @@ class SoapClient : Object (uri, proxy, port, debugFile)
    method getHost()
       proxy ? {
 	 ="http://"
-	 return tab(upto('/'))
+	 return ::tab(::upto('/'))
 	 }
    end
 
@@ -135,7 +135,7 @@ class SoapClient : Object (uri, proxy, port, debugFile)
    method getTarget()
       proxy ? {
 	 ="http://"
-	 (&pos := upto('/')) & return tab(0)
+	 (&pos := ::upto('/')) & return ::tab(0)
 	 }
    end
 
@@ -148,7 +148,7 @@ class SoapClient : Object (uri, proxy, port, debugFile)
 		       args[])      # Remaining args are args to use on rpc
       local msg, i
 
-      i := create seq()
+      i := create ::seq()
       msg :=   " <SOAP-ENV:Body>\n"
       msg ||:= "  <namesp:"||rpc||" xmlns:namesp=\""||uri||"\">\n"
       if *args > 0 then every msg ||:= soap::encode(!args,"    ",i)||"\n"
@@ -178,13 +178,13 @@ class SoapClient : Object (uri, proxy, port, debugFile)
    end
 
 #<p>
-# Create a new SOAP client. 
+# Create a new SOAP client.
 #</p>
 initially (newUri,      # URI for server
 	   newProxy,    # 'Proxy' information for server (defaults to URI)
 	   newPort)      # Port on server (defaults to 80)
    uri := newUri
    proxy := \newProxy | uri
-   port := \newPort | getserv("http").port | "80"
+   port := \newPort | ::getserv("http").port | "80"
    debugFile := &null
 end

--- a/uni/lib/soapserver.icn
+++ b/uni/lib/soapserver.icn
@@ -24,7 +24,7 @@ import lang
 #</p>
 #<pre>
 # import soap
-# 
+#
 # procedure main()
 #     server := SoapServer(URI_GOES_HERE)
 #     server.setDebugFile("/dev/null")
@@ -36,13 +36,13 @@ import lang
 #     write(msg)
 #     exit(0)
 # end
-# 
+#
 # procedure hi(a[])
 #     s := ""
 #     every s ||:= !a
 #     return ("Hi "||s)
 # end
-# 
+#
 # procedure bye(a[])
 #     s := table()
 #     s["a1"] := a[1]
@@ -50,13 +50,13 @@ import lang
 #     s["a3"] := a[3]
 #     return s
 # end
-# 
+#
 # procedure guy(a[])
 #     s := list()
 #     every put(s := [], !a)
 #     return s
 # end
-# 
+#
 # procedure spcl(a[])
 #     return "&lt;result&gt;&lt;v1&gt;special service called!&lt;/v1&gt;&lt;/result&gt;"
 # end
@@ -75,7 +75,7 @@ class SoapServer : Object(uri,            # URI of service
    #</p>
    method setDebugFile(f)  # File name or open file.
       if ::type(f) == "string" then {
-	 f := open(f, "w") | fail
+	 f := ::open(f, "w") | fail
 	 }
       debugFile := f
    end
@@ -102,7 +102,7 @@ class SoapServer : Object(uri,            # URI of service
 			    func,   # Procedure implementing service
 			    helpMsg) # (Optional) help message
       addService(sName, func, helpMsg)
-      insert(specialServices, sName)
+      ::insert(specialServices, sName)
    end
 
    #<p>
@@ -120,8 +120,8 @@ class SoapServer : Object(uri,            # URI of service
    #</p>
    method listServices()
       local aList := [], sName
-      every sName := (!sort(services))[1] do {
-	 put(aList, left(sName,30)||(\servicesHelp[sName] | ""))
+      every sName := (!::sort(services))[1] do {
+	 ::put(aList, ::left(sName,30)||(\servicesHelp[sName] | ""))
 	 }
       return aList
    end
@@ -164,20 +164,20 @@ class SoapServer : Object(uri,            # URI of service
 	 children := request.get_children()
 	 debugMsg("Children: ",image(children))
 	 (svc := (!children), ::type(svc) ~== "string")
-	 debugMsg("SVC: ",image(svc))
+	 debugMsg("SVC: ",::image(svc))
 	 sName := svc.get_name()
-	 sName ?:= 2(skipTo(upto(':')+1),tab(0))
+	 sName ?:= 2(skipTo(::upto(':')+1),::tab(0))
 	 debugMsg("Name: ",sName)
 	 arglist := []
 	 every param := !soap::getNonWSChildren(svc) do {
-	    put(arglist, soap::decode(param))
+	    ::put(arglist, soap::decode(param))
 	    }
 	 debugMsg("Param count: ",*arglist)
 	 if sName == "listServices" then {
 	    return respond(listServices())
 	    }
 	 else if msg := invokeService(sName, arglist) then {
-	    if not member(specialServices, sName) then {
+	    if not ::member(specialServices, sName) then {
 	       return respond(msg)
 	       }
 	    else {
@@ -216,10 +216,10 @@ class SoapServer : Object(uri,            # URI of service
       initial parser := soap::getXmlParser()
 
       if getenv("REQUEST_METHOD") == "GET" then {
-	 line := getenv("QUERY_STRING")
+	 line := ::getenv("QUERY_STRING")
 	 }
       else {
-	 line := reads(&input, getenv("CONTENT_LENGTH"))
+	 line := ::reads(&input, ::getenv("CONTENT_LENGTH"))
 	 }
       debugMsg("Got: '",line,"'")
       root := parser.parse(line).get_root_element()
@@ -230,7 +230,7 @@ class SoapServer : Object(uri,            # URI of service
    # Log a message to a file if told to do so.
    #</p>
    method debugMsg(msg[])   # Arguments are displayed to (non-null) debugfile
-      write ! push(msg, \debugFile)
+      ::write ! ::push(msg, \debugFile)
    end
 
    # These next methods are internal methods for constructing a response
@@ -284,8 +284,8 @@ class SoapServer : Object(uri,            # URI of service
 initially (newUri,      # URI indentifying server
 	   newServices)  # (Optional) table mapping procedures to services
    uri := newUri
-   services := \newServices | table()
-   servicesHelp := table()
-   specialServices := set()
+   services := \newServices | ::table()
+   servicesHelp := ::table()
+   specialServices := ::set()
    debugFile := &null
 end

--- a/uni/lib/soapserver.icn
+++ b/uni/lib/soapserver.icn
@@ -110,7 +110,7 @@ class SoapServer : Object(uri,            # URI of service
    #</p>
    method delService(sName) # Name of service to remove.
       services[sName] := &null
-      delete(specialServies, sName)
+      ::delete(specialServies, sName)
    end
 
    #<p>
@@ -215,7 +215,7 @@ class SoapServer : Object(uri,            # URI of service
       static parser
       initial parser := soap::getXmlParser()
 
-      if getenv("REQUEST_METHOD") == "GET" then {
+      if ::getenv("REQUEST_METHOD") == "GET" then {
 	 line := ::getenv("QUERY_STRING")
 	 }
       else {

--- a/uni/lib/str_replacer.icn
+++ b/uni/lib/str_replacer.icn
@@ -34,10 +34,10 @@ class StringReplacer : Object (tbl, ff)
    method replace(s)
       local ns := ""
       s ? {
-	 while ns ||:= tab(ff.locate()) do {
+	 while ns ||:= ::tab(ff.locate()) do {
 	    ns ||:= tbl[ff.moveMatch()]
 	    }
-	 ns ||:= tab(0)
+	 ns ||:= ::tab(0)
 	 }
       return ns
    end
@@ -49,6 +49,6 @@ class StringReplacer : Object (tbl, ff)
 initially (mapTable)
    local a
    tbl := mapTable
-   every put(a := [], key(tbl))
-   ff := FindFirst(reverse(sort(a)))
+   every ::put(a := [], ::key(tbl))
+   ff := FindFirst(::reverse(::sort(a)))
 end

--- a/uni/lib/str_util.icn
+++ b/uni/lib/str_util.icn
@@ -20,7 +20,7 @@ import lang
 # Utility to get next integer
 #
 procedure get_int()
-   suspend tab(upto(&digits)) & integer(tab(many(&digits)))
+   suspend ::tab(::upto(&digits)) & ::integer(::tab(::many(&digits)))
 end
 
 #<p>
@@ -31,7 +31,7 @@ end
 procedure zapSuffix(s,      # String to examine
                     suffix  # Suffix to find and remove
                    )
-    return (string(s), string(suffix), s[-*suffix:0] == suffix, s[1:-*suffix])
+    return (::string(s), ::string(suffix), s[-*suffix:0] == suffix, s[1:-*suffix])
 end
 
 #<p>
@@ -42,7 +42,7 @@ end
 procedure zapPrefix(s,      # String to examine
                     prefix  # Prefix to find and remove
                    )
-    return (string(s), string(prefix), s[1+:*prefix] == prefix, s[*prefix+1:0])
+    return (::string(s), ::string(prefix), s[1+:*prefix] == prefix, s[*prefix+1:0])
 end
 
 #<p>
@@ -53,7 +53,7 @@ end
 procedure delSuffix(s,      # String to examine
                     suffix  # Suffix to remove if present
                    )
-    return zapSuffix(s, suffix) | string(s)
+    return zapSuffix(s, suffix) | ::string(s)
 end
 
 #<p>
@@ -64,7 +64,7 @@ end
 procedure delPrefix(s,      # String to examine
                     prefix  # Suffix to remove if present
                    )
-    return zapPrefix(s, prefix) | string(s)
+    return zapPrefix(s, prefix) | ::string(s)
 end
 
 #<p>
@@ -75,7 +75,7 @@ end
 procedure lTrim(s,      # String to examine
                 cs      # Characters to strip from beginning of <tt>s</tt>.
                )
-    return reverse(trim(reverse(s),cs))
+    return ::reverse(::trim(::reverse(s),cs))
 end
 
 #<p>
@@ -86,8 +86,8 @@ procedure genWords(s,   # String to examine
                    cs   # Characters comprising words (default: &letters)
                   )
     /cs := &letters
-    s ? while &pos := upto(cs) do {
-        suspend tab(many(cs))\1
+    s ? while &pos := ::upto(cs) do {
+        suspend ::tab(::many(cs))\1
         }
 end
 
@@ -102,9 +102,9 @@ procedure genFields(s,  # String to examine
     local s1
 
     lTrim(s, cs) ? {
-        while s1 := tab(upto(cs)|0) do {
+        while s1 := ::tab(::upto(cs)|0) do {
             suspend s1
-            tab(many(cs)) | fail
+            ::tab(::many(cs)) | fail
             }
         }
 end
@@ -118,9 +118,9 @@ procedure genFieldsOne(s,   # String to examine
                        cs:' \t\n'
                       )
     s ? {
-        while s1 := tab(upto(cs)|0) do {
+        while s1 := ::tab(::upto(cs)|0) do {
             suspend s1
-            move(1) | fail
+            ::move(1) | fail
             }
         }
 end
@@ -150,20 +150,20 @@ procedure hideEscapedChars(s,       # String to examine
                            s2,      # ... and replace with these
                            esc:'\\' # Escape character
                           )
-    local c1 := cset(s1), ns := ""
+    local c1 := ::cset(s1), ns := ""
 
     /s2 := hideAllChars(s1)
 
     s ? {
-        while ns ||:= tab(upto(c1)) do {
+        while ns ||:= ::tab(::upto(c1)) do {
             if isEscapeSeq(ns, esc) then {
-                ns ||:= map(move(1), s1, s2)
+                ns ||:= ::map(::move(1), s1, s2)
                 }
             else {
-                ns ||:= move(1)
+                ns ||:= ::move(1)
                 }
             }
-        ns ||:= tab(0)
+        ns ||:= ::tab(0)
         }
 
     return ns
@@ -180,7 +180,7 @@ end
 #</p>
 procedure hideAllChars(s    # String of characters to hide.
                       )
-    return map(s, &ascii, &cset--&ascii)
+    return ::map(s, &ascii, &cset--&ascii)
 end
 
 #<p>
@@ -201,13 +201,13 @@ procedure replaceStrs(s,    # String to examine
                             #   entries are corresponding replacements
                      )
     local a, ns := ""
-    every put(a := [], key(tbl))
-    a := reverse(sort(a))
+    every ::put(a := [], ::key(tbl))
+    a := ::reverse(::sort(a))
     s ? {
-        while ns ||:= tab(findFirst(a)) do {
+        while ns ||:= ::tab(findFirst(a)) do {
             ns ||:= tbl[=!a]
             }
-        ns ||:= tab(0)
+        ns ||:= ::tab(0)
         }
     return ns
 end
@@ -225,7 +225,7 @@ end
 #   <[returns longest common suffix of <tt>s1</tt> and <tt>s2</tt>]>
 #</p>
 procedure lcs(s1,s2)
-   return reverse(lcp(reverse(s1),reverse(s2)))
+   return ::reverse(lcp(::reverse(s1),::reverse(s2)))
 end
 
 #<p>
@@ -259,17 +259,17 @@ procedure mapBytes(s,   # String to re-arrange
        (/saveOut | (saveOut ~== out)) then {
         saveIn  := in
         saveOut := out
-        inMap   := string(&cset)
+        inMap   := ::string(&cset)
         inMap   := inMap[1+:((*inMap/*in)*(*in))]
         outMap  := ""
-        inMap ? while(outMap ||:= map(in,out,move(*in)))
+        inMap ? while(outMap ||:= ::map(in,out,::move(*in)))
         }
-    
+
     # now do the work
     s ? {
-        while ns ||:= map(inMap,outMap,move(*inMap))
-        while ns ||:= map(in,out,move(*in))  # catch short strings
-        ns ||:= tab(0)                       # just append last tidbit
+        while ns ||:= ::map(inMap,outMap,::move(*inMap))
+        while ns ||:= ::map(in,out,::move(*in))  # catch short strings
+        ns ||:= ::tab(0)                       # just append last tidbit
         }
     return ns
 end
@@ -286,9 +286,9 @@ procedure stringToList(s, sep:'\n')
     if s[0] == sep then s := s[1:-1]       # strip only last sep
 
     s ? {
-        while put(a, tab(upto(sep)|0)) do move(1) | break
+        while ::put(a, ::tab(::upto(sep)|0)) do ::move(1) | break
         }
-        
+
     return a
 end
 
@@ -316,7 +316,7 @@ end
 #  <[param p string to use as padding]>
 #</p>
 procedure lPad(s,n,p)
-   return if *s < n then left(s,n,p) else s
+   return if *s < n then ::left(s,n,p) else s
 end
 
 #<p>
@@ -330,7 +330,7 @@ end
 #  <[param p string to use as padding]>
 #</p>
 procedure rPad(s,n,p)
-   return if *s < n then right(s,n,p) else s
+   return if *s < n then ::right(s,n,p) else s
 end
 
 #<p>
@@ -359,28 +359,28 @@ procedure genCSV(s, sep, spanFlag)
     initial {
         # Default to not treating spans of separators as single separators
         nospan := makeProc { repeat { @&source; move(1) } }
-        span   := makeProc { repeat { sep := @&source; tab(many(\sep[1])) } }
+        span   := makeProc { repeat { sep := @&source; ::tab(::many(\sep[1])) } }
         }
 
     spanner := if /spanFlag then nospan else span
-    
+
     /sep := ","
     WS := ' \t\n' -- sep  # Can't include separators in whitespace
                           #  (The '\n' is a trick so there's always
                           #  something at the end of the last field.)
 
     (s||WS) ? {
-        while not pos(0) do {
-            tab(many(WS))
+        while not ::pos(0) do {
+            ::tab(::many(WS))
             if ="\"" then {    # Quoted string
                 r := ""
                 while r ||:= tabSkip("\"") do {
                     if not ="\"" then break     # End of quoted string
                     r ||:= "\""
                     }
-                suspend (tab((upto(sep))|0)\1, r) do spanner(sep)     
+                suspend (::tab((::upto(sep))|0)\1, r) do spanner(sep)
                 }
-            else suspend trim(tab((upto(sep))|0)\1,WS) do spanner(sep)
+            else suspend ::trim(::tab((::upto(sep))|0)\1,WS) do spanner(sep)
             }
         }
 end
@@ -395,7 +395,7 @@ end
 #</p>
 procedure parseCSV(s, sep, spanFlag)
     local A
-    every put(A := [], genCSV(s, sep, spanFlag))
+    every ::put(A := [], genCSV(s, sep, spanFlag))
     return A
 end
 
@@ -422,8 +422,8 @@ procedure encodeCsvField(field)
     local r
     r := ""
     field ? {
-        while r ||:= tab(upto('"')+1) do r ||:= "\""
-        r := "\"" || r || tab(0) || "\""
+        while r ||:= ::tab(::upto('"')+1) do r ||:= "\""
+        r := "\"" || r || ::tab(0) || "\""
         }
     return r
 end

--- a/uni/lib/str_util.icn
+++ b/uni/lib/str_util.icn
@@ -358,7 +358,7 @@ procedure genCSV(s, sep, spanFlag)
     static span, nospan
     initial {
         # Default to not treating spans of separators as single separators
-        nospan := makeProc { repeat { @&source; move(1) } }
+        nospan := makeProc { repeat { @&source; ::move(1) } }
         span   := makeProc { repeat { sep := @&source; ::tab(::many(\sep[1])) } }
         }
 

--- a/uni/lib/stringbuff.icn
+++ b/uni/lib/stringbuff.icn
@@ -25,7 +25,7 @@ class StringBuff(buff)
    # Add the string to the buffer list.
    #
    method add(s)
-      return put(buff, s)
+      return ::put(buff, s)
    end
 
    #
@@ -46,12 +46,12 @@ class StringBuff(buff)
    #
    method drop_last(s)
       if buff[-1] == s then
-         pull(buff)
+         ::pull(buff)
    end
 
    initially
       buff := []
 end
 
-      
+
 

--- a/uni/lib/struct.icn
+++ b/uni/lib/struct.icn
@@ -33,8 +33,8 @@ class Struct : Object (sType, struct)
    #   <[fails if structure is not a <tt>set</tt> or <tt>list</tt>]>
    #</p>
    method addElement(e)
-      if type(struct) == "set" then return insert(struct, e)
-      else if type(struct) == "list" then return put(struct, e)
+      if ::type(struct) == "set" then return ::insert(struct, e)
+      else if ::type(struct) == "list" then return ::put(struct, e)
    end
 
    #<p>
@@ -44,7 +44,7 @@ class Struct : Object (sType, struct)
    #   <[param e element to remove]>
    #</p>
    method remove(e)
-      delete(struct, e)
+      ::delete(struct, e)
    end
 
    #<p>
@@ -75,12 +75,12 @@ class Struct : Object (sType, struct)
    #</p>
    method fromString(s, prefix:"", terminator:'\n')
       terminator := cset(terminator)
-      string(s) ? {
+      ::string(s) ? {
 	 struct := sType()        # Clear out old, if any
-	 while not pos(0) do {
+	 while not ::pos(0) do {
 	    =prefix
-	    addElement(tab(upto(terminator)|0))
-	    move(1)        # skip terminator
+	    addElement(::tab(::upto(terminator)|0))
+	    ::move(1)        # skip terminator
 	    }
 	 }
       return self
@@ -102,7 +102,7 @@ class Struct : Object (sType, struct)
    #   <[returns (a copy of internal) structure]>
    #</p>
    method toIStruct()
-      return copy(struct)
+      return ::copy(struct)
    end
 
 #<p>

--- a/uni/lib/struct.icn
+++ b/uni/lib/struct.icn
@@ -111,6 +111,6 @@ class Struct : Object (sType, struct)
 initially (sTypeCons # type of structure, e.g. <b>set</b> or <b>list</b>.
                      #   Default is <b>set</b>.
            )
-   sType := \sTypeCons | set
+   sType := \sTypeCons | ::set
    struct := sType()
 end

--- a/uni/lib/texthandler.icn
+++ b/uni/lib/texthandler.icn
@@ -6,9 +6,9 @@ package mail
 
 class TextHandler : TypeHandler()
    method can_handle(ct)
-      return map(ct.get_type()) == "text"
+      return ::map(ct.get_type()) == "text"
    end
-   
+
    method convert_to_object(m, data)
       local res
 
@@ -17,10 +17,10 @@ class TextHandler : TypeHandler()
       #
       res := ""
       data ? repeat {
-         res ||:= tab(find("\r\n") | 0)
-         if pos(0) then
+         res ||:= ::tab(::find("\r\n") | 0)
+         if ::pos(0) then
             break
-         move(2)
+         ::move(2)
          res ||:= "\n"
       }
       return res
@@ -34,10 +34,10 @@ class TextHandler : TypeHandler()
       #
       res := ""
       obj ? repeat {
-         res ||:= tab(upto('\n') | 0)
-         if pos(0) then
+         res ||:= ::tab(::upto('\n') | 0)
+         if ::pos(0) then
             break
-         move(1)
+         ::move(1)
          res ||:= "\r\n"
       }
       return res

--- a/uni/lib/thread.icn
+++ b/uni/lib/thread.icn
@@ -20,33 +20,33 @@ package threads
 class Shared_Variable(value)
    method lock()
       static builtin_lock
-      initial builtin_lock := proc("lock", 0)
+      initial builtin_lock := ::proc("lock", 0)
 
       return builtin_lock(self)
    end
 
    method trylock()
       static builtin_trylock
-      initial builtin_trylock := proc("trylock", 0)
+      initial builtin_trylock := ::proc("trylock", 0)
 
       return builtin_trylock(self)
    end
 
    method unlock()
       static builtin_unlock
-      initial builtin_unlock := proc("unlock", 0)
+      initial builtin_unlock := ::proc("unlock", 0)
 
       return builtin_unlock(self)
    end
-   
+
    initially(v, mtx)
 
       value := v
 
-      if \mtx then 
-         mutex(self, mtx)
+      if \mtx then
+         ::mutex(self, mtx)
       else
-         mutex(self)
+         ::mutex(self)
 end
 
 
@@ -54,34 +54,34 @@ procedure channel(x, port)
    local ce, T, L, chnl, TP
    static chTable, chTableP, chTableN
    initial {
-      chTable  := mutex(table())
-      chTableP := mutex(table())
-      chTableN := mutex(table())
+      chTable  := ::mutex(::table())
+      chTableP := ::mutex(::table())
+      chTableN := ::mutex(::table())
       }
-   
-   if string(x) then { # the name of the channel is what matters
+
+   if ::string(x) then { # the name of the channel is what matters
        critical chTableN:
-          if member(chTableN, x) then 
+          if ::member(chTableN, x) then
              chnl :=  chTableN[x]
           else
-	     chTableN[x] := chnl := condvar([])
+	     chTableN[x] := chnl := ::condvar([])
 
        return chnl
       }
    else if /port then {   # connect channels based on order they were received
       ce := &current
       critical chTable: {
-         if not(member(chTable, ce)) then chTable[ce] := table() 
-         if not(member(chTable, x)) then chTable[x] := table() 
+         if not(::member(chTable, ce)) then chTable[ce] := ::table()
+         if not(::member(chTable, x)) then chTable[x] := ::table()
 
-	 if \(L := chTable[ce][x]) & chnl := get(L) then {
-	    if *L=0 then delete(chTable[ce], x)
+	 if \(L := chTable[ce][x]) & chnl := ::get(L) then {
+	    if *L=0 then ::delete(chTable[ce], x)
 	    }
 	 else if \(L := chTable[x][ce]) then
-	       put(L, chnl := condvar([]))
+	       put(L, chnl := ::condvar([]))
          else {
 	    L := []
-            put(L, chnl := condvar([]))
+            ::put(L, chnl := ::condvar([]))
             chTable[x][ce] := L
 	    }
          } # critical
@@ -90,19 +90,19 @@ procedure channel(x, port)
    else {
       ce := &current
       critical chTableP: {    # connect channels based on the supplied port
-         if not(member(chTableP, ce)) then chTableP[ce] := table() 
-         if not(member(chTableP, x)) then chTableP[x] := table() 
-	 
+         if not(::member(chTableP, ce)) then chTableP[ce] := ::table()
+         if not(::member(chTableP, x)) then chTableP[x] := ::table()
+
 	 if \(TP := chTableP[ce][x]) & \(chnl := TP[port]) then {
-	    delete(TP, port)
-	    if *TP=0 then delete(chTableP[ce], x)
+	    ::delete(TP, port)
+	    if *TP=0 then ::delete(chTableP[ce], x)
 	    }
 	 else if \(TP := chTableP[x][ce]) then {
-	    TP[port] := chnl := condvar([])
+	    TP[port] := chnl := ::condvar([])
             }
          else {
-	    TP := table()
-            TP[port] := chnl := condvar([])
+	    TP := ::table()
+            TP[port] := chnl := ::condvar([])
             chTableP[x][ce] := TP
 	    }
          } # critical
@@ -124,15 +124,15 @@ class Thread(
   end
 
   method run()
-   signal(cv)
+   ::signal(cv)
   end
   method thread_func()
-    wait(cv)
+    ::wait(cv)
   end
 
 initially(work, t)
    self.work := work
-   cv := condvar()
+   cv := ::condvar()
    if \t then
       self.t := t
    else
@@ -143,12 +143,12 @@ class Task(
   nthread, 		# number of threads asked for
   active_threads, 	# the threads assigned to this task
   func,    		# proc, what I'm supposed to do
-  reduce_func,    		# proc, how do I combine results 
+  reduce_func,    		# proc, how do I combine results
   tttype,    		# thread task type , repeat, divide, chunk
   chunk_size, 		#
   caller,
   cv_caller,		#
-  args, 
+  args,
   result_list,
   done 			# set when done
   )
@@ -156,18 +156,18 @@ class Task(
   method do_work(args)
      return
   end
-  
+
   method exec()
     local rslt
     #write("args=",image(args))
     if runners()<nthread then {
-       insert(active_threads, &current)
+       ::insert(active_threads, &current)
        if \func then {
           if rslt := func(args) then done := "Yes"
 	}
        else if rslt := do_work(args) then done := "yes"
-       delete(active_threads, &current)
-       put(result_list, rslt)
+       ::delete(active_threads, &current)
+       ::put(result_list, rslt)
        return \done | *active_threads=0;
        }
   end
@@ -175,22 +175,22 @@ class Task(
   method exec_map()
     local rslt, x, rslt_lst:=[], i:=0
 
-    # if the task needs more threads and there is more work 
+    # if the task needs more threads and there is more work
     if runners()<nthread & *args>0 then {
        # each thread does chunk_size work and put it in rslt_list
-       while i<chunk_size & put(rslt_lst, func(get(args)))
+       while i<chunk_size & ::put(rslt_lst, func(get(args)))
        if *rslt_lst>0 then # if we have anything to report
           return rslt_lst
        }
   end
 
   method exec_reduce()
-     
+
   end
 
   method signal()
      static bsignal
-     initial bsignal := proc("signal", 0)
+     initial bsignal := ::proc("signal", 0)
      bsignal(cv_caller)
   end
 
@@ -200,14 +200,14 @@ class Task(
 
   method wait()
      static bwait
-     initial bwait := proc("wait", 0)
+     initial bwait := ::proc("wait", 0)
      critical cv_caller: bwait(cv_caller)
   end
 
   method runners()
      return *active_threads
   end
-  
+
   method set_caller(c)
      caller := ( \c | &current )
   end
@@ -217,7 +217,7 @@ class Task(
   end
 
   method reduce(rslt_lst)
-     return (\reduce_func)(rslt_lst) 
+     return (\reduce_func)(rslt_lst)
   end
 
   method init(func, r_func, args, n:1, chnk_size:1)
@@ -226,9 +226,9 @@ class Task(
      self.args := args
      n := n<1
      nthread := n
-     cv_caller := condvar()
-     active_threads := mutex(set())
-     result_list := mutex([])
+     cv_caller := ::condvar()
+     active_threads := ::mutex(::set())
+     result_list := ::mutex([])
      chunk_size := chnk_size
    end
 
@@ -242,20 +242,20 @@ class Threads(
  master,       # "the house keeper thread"
  thread_ready, # a list of all ready threads
  thread_active,# a list of all ready threads
- task_ready,   # the list of tasks waiting to be processed 
- task_active,  # the list of tasks being processed 
- cv_work,      # condition variable that all threads on   
-               # thread_pool wait on when there is no 
+ task_ready,   # the list of tasks waiting to be processed
+ task_active,  # the list of tasks being processed
+ cv_work,      # condition variable that all threads on
+               # thread_pool wait on when there is no
                # work to do.
  cv_master,
- actual_work,  # points to a procedure (work) that the 
+ actual_work,  # points to a procedure (work) that the
                # thread are supposed to do.
  done
 )
 
 # The work that the thread has to do.
 # This function can be implemented by the subclass
-# or actual_work can be pointed to a procedure that 
+# or actual_work can be pointed to a procedure that
 # does the work
 method do_work()
    actual_work()
@@ -263,35 +263,35 @@ end
 
 method thread_func()
    local tsk, rslt, rslt_lst, cur_thread := &current
-   while /done do { 
-      if tsk := pop(task_ready) then {
-         insert(tsk.active_threads, &current)
+   while /done do {
+      if tsk := ::pop(task_ready) then {
+         ::insert(tsk.active_threads, &current)
          if tsk.runners()+1<tsk.nthread then
-            push(task_ready, tsk)
+            ::push(task_ready, tsk)
 
-         delete(thread_ready, cur_thread)
-         insert(thread_active,cur_thread)
+         ::delete(thread_ready, cur_thread)
+         ::insert(thread_active,cur_thread)
 
          #write("thread is execing task")
 	 if rslt_lst := tsk.exec_map() then
-	    put(tsk.result_list, tsk.reduce_func(rslt_lst))
+	    ::put(tsk.result_list, tsk.reduce_func(rslt_lst))
          #write("thread done execing task")
 
-         delete(thread_active, cur_thread)
-         insert(thread_ready,  cur_thread)
-        
+         ::delete(thread_active, cur_thread)
+         ::insert(thread_ready,  cur_thread)
+
          critical task_ready: {
 	    if *tsk.args>0 & tsk~===task_ready[1] then
-            push(task_ready, tsk)
+            ::push(task_ready, tsk)
             }
 
-         delete(tsk.active_threads, &current)
+         ::delete(tsk.active_threads, &current)
          if tsk.runners()=*tsk.args=0 then tsk.signal()
          }
 
          if *task_ready=0 then
              critical cv_work: while *task_ready=0 do
-                            wait(cv_work)
+                            ::wait(cv_work)
      }
 end
 
@@ -299,9 +299,9 @@ end
 method master_func()
   while /done do {
       if *task_ready>0 & *thread_ready>0 then
-         signal(cv_work)
+         ::signal(cv_work)
       else
-         delay(1000)
+         ::delay(1000)
     #write("master")
    }
 end
@@ -310,7 +310,7 @@ method house_keeping()
 end
 
 method submit_async(tsk, r_func, args, n)
-   if (type(tsk)=="procedure") then {
+   if (::type(tsk)=="procedure") then {
       tsk := Task(tsk, r_func, args, n)
       }
    else {
@@ -320,11 +320,11 @@ method submit_async(tsk, r_func, args, n)
 
    tsk.set_caller()
    critical task_ready: put(task_ready, tsk)
-   signal(cv_work, tsk.nthread)
+   ::signal(cv_work, tsk.nthread)
 end
 
 method submit_sync(tsk, r_func, args, n)
-   if (type(tsk)=="procedure") then {
+   if (::type(tsk)=="procedure") then {
       tsk := Task(tsk, r_func, args, n)
       }
    else {
@@ -333,8 +333,8 @@ method submit_sync(tsk, r_func, args, n)
       }
 
    tsk.set_caller()
-   critical task_ready: put(task_ready, tsk)
-   signal(cv_work, tsk.nthread)
+   critical task_ready: ::put(task_ready, tsk)
+   ::signal(cv_work, tsk.nthread)
    #write("waiting to finish...")
    tsk.wait()
    return tsk.reduce(tsk.result_list)
@@ -342,7 +342,7 @@ end
 
 
 method map_reduce(tsk, r_func, args, n)
-   if (type(tsk)=="procedure") then {
+   if (::type(tsk)=="procedure") then {
       tsk := Task(tsk, r_func, args, n)
       }
    else {
@@ -351,8 +351,8 @@ method map_reduce(tsk, r_func, args, n)
       }
 
    tsk.set_caller()
-   critical task_ready: put(task_ready, tsk)
-   signal(cv_work, tsk.nthread)
+   critical task_ready: ::put(task_ready, tsk)
+   ::signal(cv_work, tsk.nthread)
    #write("waiting to finish...")
    tsk.wait()
    return tsk.reduce(tsk.result_list)
@@ -363,18 +363,18 @@ method shutdown()
 end
 
 initially(n)
-   cv_work := condvar()
-   cv_master := condvar()
+   cv_work := ::condvar()
+   cv_master := ::condvar()
    if /n | n<1 then n := 8
-   thread_ready := mutex(set())
-   thread_active := mutex(set())
-   task_ready := mutex([ ])
-   task_active := mutex([ ])
-   every 1 to n do insert(thread_ready, thread thread_func())
- 
-   master := thread master_func()    
+   thread_ready := ::mutex(set())
+   thread_active := ::mutex(set())
+   task_ready := ::mutex([ ])
+   task_active := ::mutex([ ])
+   every 1 to n do ::insert(thread_ready, thread thread_func())
+
+   master := thread master_func()
    #Threads := self   # singleton class ?
-end 
+end
 
 
 #################################################################################
@@ -405,18 +405,18 @@ global Workforce    # The collection of all worker threads.
 procedure MakePool(n: integer: 0)
     local id
     initial {
-        Work := mutex()
-        ToDo := mutex([], Work)
-        Idlers := mutex([], Work)
+        Work := ::mutex()
+        ToDo := ::mutex([], Work)
+        Idlers := ::mutex([], Work)
         Workforce := []
     }
 
     if n <= 0 then { # Use default no of threads, which is 2 + number of cores
-        &features ? { ="CPU cores " & n := 2 + tab(0) }
+        &features ? { ="CPU cores " & n := 2 + ::tab(0) }
     }
-    
+
     # Create the requested number of workers and tell each one their thread id
-    while 0 <= (n-:= 1) do { put(Workforce, id := ( thread worker(<<@)) ); id @>> id }
+    while 0 <= (n-:= 1) do { ::put(Workforce, id := ( thread worker(<<@)) ); id @>> id }
 
     return #success
 end
@@ -425,7 +425,7 @@ end
 # dummy procedure used to request thread (self) termination.
 # NB. If called directly, causes an "emergency stop"
 procedure stopWork(reason: string: "")
-    stop("Emergency Exit: ", reason )
+    ::stop("Emergency Exit: ", reason )
 end
 
 #--------------------------------------------------------------------------------
@@ -433,19 +433,19 @@ end
 #              and call the procedure with the supplied parameters.
 procedure worker(MyId)
     local task, proc
-    if type(MyId) ~== "thread" then stopWork("Invalid thread Id")
+    if ::type(MyId) ~== "thread" then stopWork("Invalid thread Id")
 
     repeat {
-        lock(Work)
+        ::lock(Work)
         if 0 = *ToDo then {     # Nothing in queue, wait for work to arrive
-            push(Idlers, MyId)  # Indicate availability for work
-            unlock(Work)
+            ::push(Idlers, MyId)  # Indicate availability for work
+            ::unlock(Work)
             task := <<@         # Wait for work to arrive
         } else {
-            task := get(ToDo)   # Remove the next task from the queue
-            unlock(Work)
+            task := ::get(ToDo)   # Remove the next task from the queue
+            ::unlock(Work)
         }
-        proc := pop(task)       # Recover the procedure placed by Dispatch()
+        proc := ::pop(task)       # Recover the procedure placed by Dispatch()
         if (proc === stopWork) then { return } else { proc ! task }
     }
 end
@@ -455,16 +455,16 @@ end
 # to be executed by (one of) the pool of worker threads.
 procedure Dispatch(p, args[])
     local worker
-    if type(p) == "procedure" then {
-        push(args, p)           # Add the procedure to call to the front of the argument list
-        lock(Work)
+    if ::type(p) == "procedure" then {
+        ::push(args, p)           # Add the procedure to call to the front of the argument list
+        ::lock(Work)
         if 0 < *Idlers then {   # A worker thread is available
-            worker := pop(Idlers);
-            unlock(Work)
+            worker := ::pop(Idlers);
+            ::unlock(Work)
             args @>> worker     # send the task to the worker
         } else {                # No worker available; queue task for later.
-            put(ToDo, args)
-            unlock(Work)
+            ::put(ToDo, args)
+            ::unlock(Work)
         }
         return # success
     }
@@ -475,10 +475,10 @@ end
 #--------------------------------------------------------------------------------
 # Fail if there is work in progress, or waiting to be done.
 procedure IsIdle()
-    lock(Work)
-    if ((*Idlers ~= *Workforce) | (*ToDo > 0)) then { unlock(Work); fail }
+    ::lock(Work)
+    if ((*Idlers ~= *Workforce) | (*ToDo > 0)) then { ::unlock(Work); fail }
 
-    unlock(Work)
+    ::unlock(Work)
     return   # success
 end
 
@@ -488,16 +488,16 @@ end
 procedure ClosePool()
     local n
     every n := 1 to *Workforce do Dispatch(stopWork)
-    every wait(!Workforce)
+    every ::wait(!Workforce)
 
     # At this point, Idlers must be empty.
-    if *Idlers > 0 then stop("(ClosePool) Idlers queue not empty")
+    if *Idlers > 0 then ::stop("(ClosePool) Idlers queue not empty")
 
     Workforce := []
 
     # There ought to be no work to do, unless Dispatch() has been called in parallel with ClosePool()
     if *ToDo > 0 then {
-        write(&errout, "Warning (ClosePool): Some work is left in the queue")
+        ::write(&errout, "Warning (ClosePool): Some work is left in the queue")
         ToDo := []
         fail
     }

--- a/uni/lib/thread.icn
+++ b/uni/lib/thread.icn
@@ -78,7 +78,7 @@ procedure channel(x, port)
 	    if *L=0 then ::delete(chTable[ce], x)
 	    }
 	 else if \(L := chTable[x][ce]) then
-	       put(L, chnl := ::condvar([]))
+	       ::put(L, chnl := ::condvar([]))
          else {
 	    L := []
             ::put(L, chnl := ::condvar([]))
@@ -319,7 +319,7 @@ method submit_async(tsk, r_func, args, n)
     }
 
    tsk.set_caller()
-   critical task_ready: put(task_ready, tsk)
+   critical task_ready: ::put(task_ready, tsk)
    ::signal(cv_work, tsk.nthread)
 end
 

--- a/uni/lib/time.icn
+++ b/uni/lib/time.icn
@@ -37,7 +37,7 @@ global Time_data_months, Time_data_base_year, Time_data_week_days,
 # @ t := Time()           # t is uninitialized
 # @ t.set_current_time(Timezone(-18000))  # t now represents the current time;
 #                                         # time zone GMT-5hrs
-# @ t.parse("1990/12/2 11:22:03 -0500")  # the given date 
+# @ t.parse("1990/12/2 11:22:03 -0500")  # the given date
 # @ t.set_fields(1990, 12, 2, 11, 22, 03, Timezone(-18000))  # the same date
 # @ t.set_seconds(n, z)      # n seconds past the base date in GMT, +/-z mins
 #
@@ -55,9 +55,9 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    # @p
    method format_int(n, w)
       local s
-      s := string(n)
+      s := ::string(n)
       if *s < w then
-	 return right(s, w, "0")
+	 return ::right(s, w, "0")
       else
 	 return s
    end
@@ -104,49 +104,49 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 
    #
    # Format the instance using the given pattern string.  The pattern
-   # consists of pattern chars and other chars.  
-   # 
+   # consists of pattern chars and other chars.
+   #
    # The "width" of a field is the number of successive equal pattern
    # chars.  For example in the pattern
-   # 
+   #
    # yyyy/MMM/dd
-   # 
+   #
    # the widths are 4, 3 and 2 respectively.
-   # 
+   #
    # The possible pattern chars are :-
-   # 
+   #
    # E - The weekday.  A width < 4 gives the first three chars (eg Mon),
    # otherwise the full day is given (eg Monday)
-   # 
+   #
    # y - The year.  If the width is 2, the year will be the least
    # significant 2 digits (eg "99"), otherwise it is the full year
-   # padded to the width. 
-   # 
+   # padded to the width.
+   #
    # d - The day of the month padded to the width.
-   # 
+   #
    # H - The hour in the day using the 24 hour clock padded to the width.
-   # 
+   #
    # h - The hour in the day using the 12 hour clock padded to the width.
-   # 
+   #
    # M - The month of the year.  If the width is less than 3 then the
    # numeric value is used, padded to the width.  If the width is 3, then
    # the abbreviated month is used (eg "Jul"); otherwise the full month is
    # used (eg "July").
-   # 
+   #
    # m - The minute in the hour padded to the width.
-   # 
+   #
    # s - The second in the minute padded to the width.
-   # 
+   #
    # a - am or pm.  The width is ignored.
-   # 
+   #
    # A - AM or PM  The width is ignored.
-   # 
+   #
    # z - the timezone id (eg UTC or +0400).   The width is ignored.
-   # 
+   #
    # Literal strings (which can include the above chars) can be
    # included using single quotes.  Two single quotes maps to
    # an actual single quote.
-   # 
+   #
    # @example
    # @
    # @ yyyy MM dd HH mm ss -> 1999 12 17 23 30 01
@@ -154,18 +154,18 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    # @ yyyy/M/d HH:mm:ss zzz -> 1999/2/7 23:30:01 PST
    # @ E MMM dd HH:mm:ss zzz yyyy -> Mon Feb 07 23:30:01 PST 1999
    # @ yy MM dd HH mm ss -> 99 12 17 23 30 01
-   # 
+   #
    method format(p)
       local res, ch, w
-      
+
       /p := DEFAULT_FORMAT
 
       res := ""
       p ? {
-	 while not pos(0) do {
+	 while not ::pos(0) do {
 	    if any('EydHMhmsaAz') then {
 	       ch := p[&pos]
-	       w := *tab(many(ch))
+	       w := *::tab(::many(ch))
 	       res ||:= case ch of {
 		  "E": format_weekday(w)
 		  "y": format_year(w)
@@ -195,16 +195,16 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 		        "PM"
  		     }
 		  }
-	    } else if any('\'') then 
+	    } else if any('\'') then
 	       res ||:= match_literal()
-	    else 
-	       res ||:= move(1)
+	    else
+	       res ||:= ::move(1)
 	 }
       }
       return res
    end
 
-   # 
+   #
    # Get the next parsed int
    # @p
    method parse_int(w)
@@ -214,55 +214,55 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       # If there is a numeric field immediately following, limit the length
       # of this field.  This allows for example yyyyMMdd to parse 20001201.
       #
-      if any('ydHMhms') then 
+      if ::any('ydHMhms') then
 	 j >:= ppos + w
 
-      n := integer(psub[ppos:j])
+      n := ::integer(psub[ppos:j])
       ppos := j
       return n
    end
 
-   # 
+   #
    # Get the next parsed timezone
    # @p
    method parse_timezone()
       local j, z
-      j := many(Time_data_tzchars, psub, ppos)|return error("Timezone expected")
+      j := ::many(Time_data_tzchars, psub, ppos)|return error("Timezone expected")
       z := get_known_timezone(psub[ppos:j]) | return error("Invalid timezone")
       ppos := j
       return z
    end
 
-   # 
+   #
    # Get the next parsed am/pm
    # @p
    method parse_ampm()
       local s
-      s := map(psub[ppos+:2]) | return error("am/pm expected")
+      s := ::map(psub[ppos+:2]) | return error("am/pm expected")
       s == ("am" | "pm") | return error("am/pm expected")
       ppos +:= 2
       return s
    end
 
-   # 
+   #
    # Get the next parsed month
    # @p
    method parse_month(w)
       local j, m
       if w < 3 then
          return parse_int(w)
-      j := many(&ucase ++ &lcase, psub, ppos) | return error("Month expected")
+      j := ::many(&ucase ++ &lcase, psub, ppos) | return error("Month expected")
       m := month_to_num(psub[ppos:j]) | return error("Invalid month")
       ppos := j
       return m
    end
 
-   # 
+   #
    # Get the next parsed weekday
    # @p
    method parse_weekday()
       local j
-      j := many(&letters, psub, ppos) | return error("Weekday expected")
+      j := ::many(&letters, psub, ppos) | return error("Weekday expected")
       ppos := j
       return
    end
@@ -276,17 +276,17 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       ="\'"
       s := ""
       repeat {
-	 s ||:= tab(find("\'") | 0)
-	 if pos(0) then
+	 s ||:= ::tab(::find("\'") | 0)
+	 if ::pos(0) then
 	    break
-	 move(1)
+	 ::move(1)
 	 # Two ''s in a row mean a single ' and press on - else break.
 	 s ||:= ="'" | break
 	 }
       return s
    end
 
-   # 
+   #
    # Get the next parsed month
    # @p
    method parse_year(w)
@@ -300,55 +300,55 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 	 return n
    end
 
-   # 
+   #
    # Parse the instance using the given pattern string.  The pattern
    # consists of pattern chars and other chars.
-   # 
+   #
    # The "width" of a field is the number of successive equal pattern
    # chars.  For example in the pattern
-   # 
+   #
    # yyyy/MMM/dd
-   # 
+   #
    # the widths are 4, 3 and 2 respectively.
-   # 
+   #
    # Except for the month (see below), the only use of the width is to
    # separate adjacent fields, eg yyyyMMdd with input "19991201".
-   # 
+   #
    # The possible pattern chars are :-
-   # 
+   #
    # E - The weekday (eg Mon) - this is just a sequence of upper and lower
    # case chars and is otherwise ignored.
-   # 
+   #
    # y - The year.  If the year is less than 70 it is taken to be 20xx; if
    # it is less than 100 it is taken to be 19xx, otherwise it is as given.
-   # 
+   #
    # d - The day of the month
-   # 
+   #
    # H/h - The hour in the day
-   # 
+   #
    # M - The month of the year.  If the width is less than 3 then the
    # numeric value is expected, otherwise the textual value is expected.
-   # 
+   #
    # m - The minute in the hour
-   # 
+   #
    # s - The second in the minute
-   # 
+   #
    # a/A - am or pm.  Case is ignored.  If pm, then the hour is
    # adjusted accordingly in the result.
-   # 
+   #
    # z - The timezone (eg UTC or +0400).
    #
    method parse(s, p)
       local y, d, m, hh, mm, ss, z, ampm, lit, ch, w
-      
+
       /p := DEFAULT_FORMAT
       psub := s
       ppos := 1
       p ? {
-         while not pos(0) do {
-            if any('EydHMhmsaAz') then {
+         while not ::pos(0) do {
+            if ::any('EydHMhmsaAz') then {
                ch := p[&pos]
-               w := *tab(many(ch))
+               w := *::tab(::many(ch))
                case ch of {
 		  "E": parse_weekday() | fail
 		  "y": y := parse_year(w) | fail
@@ -360,18 +360,18 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 		  "z": z := parse_timezone() | fail
 		  "A"|"a": {
 		     ampm := parse_ampm() | fail
-		     if ampm == "pm" & (0 < \hh < 12) then 
+		     if ampm == "pm" & (0 < \hh < 12) then
 		        hh +:= 12
 		     }
 		  }
 	       }
-	    else if any('\'') then {
+	    else if ::any('\'') then {
 	       lit := match_literal()
-	       ppos := match(lit, psub, ppos) |
+	       ppos := ::match(lit, psub, ppos) |
 		  return error("Expected literal:" || lit)
 	       }
 	    else {
-	       ch := move(1)
+	       ch := ::move(1)
 	       while psub[ppos] == ch do
 	          ppos +:= 1
 	       }
@@ -380,7 +380,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       set_fields(y, m, d, hh, mm, ss, z)
       return
    end
-      
+
    #
    # Convert to string in accordance with RFC 822.
    #
@@ -402,7 +402,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       return format("d-MMM-yy")
    end
 
-   ##      
+   ##
    # Convert to icon &date format
    #
    # @p
@@ -516,7 +516,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 
       #
       # Normalize mday downwards, adjusting month, year as we go along
-      #     
+      #
       while self.mday > (n := get_days(self.year, self.month)) do {
          self.mday -:= n
          self.month +:= 1
@@ -528,7 +528,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 
       #
       # Normalize mday upwards, adjusting month, year as we go along
-      #     
+      #
       while self.mday < 1 do {
          self.month -:= 1
          if self.month = 0 then {
@@ -658,7 +658,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       self.mday := 1
       self.month := n
       self.compute_seconds()
-      
+
       d := get_days(self.year, self.month)
       if t > d then
          t := d
@@ -712,7 +712,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    method get_zone()
       return self.zone
    end
-   
+
    #
    # Get the seconds past the base date
    #
@@ -772,7 +772,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       else							# non-leap year
          [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365][m]
    end
-   
+
    #
    # Utility procedure - return in month m for year y
    #
@@ -787,10 +787,13 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    #
    # Utility to get next integer
    #
+   # Remove and allow the procedure get_int() from str_util.icn to be used
+   # instead as the code is identical to the procedure get_int()
+   #
    # @p
-   method get_int()
-      suspend tab(upto(&digits)) & integer(tab(many(&digits)))
-   end
+   #method get_int()
+   #   suspend ::tab(::upto(&digits)) & ::integer(::tab(::many(&digits)))
+   #end
 
    #
    # An alternative more liberal form of parsing.  The numeric fields are taken
@@ -836,7 +839,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    #
    # Set the fields
    #
-   method set_fields(year, month, mday, hour, min, sec, zone)   
+   method set_fields(year, month, mday, hour, min, sec, zone)
       self.year := \year | Time_data_base_year
       self.month := \month | 1
       self.mday := \mday | 1
@@ -893,9 +896,9 @@ procedure month_to_num(s)
       init_time()
    }
 
-   s := map(s)
+   s := ::map(s)
    every i := 1 to *Time_data_months do {
-      if match(s, map(Time_data_months[i])) then
+      if ::match(s, ::map(Time_data_months[i])) then
          return i
    }
 end
@@ -905,7 +908,7 @@ end
 # use the built-in function delay() instead.
 #
 procedure sleep(n)
-   return delay(\n)
+   return ::delay(\n)
 end
 
 #

--- a/uni/lib/time.icn
+++ b/uni/lib/time.icn
@@ -163,7 +163,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
       res := ""
       p ? {
 	 while not ::pos(0) do {
-	    if any('EydHMhmsaAz') then {
+	    if ::any('EydHMhmsaAz') then {
 	       ch := p[&pos]
 	       w := *::tab(::many(ch))
 	       res ||:= case ch of {
@@ -195,7 +195,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
 		        "PM"
  		     }
 		  }
-	    } else if any('\'') then
+	    } else if ::any('\'') then
 	       res ||:= match_literal()
 	    else
 	       res ||:= ::move(1)
@@ -209,7 +209,7 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
    # @p
    method parse_int(w)
       local j, n
-      j := many(&digits, psub, ppos) | return error("Digit expected")
+      j := ::many(&digits, psub, ppos) | return error("Digit expected")
       #
       # If there is a numeric field immediately following, limit the length
       # of this field.  This allows for example yyyyMMdd to parse 20001201.
@@ -810,8 +810,8 @@ class Time : Error : Object(seconds, year, month, mday, hour, min, sec,
          hh := get_int() | 0
          mm := get_int() | 0
          ss := get_int() | 0
-         if tab(upto(Time_data_tzchars)) then
-            z := get_known_timezone(tab(many(Time_data_tzchars))) |
+         if ::tab(::upto(Time_data_tzchars)) then
+            z := get_known_timezone(::tab(::many(Time_data_tzchars))) |
 	    return error("No timezone")
          else
             z := get_system_timezone()

--- a/uni/lib/timezone.icn
+++ b/uni/lib/timezone.icn
@@ -49,7 +49,7 @@ end
 
 procedure init_timezone()
    local s, t1, pat, t2, f, t
-   known_timezones := table()
+   known_timezones := ::table()
 
    utc_timezone := Timezone(0, "UTC")
    ::insert(known_timezones, "GMT", Timezone(0, "GMT"))

--- a/uni/lib/timezone.icn
+++ b/uni/lib/timezone.icn
@@ -30,11 +30,11 @@ class Timezone(offset, id)
 	 offset := 0
 	 }
       else if *a = 1 then {
-	 if type(a[1]) == "integer" then {
+	 if ::type(a[1]) == "integer" then {
 	    offset := a[1]
 	    id := (if offset < 0 then "-" else "+") ||
-	       right(abs(offset) / 3600, 2, "0") || 
-	       right((abs(offset) % 3600) / 60, 2, "0") 
+	       ::right(::abs(offset) / 3600, 2, "0") ||
+	       ::right((::abs(offset) % 3600) / 60, 2, "0")
 	    }
 	 else {
 	    id := a[1]
@@ -52,34 +52,34 @@ procedure init_timezone()
    known_timezones := table()
 
    utc_timezone := Timezone(0, "UTC")
-   insert(known_timezones, "GMT", Timezone(0, "GMT"))
-   insert(known_timezones, "UTC", utc_timezone)
-   insert(known_timezones, "UT", Timezone(0, "UT"))
-   insert(known_timezones, "BST", Timezone(3600, "BST"))
-   insert(known_timezones, "EST", Timezone(-18000, "EST"))
-   insert(known_timezones, "EDT", Timezone(-14400, "EDT"))
-   insert(known_timezones, "CST", Timezone(-21600, "CST"))
-   insert(known_timezones, "CDT", Timezone(-18000, "CDT"))
-   insert(known_timezones, "MST", Timezone(-25200, "MST"))
-   insert(known_timezones, "MDT", Timezone(-21600, "MDT"))
-   insert(known_timezones, "PST", Timezone(-28800, "PST"))
-   insert(known_timezones, "PDT", Timezone(-25200, "PDT"))
+   ::insert(known_timezones, "GMT", Timezone(0, "GMT"))
+   ::insert(known_timezones, "UTC", utc_timezone)
+   ::insert(known_timezones, "UT", Timezone(0, "UT"))
+   ::insert(known_timezones, "BST", Timezone(3600, "BST"))
+   ::insert(known_timezones, "EST", Timezone(-18000, "EST"))
+   ::insert(known_timezones, "EDT", Timezone(-14400, "EDT"))
+   ::insert(known_timezones, "CST", Timezone(-21600, "CST"))
+   ::insert(known_timezones, "CDT", Timezone(-18000, "CDT"))
+   ::insert(known_timezones, "MST", Timezone(-25200, "MST"))
+   ::insert(known_timezones, "MDT", Timezone(-21600, "MDT"))
+   ::insert(known_timezones, "PST", Timezone(-28800, "PST"))
+   ::insert(known_timezones, "PDT", Timezone(-25200, "PDT"))
 
    #
    # Set the system timezone
    #
-   s := gettimeofday()[1]
+   s := ::gettimeofday()[1]
    t1 := util::Time()
    pat := "E MMM dd hh:mm:ss yyyy zzzz"
-   t1.parse(ctime(s) || " +0000", pat) | stop("Couldn't parse ctime")
+   t1.parse(ctime(s) || " +0000", pat) | ::stop("Couldn't parse ctime")
    t2 := util::Time()
-   t2.parse(gtime(s) || " +0000", pat) | stop("Couldn't parse gtime")
+   t2.parse(gtime(s) || " +0000", pat) | ::stop("Couldn't parse gtime")
    system_timezone := Timezone(t1.get_seconds() - t2.get_seconds())
    # If possible, use a symbolic representation, eg "EST" instead of -0500
    if &features == "UNIX" then {
-      if f := open("date +%Z", "p") then {
-	 t := read(f)
-	 close(f)
+      if f := ::open("date +%Z", "p") then {
+	 t := ::read(f)
+	 ::close(f)
 	 }
       # Only use a known symbol whose offset agrees with the one just calculated
       if (\known_timezones[\t]).get_offset() = system_timezone.get_offset() then
@@ -109,18 +109,18 @@ procedure get_known_timezone(id)
    initial {
       init_timezone()
       }
-   if member(known_timezones, id) then
+   if ::member(known_timezones, id) then
       return known_timezones[id]
 
    id ? {
-      if any('+-') then {
-	 if any('-') then 
+      if ::any('+-') then {
+	 if ::any('-') then
 	    sign := -1
 	 else
 	    sign := 1
-	 move(1)
-	 s := tab(many(&digits)) | fail
-	 return Timezone(sign * 3600 * integer(s[1:3]) + 60 * integer(s[3:5]),
+	 ::move(1)
+	 s := ::tab(::many(&digits)) | fail
+	 return Timezone(sign * 3600 * ::integer(s[1:3]) + 60 * ::integer(s[3:5]),
 			 id) | fail
 	 }
       }

--- a/uni/lib/undomanager.icn
+++ b/uni/lib/undomanager.icn
@@ -46,7 +46,7 @@ class UndoManager:CompoundEdit(limit, index)
          return self.CompoundEdit.add_edit(other)
 
       while *l >= index do
-         pull(l)
+         ::pull(l)
 
       if not l[-1].add_edit(other) then {
          ::put(l, other)

--- a/uni/lib/undomanager.icn
+++ b/uni/lib/undomanager.icn
@@ -49,13 +49,13 @@ class UndoManager:CompoundEdit(limit, index)
          pull(l)
 
       if not l[-1].add_edit(other) then {
-         put(l, other)
+         ::put(l, other)
          index +:= 1
       }
 
       while (*l > limit) & (index > 1) do {
          index -:= 1
-         pop(l)
+         ::pop(l)
       }
    end
 

--- a/uni/lib/union.icn
+++ b/uni/lib/union.icn
@@ -169,7 +169,7 @@ procedure _toUs(u,uerror, seen)
          else if ::match("record ", tmp) then {
             s := "{record:"||ref||" \""||::type(u)||"\" "
             }
-         else return uerror.set_err(type(u) || " has no UniON equivalent")
+         else return uerror.set_err(::type(u) || " has no UniON equivalent")
          needComma := &null
          every k := ::key(u) do {
             if \needComma then s ||:= ","
@@ -183,7 +183,7 @@ procedure _toUs(u,uerror, seen)
 end
 
 procedure mkRef(u)
-   image(u) ? return "\""||::map(::tab(::upto('(')|0)," ","_")||"\""
+   ::image(u) ? return "\""||::map(::tab(::upto('(')|0)," ","_")||"\""
 end
 
 #####################
@@ -827,7 +827,7 @@ end
 procedure parse_set(token, token_gen, parse_funcs, refs, uerror)
    local union_array, union_value, prev_token, tok, s
    prev_token := "{"
-   s := set()
+   s := ::set()
    refs[@token_gen] := s
 
    while tok := @token_gen do {
@@ -847,7 +847,7 @@ procedure parse_set(token, token_gen, parse_funcs, refs, uerror)
          if prev_token == ("{"|",") then {
             union_value := func(tok, token_gen, parse_funcs, refs, uerror)
             prev_token := "value"
-            insert(s, union_value)
+            ::insert(s, union_value)
             }
          else return uerror.set_err("Expected comma in UniON set before: " ||
               tok)

--- a/uni/lib/union.icn
+++ b/uni/lib/union.icn
@@ -78,13 +78,13 @@ class Union:Object()
    #</p>
    method decode(s,error)
       local tok_gen, u, uerror
-   
+
       uerror := ErrorHandler()
       tok_gen := create union_scanner(s, uerror)
       while u := union_parser(tok_gen, uerror) do suspend u
       uerror.get_err()
    end
-   
+
    #<p>
    # Given a Unicon value, produce a UniON equivalent if possible.
    # <[param x Unicon value to encode into UniON]>
@@ -99,7 +99,7 @@ class Union:Object()
 initially
    Union := create |self
 end
-   
+
 #<p>
 # Given a Unicon structure, produce a UniON equivalent if possible.
 # <b><i>Intended for internal use only.</i></b>
@@ -108,20 +108,20 @@ end
 #</p>
 procedure _toUs(u,uerror, seen)
    local s, tmp, firstElem, ref
-   /seen := set()
-   case type(u) of {
-      "null": return type(u)
+   /seen := ::set()
+   case ::type(u) of {
+      "null": return ::type(u)
       "string": {
          return      if u == "__true__" then "true"
                 else if u == "__false__" then "false"
                 else unionify_string(u,uerror)
          }
-      "integer" | "real": return image(u)
+      "integer" | "real": return ::image(u)
       "cset": return ximage(u)
       "list": {
          ref := mkRef(u)
-         if member(seen,ref) then return "{ref:"||ref||"}"
-         insert(seen,ref)
+         if ::member(seen,ref) then return "{ref:"||ref||"}"
+         ::insert(seen,ref)
          s := "["||ref||" "
          if *u > 0 then s ||:= _toUs(u[1],uerror,seen)
          every i := 2 to *u do {
@@ -132,8 +132,8 @@ procedure _toUs(u,uerror, seen)
          }
       "set": {
          ref := mkRef(u)
-         if member(seen,ref) then return "{ref:"||ref||"}"
-         insert(seen,ref)
+         if ::member(seen,ref) then return "{ref:"||ref||"}"
+         ::insert(seen,ref)
          s := "{set:"||mkRef(u)||" "; i := 1
          every x := !u do {
             if i>1 then s ||:= ","
@@ -145,11 +145,11 @@ procedure _toUs(u,uerror, seen)
          }
       "table": {
          ref := mkRef(u)
-         if member(seen,ref) then return "{ref:"||ref||"}"
-         insert(seen,ref)
+         if ::member(seen,ref) then return "{ref:"||ref||"}"
+         ::insert(seen,ref)
          s := "{table:"||mkRef(u)||" "
          firstElem := "y"
-         every k := key(u) do {
+         every k := ::key(u) do {
             if /firstElem then s ||:= ","
             firstElem := &null
             s ||:= _toUs(k,uerror,seen) || ":" || _toUs(u[k],uerror,seen) | fail
@@ -159,19 +159,19 @@ procedure _toUs(u,uerror, seen)
          }
       default: {
          ref := mkRef(u)
-         if member(seen,ref) then return "{ref:"||ref||"}"
-         insert(seen,ref)
-         tmp := image(u)
+         if ::member(seen,ref) then return "{ref:"||ref||"}"
+         ::insert(seen,ref)
+         tmp := ::image(u)
          # Class - Do we care about method names? Currently we don't
-         if match("object ", tmp) then {
-            s := "{object:"||ref||" \""||classname(u)||"\" "
+         if ::match("object ", tmp) then {
+            s := "{object:"||ref||" \""||::classname(u)||"\" "
             }
-         else if match("record ", tmp) then {
-            s := "{record:"||ref||" \""||type(u)||"\" "
+         else if ::match("record ", tmp) then {
+            s := "{record:"||ref||" \""||::type(u)||"\" "
             }
          else return uerror.set_err(type(u) || " has no UniON equivalent")
          needComma := &null
-         every k := key(u) do {
+         every k := ::key(u) do {
             if \needComma then s ||:= ","
             needComma := "y"
             s ||:= unionify_string(k)|| ":" || _toUs(u[k],uerror,seen) | fail
@@ -183,7 +183,7 @@ procedure _toUs(u,uerror, seen)
 end
 
 procedure mkRef(u)
-   image(u) ? return "\""||map(tab(upto('(')|0)," ","_")||"\""
+   image(u) ? return "\""||::map(::tab(::upto('(')|0)," ","_")||"\""
 end
 
 #####################
@@ -191,7 +191,7 @@ end
 #####################
 
 #<p>
-# A string-scanning generator - takes a UniON-formatted string 
+# A string-scanning generator - takes a UniON-formatted string
 # and returns single UniON tokens until scanning is complete
 # <b><i>Intended for internal use only.</i></b>
 # <[param s UniON string to convert]>
@@ -199,7 +199,7 @@ end
 #</p>
 procedure union_scanner(s,uerror)
    local token
-   local end_pos := *s + 1 
+   local end_pos := *s + 1
    static ws, operator, number
 
    initial {
@@ -210,7 +210,7 @@ procedure union_scanner(s,uerror)
 
    s ? {
       repeat {
-         tab(many(ws))
+         ::tab(::many(ws))
          # Special case Unicon structures (UniON objects)
          if ="ref:"         then token := "ref"
          else if ="set:"    then token := "set"
@@ -218,9 +218,9 @@ procedure union_scanner(s,uerror)
          else if ="record:" then token := "record"
          else if ="object:" then token := "object"
          else {
-            c := move(1) | fail
-            if any(operator, c) then token := c
-            else if any(number, c) then token := scan_number(c,uerror) | fail
+            c := ::move(1) | fail
+            if ::any(operator, c) then token := c
+            else if ::any(number, c) then token := scan_number(c,uerror) | fail
             else if c == "\"" then token := scan_string(uerror) | fail
             else if c == "'"  then token := scan_cset(uerror) | fail
             else if c == "t"  then token := scan_true(uerror) | fail
@@ -228,7 +228,7 @@ procedure union_scanner(s,uerror)
             else if c == "n"  then token := scan_null(uerror) | fail
             else if c == "\n" then { uerror.incr_line(); next }
             else return uerror.set_err("Unrecognized UniON token: " ||
-                      c || tab(upto(ws++operator)\1))
+                      c || ::tab(::upto(ws++operator)\1))
             }
          suspend token
          }
@@ -242,10 +242,10 @@ end
 # <[param uerror Error handling support class instance]>
 #</p>
 procedure scan_true(uerror)
-   if move(3) == "rue" then return "true"
-   else return uerror.set_err("Expected UniON true: " || 
-                "t"||tab(upto(' \t\n{}[]:,')\1))
-end   
+   if ::move(3) == "rue" then return "true"
+   else return uerror.set_err("Expected UniON true: " ||
+                "t"||::tab(::upto(' \t\n{}[]:,')\1))
+end
 
 #<p>
 # String scanning helper function to retrieve UniON value 'false'
@@ -253,9 +253,9 @@ end
 # <[param uerror Error handling support class instance]>
 #</p>
 procedure scan_false(uerror)
-   if move(4) == "alse" then return "false"
-   else return uerror.set_err("Expected UniON false: " || 
-                "f"||tab(upto(' \t\n{}[]:,')\1))
+   if ::move(4) == "alse" then return "false"
+   else return uerror.set_err("Expected UniON false: " ||
+                "f"||::tab(::upto(' \t\n{}[]:,')\1))
 end
 
 #<p>
@@ -264,9 +264,9 @@ end
 # <[param uerror Error handling support class instance]>
 #</p>
 procedure scan_null(uerror)
-   if move(3) == "ull" then return "null" 
-   else return uerror.set_err("Expected UniON null: " || 
-                "n"||tab(upto(' \t\n{}[]:,')\1))
+   if ::move(3) == "ull" then return "null"
+   else return uerror.set_err("Expected UniON null: " ||
+                "n"||::tab(::upto(' \t\n{}[]:,')\1))
 end
 
 #<p>
@@ -282,7 +282,7 @@ procedure scan_ctrl_char(uerror)
    #
    # This code is modified from escape() from IPL file escape.icn
    #
-   case (c := move(1)) | 
+   case (c := ::move(1)) |
         return uerror.set_err("Incomplete UniON escape sequence") of {
       "b":  return "\b"
       "d":  return "\d"
@@ -304,7 +304,7 @@ procedure scan_ctrl_char(uerror)
 end
 
 #<p>
-# String scanning helper function that identifies a UniON string and 
+# String scanning helper function that identifies a UniON string and
 # returns a Unicon string
 # <b><i>Intended for internal use only.</i></b>
 # <[param uerror Error handling support class instance]>
@@ -313,20 +313,20 @@ procedure scan_string(uerror)
    local str, ctrl, c, is_cset
    str := ""
 
-   while any(~'\"', c := move(1)) do {
+   while ::any(~'\"', c := ::move(1)) do {
       if c ~== "\\" then str ||:= c
-      else { 
+      else {
          if ctrl := scan_ctrl_char(uerror) then str ||:= ctrl
          else fail
          }
       }
-   if move(1) == "\"" then return "\""||str||"\""
+   if ::move(1) == "\"" then return "\""||str||"\""
    else return uerror.set_err(
-               "UniON string missing terminating double-quotes: " || str) 
+               "UniON string missing terminating double-quotes: " || str)
 end
 
 #<p>
-# String scanning helper function that identifies a UniON cset and 
+# String scanning helper function that identifies a UniON cset and
 # returns a Unicon cset.
 # <b><i>Intended for internal use only.</i></b>
 # <[param uerror Error handling support class instance]>
@@ -335,16 +335,16 @@ procedure scan_cset(uerror)
    local str, ctrl, c, is_cset
    str := ""
 
-   while any(~'\'', c := move(1)) do {
+   while ::any(~'\'', c := ::move(1)) do {
       if c ~== "\\" then str ||:= c
-      else { 
+      else {
          if ctrl := scan_ctrl_char(uerror) then str ||:= ctrl
          else fail
          }
       }
-   if move(1) == "'" then return "'"||str||"'"
+   if ::move(1) == "'" then return "'"||str||"'"
    else return uerror.set_err(
-               "UniON cset missing terminating single-quote: " || str) 
+               "UniON cset missing terminating single-quote: " || str)
 end
 
 #<p>
@@ -356,46 +356,46 @@ end
 procedure scan_number(c,uerror)
    local num_str
    num_str := ""
- 
+
    # if negative
    if c == "-" then {
       num_str ||:= c
-      c := move(1)
+      c := ::move(1)
       }
 
-   # integer 
-   if any(&digits,c) then {
+   # integer
+   if ::any(&digits,c) then {
       num_str ||:= c
       if c == "0" then {
          # number starting with 0 is either 0, frac, or exp
-         if any(&digits,move(1)) then 
-            return uerror.set_err("UniON int cannot have leading zero: " || 
+         if ::any(&digits,move(1)) then
+            return uerror.set_err("UniON int cannot have leading zero: " ||
                    num_str)
-         } 
+         }
       # c is 1-9, get all sequential digits
-      else num_str ||:= tab(many(&digits)) 
+      else num_str ||:= ::tab(::many(&digits))
       }
-   
-   # fraction 
-   if (c := move(1)) == "." then {
+
+   # fraction
+   if (c := ::move(1)) == "." then {
       num_str ||:= c
-      if not (num_str ||:= tab(many(&digits))) then 
-         return uerror.set_err("Expected digits after '.' in UniON frac: " || 
+      if not (num_str ||:= ::tab(::many(&digits))) then
+         return uerror.set_err("Expected digits after '.' in UniON frac: " ||
                 num_str)
       }
    # exponent
-   if any('eE',c := move(1)) then { 
+   if ::any('eE',c := ::move(1)) then {
       num_str ||:= c
-      if (c := move(1)) == "-" then num_str ||:= c
-      else if (c := move(1)) == "+" then {}
+      if (c := ::move(1)) == "-" then num_str ||:= c
+      else if (c := ::move(1)) == "+" then {}
 
-      if not (num_str ||:= tab(many(&digits))) then 
+      if not (num_str ||:= ::tab(::many(&digits))) then
          return uerror.set_err("Expected digits after 'e' in UniON exp: " ||
                    num_str)
-      } 
+      }
    return num_str
 end
-   
+
 #########################
 # END SCANNER FUNCTIONS #
 #########################
@@ -425,12 +425,12 @@ procedure union_parser(token_gen,uerror)
    static parse_funcs, refs
 
    initial {
-      parse_funcs := table()
+      parse_funcs := ::table()
 
-      parse_funcs["{"] := parse_object 
-      parse_funcs["["] := parse_array 
-      parse_funcs["\""] := parse_string 
-      parse_funcs["'"] := parse_string 
+      parse_funcs["{"] := parse_object
+      parse_funcs["["] := parse_array
+      parse_funcs["\""] := parse_string
+      parse_funcs["'"] := parse_string
       parse_funcs["-"] := parse_number
       parse_funcs["0"] := parse_number
       parse_funcs["1"] := parse_number
@@ -446,9 +446,9 @@ procedure union_parser(token_gen,uerror)
       parse_funcs["f"] := parse_false
       parse_funcs["n"] := parse_null
 
-      refs := table()
+      refs := ::table()
       }
-   
+
    while token := @token_gen do {
       if \(func := parse_funcs[token[1]]) then {
          if struct := func(token, token_gen, parse_funcs, refs, uerror) then
@@ -505,7 +505,7 @@ end
 # <b><i>Intended for internal use only.</i></b>
 #</p>
 procedure parse_number(token, token_gen, parse_funcs, refs, uerror)
-   return numeric(token)
+   return ::numeric(token)
 end
 
 #<p>
@@ -514,8 +514,8 @@ end
 # <b><i>Intended for internal use only.</i></b>
 #</p>
 procedure parse_string(token, token_gen, parse_funcs, refs, uerror)
-   if token[1] == "\'" then 
-      return cset(token[2:-1])
+   if token[1] == "\'" then
+      return ::cset(token[2:-1])
    else
       return escape(token[2:-1])
 end
@@ -555,7 +555,7 @@ procedure parse_record(token, token_gen, parse_funcs, refs, uerror)
    local rName, union_object, union_key, union_value, prev_token, tok, r
    ref := @token_gen
    rName := (@token_gen)[2:-1]  # skips ":" and strips quotes
-   if not proc(rName) then {	# No constructor in this context
+   if not ::proc(rName) then {	# No constructor in this context
       uerror.set_err("No constructor for record '"||rName||" in this context.")
       fail
       }
@@ -592,31 +592,31 @@ procedure parse_record(token, token_gen, parse_funcs, refs, uerror)
             if \(func := parse_funcs[tok[1]]) then {
                union_key := func(tok, token_gen, parse_funcs, refs, uerror)
                }
-            else 
+            else
                return uerror.set_err("Expected UniON key in UniON pair" ||                        ", got: " || tok)
 
             # check for colon
-            if (tok := @token_gen) == ":" then prev_token := tok 
+            if (tok := @token_gen) == ":" then prev_token := tok
             else return uerror.set_err(
                         "Expected colon in UniON pair before: " || tok)
 
-            # value 
+            # value
             if tok := @token_gen then {
                if \(func := parse_funcs[tok[1]]) then {
                   union_value := func(tok, token_gen, parse_funcs, refs, uerror)
                   r[union_key] := union_value
                   prev_token := "value"
                   }
-               else 
+               else
                   return uerror.set_err("Expected UniON value in UniON pair" ||                        ", got: " || tok)
                }
-            else 
+            else
                return uerror.set_err("UniON pair missing UniON value")
             }
 
       # Invalid object syntax
       else {
-         if prev_token == (","|"{") then 
+         if prev_token == (","|"{") then
             return uerror.set_err("Expected UniON pair, got: " || tok)
          else
             return uerror.set_err("Token violated UniON object syntax: " ||
@@ -635,7 +635,7 @@ procedure parse_class(token, token_gen, parse_funcs, refs, uerror)
    local ref
    ref := @token_gen
    cName := (@token_gen)[2:-1]  # skips ":" and strips quotes
-   if not proc(cName) then {	# No constructor in this context
+   if not ::proc(cName) then {	# No constructor in this context
       uerror.set_err("No constructor for class '"||cName||" in this context.")
       fail
       }
@@ -672,31 +672,31 @@ procedure parse_class(token, token_gen, parse_funcs, refs, uerror)
             if \(func := parse_funcs[tok[1]]) then {
                union_key := func(tok, token_gen, parse_funcs, refs, uerror)
                }
-            else 
+            else
                return uerror.set_err("Expected UniON key in UniON pair" ||                        ", got: " || tok)
 
             # check for colon
-            if (tok := @token_gen) == ":" then prev_token := tok 
+            if (tok := @token_gen) == ":" then prev_token := tok
             else return uerror.set_err(
                         "Expected colon in UniON pair before: " || tok)
 
-            # value 
+            # value
             if tok := @token_gen then {
                if \(func := parse_funcs[tok[1]]) then {
                   union_value := func(tok, token_gen, parse_funcs, refs, uerror)
                   cl[union_key] := union_value
                   prev_token := "value"
                   }
-               else 
+               else
                   return uerror.set_err("Expected UniON value in UniON pair" ||                        ", got: " || tok)
                }
-            else 
+            else
                return uerror.set_err("UniON pair missing UniON value")
             }
 
       # Invalid class syntax
       else {
-         if prev_token == (","|"{") then 
+         if prev_token == (","|"{") then
             return uerror.set_err("Expected UniON pair, got: " || tok)
          else
             return uerror.set_err("Token violated UniON class syntax: " ||
@@ -711,7 +711,7 @@ end
 #</p>
 procedure parse_table(token, token_gen, parse_funcs, refs, uerror)
    local union_object, union_key, union_value, prev_token, tok, pt
-   union_object := table()
+   union_object := ::table()
 
    refs[@token_gen] := union_object
    prev_token := "{"
@@ -737,31 +737,31 @@ procedure parse_table(token, token_gen, parse_funcs, refs, uerror)
             if \(func := parse_funcs[tok[1]]) then {
                union_key := func(tok, token_gen, parse_funcs, refs, uerror)
                }
-            else 
+            else
                return uerror.set_err("Expected UniON key in UniON pair" ||                        ", got: " || tok)
 
             # check for colon
-            if (tok := @token_gen) == ":" then prev_token := tok 
+            if (tok := @token_gen) == ":" then prev_token := tok
             else return uerror.set_err(
                         "Expected colon in UniON pair before: " || tok)
 
-            # value 
+            # value
             if tok := @token_gen then {
                if \(func := parse_funcs[tok[1]]) then {
                   union_value := func(tok, token_gen, parse_funcs, refs, uerror)
                   prev_token := "value"
                   union_object[union_key] := union_value
                   }
-               else 
+               else
                   return uerror.set_err("Expected UniON value in UniON pair" ||                        ", got: " || tok)
                }
-            else 
+            else
                return uerror.set_err("UniON pair missing UniON value")
             }
 
       # Invalid object syntax
       else {
-         if prev_token == (","|"{") then 
+         if prev_token == (","|"{") then
             return uerror.set_err("Expected UniON pair, got: " || tok)
          else
             return uerror.set_err("Token violated UniON object syntax: " ||
@@ -792,28 +792,28 @@ procedure parse_array(token, token_gen, parse_funcs, refs, uerror)
 
       # comma can only come after a value (not [ or ,)
       else if tok == "," then {
-         if not any('[,', prev_token) then prev_token := tok
+         if not ::any('[,', prev_token) then prev_token := tok
          else return uerror.set_err("Unexpected comma in UniON array")
          }
 
       # value
       else if \(func := parse_funcs[tok[1]]) then {
-         if prev_token == ("["|",") then { 
+         if prev_token == ("["|",") then {
             union_value := func(tok, token_gen, parse_funcs, refs, uerror)
             prev_token := "value"
-            put(union_array, union_value) 
+            ::put(union_array, union_value)
             }
          else return uerror.set_err("Expected comma in UniON array before: " ||
               tok)
          }
-        
+
       # invalid array syntax
-      else { 
+      else {
          if prev_token == ("["|",") then
             return uerror.set_err("Expected UniON value, got: " || tok)
          else
-            return uerror.set_err("Token violated UniON array syntax: " || 
-                tok) 
+            return uerror.set_err("Token violated UniON array syntax: " ||
+                tok)
          }
       }
    return uerror.set_err("Expected terminating ] for UniON array")
@@ -838,27 +838,27 @@ procedure parse_set(token, token_gen, parse_funcs, refs, uerror)
 
       # comma can only come after a value (not [ or ,)
       else if tok == "," then {
-         if not any('{,', prev_token) then prev_token := tok
+         if not ::any('{,', prev_token) then prev_token := tok
          else return uerror.set_err("Unexpected comma in UniON set")
          }
 
       # value
       else if \(func := parse_funcs[tok[1]]) then {
-         if prev_token == ("{"|",") then { 
+         if prev_token == ("{"|",") then {
             union_value := func(tok, token_gen, parse_funcs, refs, uerror)
             prev_token := "value"
-            insert(s, union_value) 
+            insert(s, union_value)
             }
          else return uerror.set_err("Expected comma in UniON set before: " ||
               tok)
          }
-        
+
       # invalid set syntax
-      else { 
+      else {
          if prev_token == ("{"|",") then
             return uerror.set_err("Expected UniON value, got: " || tok)
          else
-            return uerror.set_err("Token violated UniON set syntax: " || tok) 
+            return uerror.set_err("Token violated UniON set syntax: " || tok)
          }
       }
    return uerror.set_err("Expected terminating } for UniON set")
@@ -888,14 +888,14 @@ class ErrorHandler:Object(lineno, error, tag)
    # Writes error (s) to <tt>&errout</tt>
    #</p>
    method write_err(s)
-      write(&errout,tag||" "||s)
+      ::write(&errout,tag||" "||s)
    end
 
    #<p>
    # Write out <tt>error</tt>, if it exists, to &errout
    #</p>
-   method get_err() 
-       if \error then write(&errout, error)
+   method get_err()
+       if \error then ::write(&errout, error)
    end
 
 initially()

--- a/uni/lib/url.icn
+++ b/uni/lib/url.icn
@@ -101,7 +101,7 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
       s ||:= "#" || \self.ref
       return s
    end
-   
+
    #
    # Open a file based on the address and the port and return it.
    #
@@ -123,19 +123,19 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    method extract_cgi_parameters()
       local cgi, s, key, data, val
 
-      cgi := table()
+      cgi := ::table()
       self.file ? {
-	 if tab(find("?")) then {
-	    move(1)
-	    while not pos(0) do {
-	       key := tab(upto('&=') | 0)
+	 if ::tab(::find("?")) then {
+	    ::move(1)
+	    while not ::pos(0) do {
+	       key := ::tab(::upto('&=') | 0)
 	       if ="=" then
-	          val := extract_hex(tab(find("&") | 0))
+	          val := extract_hex(::tab(::find("&") | 0))
 	       else
 	          val := ""
 	       ="&"
 	       /cgi[key] := []
-	       put(cgi[key], val)
+	       ::put(cgi[key], val)
 	    }
 	 }
       }
@@ -148,7 +148,7 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    # @param cgi   The table of keys/values.
    #
    method set_cgi_parameters(cgi)
-      self.file ?:= tab(find("?") | 0) || "?" || make_cgi_string(cgi)
+      self.file ?:= ::tab(::find("?") | 0) || "?" || make_cgi_string(cgi)
    end
 
    #
@@ -157,8 +157,8 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    method make_cgi_string(cgi)
       local l, s
       s := ""
-      every l := !sort(cgi) do {
-	 if string(l[2]) then
+      every l := !::sort(cgi) do {
+	 if ::string(l[2]) then
 	    s ||:= convert_hex(l[1]) || "=" || convert_hex(l[2]) || "&"
 	 else
 	    every s ||:= convert_hex(l[1]) || "=" || convert_hex(!l[2]) || "&"
@@ -173,17 +173,17 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    method convert_hex(s)
       local res
       static convert_chars
-      initial 
+      initial
 	 convert_chars := &lcase ++ &ucase ++ &digits ++ '_*.- '
 
       res := ""
       s ? repeat {
-	 res ||:= tab(many(convert_chars))
-	 if pos(0) then
+	 res ||:= ::tab(::many(convert_chars))
+	 if ::pos(0) then
 	    break
-	 res ||:= "%" || format_int_to_string(ord(move(1)),,2)
+	 res ||:= "%" || format_int_to_string(::ord(::move(1)),,2)
 	 }
-      res := map(res, " ", "+")
+      res := ::map(res, " ", "+")
       return res
    end
 
@@ -193,13 +193,13 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    method extract_hex(s)
       local res
       res := ""
-      s := map(s, "+", " ") 
+      s := ::map(s, "+", " ")
       s ? repeat {
-	 res ||:= tab(find("%") | 0)
-	 if pos(0) then
+	 res ||:= ::tab(::find("%") | 0)
+	 if ::pos(0) then
 	    break
-	 move(1)
-	 res ||:= char(format_string_to_int(move(2)))
+	 ::move(1)
+	 res ||:= ::char(format_string_to_int(::move(2)))
 	 }
       return res
    end
@@ -209,24 +209,24 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    #
    method parse(s)
       s ? {
-	 set_protocol(1(tab(many(&letters)), ="://") | "http")
-	 set_address(tab(upto(':/') | 0))
+	 set_protocol(1(::tab(::many(&letters)), ="://") | "http")
+	 set_address(::tab(::upto(':/') | 0))
 
 	 if =":" then {
-	    set_port(integer(tab(many(&digits)))) | return error("Bad port")
+	    set_port(::integer(::tab(::many(&digits)))) | return error("Bad port")
 	    }
 	 else
 	    set_port(getserv(get_protocol() | "www").port) |
 	       return error("Unknown protocol")
 
-	 if pos(0) then
+	 if ::pos(0) then
 	    set_file("/")
 	 else {
-	    any('/') | fail
-	    set_file(tab(find("#") | 0))
-	    if any('#') then {
-	       move(1)
-	       set_ref(tab(0))
+	    ::any('/') | fail
+	    set_file(::tab(::find("#") | 0))
+	    if ::any('#') then {
+	       ::move(1)
+	       set_ref(::tab(0))
 	    }
 	 }
       }
@@ -242,7 +242,7 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
       if s[1] == "#" then
 	 #
 	 # Just reference, filename doesn't change.
-	 # 
+	 #
 	 set_ref(s[2:0])
       else {
 	 #
@@ -253,9 +253,9 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
 	    s := get_file_dir() || s
 
 	 s ? {
-	    set_file(tab(find("#") | 0))
+	    set_file(::tab(::find("#") | 0))
 	    if ="#" then {
-	       set_ref(tab(0))
+	       set_ref(::tab(0))
 	       }
 	    else
 	       set_ref()
@@ -268,8 +268,8 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    #
    method get_file_last()
       file ? {
-	 while tab(find("/")+1)
-	 return tab(0)
+	 while ::tab(::find("/")+1)
+	 return ::tab(0)
 	 }
    end
 
@@ -278,8 +278,8 @@ class URL : Error : Object : SelectiveClassCoding(protocol, address, file, ref,
    #
    method get_file_dir()
       file ? {
-	 while tab(find("/")+1)
-	 return tab(1)
+	 while ::tab(::find("/")+1)
+	 return ::tab(1)
 	 }
    end
 


### PR DESCRIPTION
Updates have been made to uni/lib/langprocs.icn to use the Unicon functions fieldnames(r), serial(o), membernames(o) and methodnames(o) to remove implementation dependencies within the langprocs procedures.

Two of the langproc procedures get_class_name(o) and get_id(o) have been marked deprecated as get_class_name is a direct match for classname() and get_id is a direct match for serial().