### PR TITLE
cfuncs: drop unnecessary dylib linker option

### DIFF
--- a/configure
+++ b/configure
@@ -6973,7 +6973,7 @@ case $unicon_host in
      *bsd*)
         ;;
      *macos*)
-       LDDYN="-Xlinker -dylib -Xlinker -undefined -Xlinker dynamic_lookup -shared "
+       LDDYN="-Xlinker -undefined -Xlinker dynamic_lookup -shared "
        DASHX=-x
        RLIBS="-ldl "
 	;;

--- a/configure.ac
+++ b/configure.ac
@@ -318,7 +318,7 @@ case $unicon_host in
      *bsd*)
         ;;
      *macos*)
-       LDDYN="-Xlinker -dylib -Xlinker -undefined -Xlinker dynamic_lookup -shared "
+       LDDYN="-Xlinker -undefined -Xlinker dynamic_lookup -shared "
        DASHX=-x
        RLIBS="-ldl "
 	;;

--- a/ipl/cfuncs/Makefile
+++ b/ipl/cfuncs/Makefile
@@ -42,8 +42,9 @@ windows:
 	echo cfuncs are not supported on Windows builds yet
 
 # library
-$(FUNCLIB):	$(FUNCS) mklib.sh
-		CC="$(CC)" CFLAGS="$(CFLAGS)" sh mklib.sh $(FUNCLIB) $(FUNCS)
+$(FUNCLIB):	$(FUNCS)
+		$(CC) $(LDDYN) -o $(FUNCLIB) $(CFDYN) $(FUNCS)
+
 $(FUNCS):	icall.h
 
 # Icon interface
@@ -55,4 +56,4 @@ cfunc.icn:	$(CSRC) mkfunc.sh
 
 # cleanup
 clean Clean:
-	-rm -f $(FUNCLIB) *.o *.u? *.so so_locations
+	-$(RM) -f $(FUNCLIB) *.o *.u? *.so so_locations


### PR DESCRIPTION
Also move building the cfunc dynamic library from a script to the Makefile
Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>