### PR TITLE
Add records to member().  Patch from Clint.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2728,7 +2728,7 @@ arguments, which must be numeric.
 
 \noindent
 \index{member()}\texttt{member(x, ...)} returns \texttt{x} if its second
-and subsequent arguments are all members of set, cset, list or table
+and subsequent arguments are all members of set, cset, list, table or record
 \texttt{x} but fails otherwise. If \texttt{x} is a cset, all of the
 characters in subsequent string arguments must be present in \texttt{x}
 in order to succeed.


### PR DESCRIPTION
This is an update from Clint to add a test for whether a string is a
field name in a record (as described in section 2.3 of the Unicon book).