### PR TITLE
JSON library bug fix

### DIFF
--- a/doc/utr/utr20.tex
+++ b/doc/utr/utr20.tex
@@ -3,9 +3,9 @@
 \usepackage[margin=1in]{geometry}
 
 \title{The Unicon JSON Library}
-\author{Gigi Young, Clinton Jeffery}
+\author{Gigi Young and Clinton Jeffery}
 \trnumber{20}
-\date{October 9, 2018}
+\date{October 16, 2020}
 
 \begin{document}
 \abstract{

--- a/uni/lib/json.icn
+++ b/uni/lib/json.icn
@@ -846,11 +846,6 @@ procedure parse_object(token, token_gen, parse_funcs, jerror)
                      "__uniclass__": { 
                         if constr := proc(json_value) then {
                            fields := membernames(json_value)
-                           # Get rid of internal class members: 
-                           # [name, methods, methods_map, variables, 
-                           # state_instance, oprec, supers, implemented_classes]
-                           if fields[-1] == "implemented_classes" then
-                              fields := fields[1:-8]
                            attribs := list(*fields) 
                            next
                            }


### PR DESCRIPTION
-The library incorrectly removed eight fieldnames from Robert Parlett's
 class "Class".
-Additionally, amended the date of UTR20.

Signed-off-by: Gigi Young <kzyoung93@gmail.com>