### PR TITLE
Fix Unicon compiler crash after emitting a warning (Patch from Clint)

### DIFF
--- a/uni/unicon/Makefile
+++ b/uni/unicon/Makefile
@@ -61,7 +61,7 @@ ca.u : ca.icn
 #unigram.u: unigram.icn
 #	$(ICONT) -c unigram
 
-# build iyacc, and uncomment these lines, if you change the language grammar
+# build iyacc, and uncomment these lines, if you change the language grammar (or unigram.y)
 #unigram.icn : unigram.y ytab_h.icn
 #	$(IYACC) -i unigram.y
 

--- a/uni/unicon/unigram.icn
+++ b/uni/unicon/unigram.icn
@@ -2900,7 +2900,6 @@ procedure yyparse()
   local yys        # current token string
   local doaction   # set to 1 if there need to execute action
   local token      # current token
-  local arv        # action return value (0=accept; 1=abort; else fail)
 
   if /yytable then init() 
   init_stacks() 
@@ -3114,7 +3113,7 @@ procedure action_18()
    yyval.name := package_mangled_symbol(valstk[5].s)
    if proc(yyval.name, 0) then
       warning("Warning: class "|| yyval.name ||" overrides the built-in function")
-   else if \ (foobar := classes.lookup(yyval.name)) then {
+   if \ (foobar := classes.lookup(yyval.name)) then {
       yyerror("redeclaration of class " || yyval.name)
       }
    else
@@ -4470,4 +4469,4 @@ procedure action_323()
  yyval := node("error") 
 end
 
-#line 4477 "unigram.icn"
+#line 4476 "unigram.icn"

--- a/uni/unicon/unigram.u
+++ b/uni/unicon/unigram.u
@@ -1,5 +1,5 @@
 version	U12.1.00
-uid	unigram.u1-1526502907-0
+uid	unigram.u1-1606758396-0
 record	ParseError,2
 	0,lineNumber
 	1,errorMessage
@@ -566,7 +566,7 @@ proc Field
 	con	2,010000,5,146,151,145,154,144
 	declend
 	line	177
-	colm	12
+	colm	11
 	synt	any
 lab L1
 	init	L3
@@ -680,7 +680,7 @@ proc Clone1stToken
 	con	1,010000,8,164,162,145,145,156,157,144,145
 	declend
 	line	190
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	191
@@ -825,7 +825,7 @@ proc Progend
 	con	15,010000,1,051
 	declend
 	line	201
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	203
@@ -2899,7 +2899,7 @@ proc init
 	declend
 	filen	unigram.icn
 	line	280
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -33938,7 +33938,7 @@ proc init_stacks
 	con	3,010000,7,141,143,164,151,157,156,137
 	declend
 	line	2624
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -34079,7 +34079,7 @@ proc parenthesize_assign
 	declend
 	filen	unigram.y
 	line	914
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	917
@@ -34297,7 +34297,7 @@ lab L16
 lab L15
 	pnull
 	line	929
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -34323,7 +34323,7 @@ proc FieldRef
 	con	10,010000,1,056
 	declend
 	line	931
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	932
@@ -34525,7 +34525,7 @@ proc InvocationNode
 	con	20,002000,1,8
 	declend
 	line	945
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -35168,7 +35168,7 @@ proc SimpleInvocation
 	con	15,002000,1,3
 	declend
 	line	985
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	986
@@ -35547,7 +35547,7 @@ proc SuperMethodInvok
 	con	20,002000,1,8
 	declend
 	line	1020
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -36007,7 +36007,7 @@ proc isloco
 	con	3,002000,3,257
 	declend
 	line	1049
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	1050
@@ -36168,7 +36168,7 @@ proc buildtab_from_cclause
 	con	9,002000,1,1
 	declend
 	line	1060
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	1061
@@ -36486,7 +36486,7 @@ proc ListComp
 	con	8,010000,1,175
 	declend
 	line	1084
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -36612,7 +36612,7 @@ proc AppendListCompTemps
 	con	12,010000,27,144,157,156,047,164,040,153,156,157,167,040,167,150,141,164,040,164,157,040,144,157,040,167,151,164,150,040
 	declend
 	line	1100
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	1102
@@ -36905,7 +36905,7 @@ proc ListCompTemps
 	con	4,002000,1,1
 	declend
 	line	1127
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	1129
@@ -37182,7 +37182,7 @@ proc tablelit
 	con	11,010000,6,151,156,166,157,153,145
 	declend
 	line	1144
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -37459,31 +37459,31 @@ proc yyparse
 	local	3,000020,yys
 	local	4,000020,doaction
 	local	5,000020,token
-	local	6,000020,arv
-	local	7,000000,yytable
-	local	8,000000,init
-	local	9,000000,init_stacks
-	local	10,000000,yynerrs
-	local	11,000000,yyerrflag
-	local	12,000000,yychar
-	local	13,000000,push
-	local	14,000000,statestk
-	local	15,000000,yydefred
-	local	16,000000,yylex
-	local	17,000000,yydebug
-	local	18,000000,yylexdebug
-	local	19,000000,yysindex
-	local	20,000000,yycheck
-	local	21,000000,valstk
-	local	22,000000,yylval
-	local	23,000000,yyrindex
-	local	24,000000,yyerror
-	local	25,000000,write
-	local	26,000000,pop
-	local	27,000000,yyname
-	local	28,000000,integer
-	local	29,000000,yylen
-	local	30,000000,yyval
+	local	6,000000,yytable
+	local	7,000000,init
+	local	8,000000,init_stacks
+	local	9,000000,yynerrs
+	local	10,000000,yyerrflag
+	local	11,000000,yychar
+	local	12,000000,push
+	local	13,000000,statestk
+	local	14,000000,yydefred
+	local	15,000000,yylex
+	local	16,000000,yydebug
+	local	17,000000,yylexdebug
+	local	18,000000,yysindex
+	local	19,000000,yycheck
+	local	20,000000,valstk
+	local	21,000000,yylval
+	local	22,000000,yyrindex
+	local	23,000000,yyerror
+	local	24,000000,write
+	local	25,000000,pop
+	local	26,000000,yyname
+	local	27,000000,integer
+	local	28,000000,yylen
+	local	29,000000,yyval
+	local	30,000000,arv
 	local	31,000000,action
 	local	32,000000,yylhs
 	local	33,000000,yygindex
@@ -37509,36 +37509,46 @@ proc yyparse
 	colm	11
 	synt	any
 	mark	L1
-	line	2909
+	line	2908
 	colm	3
 	synt	if
 	mark0
 	pnull
-	var	7
-	line	2909
+	var	6
+	line	2908
 	colm	6
 	synt	any
 	null
 	unmark
-	var	8
-	line	2909
+	var	7
+	line	2908
 	colm	24
 	synt	any
 	invoke	0
-	line	2909
+	line	2908
 	colm	3
 	synt	endif
 	unmark
 lab L1
 	mark	L2
-	var	9
-	line	2910
+	var	8
+	line	2909
 	colm	14
 	synt	any
 	invoke	0
 	unmark
 lab L2
 	mark	L3
+	pnull
+	var	9
+	int	0
+	line	2910
+	colm	13
+	synt	any
+	asgn
+	unmark
+lab L3
+	mark	L4
 	pnull
 	var	10
 	int	0
@@ -37547,27 +37557,17 @@ lab L2
 	synt	any
 	asgn
 	unmark
-lab L3
-	mark	L4
-	pnull
-	var	11
-	int	0
-	line	2912
-	colm	13
-	synt	any
-	asgn
-	unmark
 lab L4
 	mark	L5
 	pnull
-	var	12
+	var	11
 	pnull
 	int	1
-	line	2913
+	line	2912
 	colm	16
 	synt	any
 	neg
-	line	2913
+	line	2912
 	colm	13
 	synt	any
 	asgn
@@ -37577,17 +37577,17 @@ lab L5
 	pnull
 	var	2
 	int	0
-	line	2914
+	line	2913
 	colm	13
 	synt	any
 	asgn
 	unmark
 lab L6
 	mark	L7
+	var	12
 	var	13
-	var	14
 	var	2
-	line	2915
+	line	2914
 	colm	7
 	synt	any
 	invoke	2
@@ -37595,7 +37595,7 @@ lab L6
 lab L7
 	mark	L8
 lab L9
-	line	2917
+	line	2916
 	colm	3
 	synt	repeat
 	mark	L9
@@ -37603,7 +37603,7 @@ lab L9
 	pnull
 	var	4
 	int	1
-	line	2918
+	line	2917
 	colm	14
 	synt	any
 	asgn
@@ -37613,19 +37613,19 @@ lab L12
 	pnull
 	var	0
 	pnull
-	var	15
+	var	14
 	pnull
 	var	2
 	int	1
-	line	2921
+	line	2920
 	colm	32
 	synt	any
 	plus
-	line	2921
+	line	2920
 	colm	24
 	synt	any
 	subsc
-	line	2921
+	line	2920
 	colm	13
 	synt	any
 	asgn
@@ -37633,99 +37633,99 @@ lab L12
 lab L13
 	mark	L14
 lab L15
-	line	2923
+	line	2922
 	colm	5
 	synt	while
 	mark0
 	pnull
 	var	0
 	int	0
-	line	2923
+	line	2922
 	colm	15
 	synt	any
 	numeq
 	unmark
 	mark	L15
 	mark	L18
-	line	2925
+	line	2924
 	colm	7
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	2925
+	line	2924
 	colm	17
 	synt	any
 	numlt
 	unmark
 	mark	L19
 	pnull
-	var	12
-	var	16
-	line	2926
+	var	11
+	var	15
+	line	2925
 	colm	24
 	synt	any
 	invoke	0
-	line	2926
+	line	2925
 	colm	16
 	synt	any
 	asgn
 	unmark
 lab L19
-	line	2928
+	line	2927
 	colm	9
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	2928
+	line	2927
 	colm	19
 	synt	any
 	numlt
 	unmark
 	mark	L20
 	pnull
-	var	12
+	var	11
 	int	0
-	line	2929
+	line	2928
 	colm	18
 	synt	any
 	asgn
 	unmark
 lab L20
-	line	2930
+	line	2929
 	colm	11
 	synt	if
 	mark0
 	pnull
 	pnull
-	var	17
-	line	2930
+	var	16
+	line	2929
 	colm	14
 	synt	any
 	nonnull
 	int	1
-	line	2930
+	line	2929
 	colm	23
 	synt	any
 	numeq
 	unmark
-	var	18
+	var	17
 	var	2
-	var	12
-	line	2930
+	var	11
+	line	2929
 	colm	42
 	synt	any
 	invoke	2
-	line	2930
+	line	2929
 	colm	11
 	synt	endif
-	line	2928
+	line	2927
 	colm	9
 	synt	endif
-	line	2925
+	line	2924
 	colm	7
 	synt	endif
 	unmark
@@ -37734,33 +37734,33 @@ lab L18
 	pnull
 	var	0
 	pnull
-	var	19
+	var	18
 	pnull
 	var	2
 	int	1
-	line	2934
+	line	2933
 	colm	30
 	synt	any
 	plus
-	line	2934
+	line	2933
 	colm	22
 	synt	any
 	subsc
-	line	2934
+	line	2933
 	colm	11
 	synt	any
 	asgn
 	unmark
 lab L21
 	mark	L22
-	line	2936
+	line	2935
 	colm	7
 	synt	if
 	mark0
 	pnull
 	var	0
 	int	0
-	line	2936
+	line	2935
 	colm	15
 	synt	any
 	numne
@@ -37769,14 +37769,14 @@ lab L21
 	pnull
 	var	0
 	dup
-	var	12
-	line	2936
+	var	11
+	line	2935
 	colm	39
 	synt	any
 	plus
 	asgn
 	int	0
-	line	2936
+	line	2935
 	colm	51
 	synt	any
 	numge
@@ -37784,27 +37784,27 @@ lab L21
 	pnull
 	var	0
 	int	2
-	line	2937
+	line	2936
 	colm	15
 	synt	any
 	numle
 	pop
 	pnull
 	pnull
-	var	20
+	var	19
 	pnull
 	var	0
 	int	1
-	line	2937
+	line	2936
 	colm	38
 	synt	any
 	plus
-	line	2937
+	line	2936
 	colm	34
 	synt	any
 	subsc
-	var	12
-	line	2937
+	var	11
+	line	2936
 	colm	42
 	synt	any
 	numeq
@@ -37813,39 +37813,39 @@ lab L21
 	pnull
 	var	2
 	pnull
-	var	7
+	var	6
 	pnull
 	var	0
 	int	1
-	line	2940
+	line	2939
 	colm	31
 	synt	any
 	plus
-	line	2940
+	line	2939
 	colm	27
 	synt	any
 	subsc
-	line	2940
+	line	2939
 	colm	17
 	synt	any
 	asgn
 	unmark
 lab L23
 	mark	L24
+	var	12
 	var	13
-	var	14
 	var	2
-	line	2941
+	line	2940
 	colm	13
 	synt	any
 	invoke	2
 	unmark
 lab L24
 	mark	L25
-	var	13
+	var	12
+	var	20
 	var	21
-	var	22
-	line	2942
+	line	2941
 	colm	13
 	synt	any
 	invoke	2
@@ -37853,42 +37853,42 @@ lab L24
 lab L25
 	mark	L26
 	pnull
-	var	12
+	var	11
 	pnull
 	int	1
-	line	2943
+	line	2942
 	colm	19
 	synt	any
 	neg
-	line	2943
+	line	2942
 	colm	16
 	synt	any
 	asgn
 	unmark
 lab L26
 	mark	L27
-	line	2944
+	line	2943
 	colm	9
 	synt	if
 	mark0
 	pnull
-	var	11
+	var	10
 	int	0
-	line	2944
+	line	2943
 	colm	22
 	synt	any
 	numgt
 	unmark
 	pnull
-	var	11
+	var	10
 	dup
 	int	1
-	line	2945
+	line	2944
 	colm	22
 	synt	any
 	minus
 	asgn
-	line	2944
+	line	2943
 	colm	9
 	synt	endif
 	unmark
@@ -37897,7 +37897,7 @@ lab L27
 	pnull
 	var	4
 	int	0
-	line	2946
+	line	2945
 	colm	18
 	synt	any
 	asgn
@@ -37907,7 +37907,7 @@ lab L28
 	unmark
 	pnull
 	goto	L17
-	line	2936
+	line	2935
 	colm	7
 	synt	endif
 	unmark
@@ -37916,33 +37916,33 @@ lab L22
 	pnull
 	var	0
 	pnull
-	var	23
+	var	22
 	pnull
 	var	2
 	int	1
-	line	2950
+	line	2949
 	colm	28
 	synt	any
 	plus
-	line	2950
+	line	2949
 	colm	20
 	synt	any
 	subsc
-	line	2950
+	line	2949
 	colm	9
 	synt	any
 	asgn
 	unmark
 lab L29
 	mark	L30
-	line	2952
+	line	2951
 	colm	5
 	synt	ifelse
 	mark	L31
 	pnull
 	var	0
 	int	0
-	line	2952
+	line	2951
 	colm	13
 	synt	any
 	numne
@@ -37951,14 +37951,14 @@ lab L29
 	pnull
 	var	0
 	dup
-	var	12
-	line	2952
+	var	11
+	line	2951
 	colm	37
 	synt	any
 	plus
 	asgn
 	int	0
-	line	2952
+	line	2951
 	colm	49
 	synt	any
 	numge
@@ -37966,27 +37966,27 @@ lab L29
 	pnull
 	var	0
 	int	2
-	line	2953
+	line	2952
 	colm	13
 	synt	any
 	numle
 	pop
 	pnull
 	pnull
-	var	20
+	var	19
 	pnull
 	var	0
 	int	1
-	line	2953
+	line	2952
 	colm	36
 	synt	any
 	plus
-	line	2953
+	line	2952
 	colm	32
 	synt	any
 	subsc
-	var	12
-	line	2953
+	var	11
+	line	2952
 	colm	40
 	synt	any
 	numeq
@@ -37995,19 +37995,19 @@ lab L29
 	pnull
 	var	0
 	pnull
-	var	7
+	var	6
 	pnull
 	var	0
 	int	1
-	line	2955
+	line	2954
 	colm	30
 	synt	any
 	plus
-	line	2955
+	line	2954
 	colm	26
 	synt	any
 	subsc
-	line	2955
+	line	2954
 	colm	16
 	synt	any
 	asgn
@@ -38017,7 +38017,7 @@ lab L33
 	pnull
 	var	4
 	int	1
-	line	2956
+	line	2955
 	colm	16
 	synt	any
 	asgn
@@ -38030,14 +38030,14 @@ lab L34
 	goto	L32
 lab L31
 	mark	L35
-	line	2960
+	line	2959
 	colm	7
 	synt	if
 	mark0
 	pnull
-	var	11
+	var	10
 	int	0
-	line	2960
+	line	2959
 	colm	20
 	synt	any
 	lexeq
@@ -38045,81 +38045,81 @@ lab L31
 	mark	L36
 	mark	L37
 	pnull
-	var	24
-	line	2961
+	var	23
+	line	2960
 	colm	10
 	synt	any
 	nonnull
-	line	2961
+	line	2960
 	colm	19
 	synt	any
 	esusp
 	goto	L38
 lab L37
-	var	25
+	var	24
 lab L38
 	str	3
-	line	2961
+	line	2960
 	colm	27
 	synt	any
 	invoke	1
 	unmark
 lab L36
 	pnull
-	var	10
+	var	9
 	dup
 	int	1
-	line	2962
+	line	2961
 	colm	17
 	synt	any
 	plus
 	asgn
-	line	2960
+	line	2959
 	colm	7
 	synt	endif
 	unmark
 lab L35
-	line	2964
+	line	2963
 	colm	7
 	synt	ifelse
 	mark	L39
 	pnull
-	var	11
+	var	10
 	int	4
-	line	2964
+	line	2963
 	colm	20
 	synt	any
 	numlt
 	unmark
 	mark	L41
 	pnull
-	var	11
+	var	10
 	int	4
-	line	2965
+	line	2964
 	colm	19
 	synt	any
 	asgn
 	unmark
 lab L41
 lab L42
-	line	2966
+	line	2965
 	colm	9
 	synt	repeat
 	mark	L42
 	mark	L45
-	line	2967
+	line	2966
 	colm	11
 	synt	if
 	mark0
 	pnull
 	pnull
-	var	14
-	line	2967
+	var	13
+	line	2966
 	colm	14
 	synt	any
 	size
 	int	1
-	line	2967
+	line	2966
 	colm	24
 	synt	any
 	numlt
@@ -38127,21 +38127,21 @@ lab L42
 	mark	L46
 	mark	L47
 	pnull
-	var	24
-	line	2968
+	var	23
+	line	2967
 	colm	14
 	synt	any
 	nonnull
-	line	2968
+	line	2967
 	colm	23
 	synt	any
 	esusp
 	goto	L48
 lab L47
-	var	25
+	var	24
 lab L48
 	str	5
-	line	2968
+	line	2967
 	colm	31
 	synt	any
 	invoke	1
@@ -38149,14 +38149,14 @@ lab L48
 lab L46
 	mark	L49
 	int	1
-	line	2969
+	line	2968
 	colm	13
 	synt	any
 	pret
 lab L49
 	synt	any
 	pfail
-	line	2967
+	line	2966
 	colm	11
 	synt	endif
 	unmark
@@ -38165,32 +38165,32 @@ lab L45
 	pnull
 	var	0
 	pnull
-	var	19
+	var	18
 	pnull
-	var	14
+	var	13
 	int	1
-	line	2971
+	line	2970
 	colm	35
 	synt	any
 	subsc
-	line	2971
+	line	2970
 	colm	26
 	synt	any
 	subsc
-	line	2971
+	line	2970
 	colm	15
 	synt	any
 	asgn
 	unmark
 lab L50
-	line	2972
+	line	2971
 	colm	11
 	synt	ifelse
 	mark	L51
 	pnull
 	var	0
 	int	0
-	line	2972
+	line	2971
 	colm	20
 	synt	any
 	numne
@@ -38200,13 +38200,13 @@ lab L50
 	var	0
 	dup
 	int	6
-	line	2972
+	line	2971
 	colm	33
 	synt	any
 	plus
 	asgn
 	int	0
-	line	2972
+	line	2971
 	colm	42
 	synt	any
 	numge
@@ -38214,27 +38214,27 @@ lab L50
 	pnull
 	var	0
 	int	2
-	line	2973
+	line	2972
 	colm	25
 	synt	any
 	numle
 	pop
 	pnull
 	pnull
-	var	20
+	var	19
 	pnull
 	var	0
 	int	1
-	line	2973
+	line	2972
 	colm	46
 	synt	any
 	plus
-	line	2973
+	line	2972
 	colm	42
 	synt	any
 	subsc
 	int	6
-	line	2973
+	line	2972
 	colm	50
 	synt	any
 	lexeq
@@ -38243,39 +38243,39 @@ lab L50
 	pnull
 	var	2
 	pnull
-	var	7
+	var	6
 	pnull
 	var	0
 	int	1
-	line	2974
+	line	2973
 	colm	35
 	synt	any
 	plus
-	line	2974
+	line	2973
 	colm	31
 	synt	any
 	subsc
-	line	2974
+	line	2973
 	colm	21
 	synt	any
 	asgn
 	unmark
 lab L53
 	mark	L54
+	var	12
 	var	13
-	var	14
 	var	2
-	line	2975
+	line	2974
 	colm	17
 	synt	any
 	invoke	2
 	unmark
 lab L54
 	mark	L55
-	var	13
+	var	12
+	var	20
 	var	21
-	var	22
-	line	2976
+	line	2975
 	colm	17
 	synt	any
 	invoke	2
@@ -38285,7 +38285,7 @@ lab L55
 	pnull
 	var	4
 	int	0
-	line	2977
+	line	2976
 	colm	22
 	synt	any
 	asgn
@@ -38297,27 +38297,27 @@ lab L56
 	goto	L52
 lab L51
 	mark	L57
-	line	2981
+	line	2980
 	colm	13
 	synt	if
 	mark0
 	pnull
 	pnull
-	var	14
-	line	2981
+	var	13
+	line	2980
 	colm	16
 	synt	any
 	size
 	int	0
-	line	2981
+	line	2980
 	colm	26
 	synt	any
 	numeq
 	unmark
 	mark	L58
-	var	25
+	var	24
 	str	7
-	line	2982
+	line	2981
 	colm	20
 	synt	any
 	invoke	1
@@ -38325,87 +38325,87 @@ lab L51
 lab L58
 	mark	L59
 	int	1
-	line	2983
+	line	2982
 	colm	15
 	synt	any
 	pret
 lab L59
 	synt	any
 	pfail
-	line	2981
+	line	2980
 	colm	13
 	synt	endif
 	unmark
 lab L57
 	mark	L60
-	var	26
-	var	14
-	line	2985
+	var	25
+	var	13
+	line	2984
 	colm	16
 	synt	any
 	invoke	1
 	unmark
 lab L60
-	var	26
-	var	21
-	line	2986
+	var	25
+	var	20
+	line	2985
 	colm	16
 	synt	any
 	invoke	1
 lab L52
-	line	2972
+	line	2971
 	colm	11
 	synt	endifelse
 lab L43
 	unmark
 	goto	L42
 lab L44
-	line	2966
+	line	2965
 	colm	9
 	synt	endrepeat
 	goto	L40
 lab L39
 	mark	L61
-	line	2992
+	line	2991
 	colm	9
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	2992
+	line	2991
 	colm	19
 	synt	any
 	numeq
 	unmark
 	mark	L62
 	int	1
-	line	2992
+	line	2991
 	colm	28
 	synt	any
 	pret
 lab L62
 	synt	any
 	pfail
-	line	2992
+	line	2991
 	colm	9
 	synt	endif
 	unmark
 lab L61
 	mark	L63
-	line	2993
+	line	2992
 	colm	9
 	synt	if
 	mark0
 	pnull
 	pnull
-	var	17
-	line	2993
+	var	16
+	line	2992
 	colm	12
 	synt	any
 	nonnull
 	int	1
-	line	2993
+	line	2992
 	colm	21
 	synt	any
 	numeq
@@ -38413,25 +38413,25 @@ lab L61
 	mark	L64
 	pnull
 	var	3
-	line	2994
+	line	2993
 	colm	18
 	synt	any
 	keywd	null
-	line	2994
+	line	2993
 	colm	15
 	synt	any
 	asgn
 	unmark
 lab L64
 	mark	L65
-	line	2995
+	line	2994
 	colm	11
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	8
-	line	2995
+	line	2994
 	colm	21
 	synt	any
 	numle
@@ -38439,35 +38439,35 @@ lab L64
 	pnull
 	var	3
 	pnull
-	var	27
+	var	26
 	pnull
-	var	12
+	var	11
 	int	1
-	line	2995
+	line	2994
 	colm	53
 	synt	any
 	plus
-	line	2995
+	line	2994
 	colm	46
 	synt	any
 	subsc
-	line	2995
+	line	2994
 	colm	37
 	synt	any
 	asgn
-	line	2995
+	line	2994
 	colm	11
 	synt	endif
 	unmark
 lab L65
 	mark	L66
-	line	2996
+	line	2995
 	colm	11
 	synt	if
 	mark0
-	var	28
+	var	27
 	var	3
-	line	2996
+	line	2995
 	colm	21
 	synt	any
 	invoke	1
@@ -38475,7 +38475,7 @@ lab L65
 	pnull
 	var	3
 	int	0
-	line	2996
+	line	2995
 	colm	33
 	synt	any
 	numeq
@@ -38483,50 +38483,50 @@ lab L65
 	pnull
 	var	3
 	str	9
-	line	2996
+	line	2995
 	colm	46
 	synt	any
 	asgn
-	line	2996
+	line	2995
 	colm	11
 	synt	endif
 	unmark
 lab L66
-	var	25
+	var	24
 	str	10
 	var	2
 	str	11
-	var	12
+	var	11
 	str	12
 	var	3
 	str	13
-	line	2997
+	line	2996
 	colm	16
 	synt	any
 	invoke	7
-	line	2993
+	line	2992
 	colm	9
 	synt	endif
 	unmark
 lab L63
 	pnull
-	var	12
+	var	11
 	pnull
 	int	1
-	line	3000
+	line	2999
 	colm	19
 	synt	any
 	neg
-	line	3000
+	line	2999
 	colm	16
 	synt	any
 	asgn
 lab L40
-	line	2964
+	line	2963
 	colm	7
 	synt	endifelse
 lab L32
-	line	2952
+	line	2951
 	colm	5
 	synt	endifelse
 	unmark
@@ -38534,19 +38534,19 @@ lab L30
 	pnull
 	var	0
 	pnull
-	var	15
+	var	14
 	pnull
 	var	2
 	int	1
-	line	3003
+	line	3002
 	colm	30
 	synt	any
 	plus
-	line	3003
+	line	3002
 	colm	22
 	synt	any
 	subsc
-	line	3003
+	line	3002
 	colm	11
 	synt	any
 	asgn
@@ -38554,27 +38554,27 @@ lab L16
 	unmark
 	goto	L15
 lab L17
-	line	2923
+	line	2922
 	colm	5
 	synt	endwhile
 	unmark
 lab L14
 	mark	L67
-	line	3006
+	line	3005
 	colm	5
 	synt	if
 	mark0
 	pnull
 	var	4
 	int	0
-	line	3006
+	line	3005
 	colm	17
 	synt	any
 	numeq
 	unmark
 	unmark
 	goto	L10
-	line	3006
+	line	3005
 	colm	5
 	synt	endif
 	unmark
@@ -38583,19 +38583,19 @@ lab L67
 	pnull
 	var	1
 	pnull
-	var	29
+	var	28
 	pnull
 	var	0
 	int	1
-	line	3009
+	line	3008
 	colm	21
 	synt	any
 	plus
-	line	3009
+	line	3008
 	colm	17
 	synt	any
 	subsc
-	line	3009
+	line	3008
 	colm	9
 	synt	any
 	asgn
@@ -38603,59 +38603,59 @@ lab L67
 lab L68
 	mark	L69
 	pnull
-	var	30
+	var	29
 	pnull
-	var	21
+	var	20
 	var	1
-	line	3010
+	line	3009
 	colm	20
 	synt	any
 	subsc
-	line	3010
+	line	3009
 	colm	11
 	synt	any
 	asgn
 	unmark
 lab L69
 	mark	L70
-	line	3011
+	line	3010
 	colm	5
 	synt	if
 	mark0
 	pnull
-	var	6
+	var	30
 	pnull
 	var	31
 	var	0
-	line	3011
+	line	3010
 	colm	21
 	synt	any
 	subsc
-	line	3011
+	line	3010
 	colm	26
 	synt	any
 	invoke	0
-	line	3011
+	line	3010
 	colm	12
 	synt	any
 	asgn
 	unmark
 	mark	L71
-	var	6
-	line	3011
+	var	30
+	line	3010
 	colm	34
 	synt	any
 	pret
 lab L71
 	synt	any
 	pfail
-	line	3011
+	line	3010
 	colm	5
 	synt	endif
 	unmark
 lab L70
 	mark	L72
-	line	3014
+	line	3013
 	colm	5
 	synt	every
 	mark0
@@ -38663,15 +38663,15 @@ lab L70
 	int	1
 	var	1
 	push1
-	line	3014
+	line	3013
 	colm	13
 	synt	any
 	toby
 	pop
 	mark0
-	var	26
-	var	14
-	line	3014
+	var	25
+	var	13
+	line	3013
 	colm	26
 	synt	any
 	invoke	1
@@ -38679,7 +38679,7 @@ lab L70
 lab L73
 	efail
 lab L74
-	line	3014
+	line	3013
 	colm	5
 	synt	endevery
 	unmark
@@ -38688,20 +38688,20 @@ lab L72
 	pnull
 	var	2
 	pnull
-	var	14
+	var	13
 	int	1
-	line	3015
+	line	3014
 	colm	24
 	synt	any
 	subsc
-	line	3015
+	line	3014
 	colm	13
 	synt	any
 	asgn
 	unmark
 lab L75
 	mark	L76
-	line	3017
+	line	3016
 	colm	5
 	synt	every
 	mark0
@@ -38709,15 +38709,15 @@ lab L75
 	int	1
 	var	1
 	push1
-	line	3017
+	line	3016
 	colm	13
 	synt	any
 	toby
 	pop
 	mark0
-	var	26
-	var	21
-	line	3017
+	var	25
+	var	20
+	line	3016
 	colm	26
 	synt	any
 	invoke	1
@@ -38725,7 +38725,7 @@ lab L75
 lab L77
 	efail
 lab L78
-	line	3017
+	line	3016
 	colm	5
 	synt	endevery
 	unmark
@@ -38738,28 +38738,28 @@ lab L76
 	pnull
 	var	0
 	int	1
-	line	3018
+	line	3017
 	colm	21
 	synt	any
 	plus
-	line	3018
+	line	3017
 	colm	17
 	synt	any
 	subsc
-	line	3018
+	line	3017
 	colm	9
 	synt	any
 	asgn
 	unmark
 lab L79
-	line	3019
+	line	3018
 	colm	5
 	synt	ifelse
 	mark	L80
 	pnull
 	var	2
 	int	0
-	line	3019
+	line	3018
 	colm	16
 	synt	any
 	numeq
@@ -38767,7 +38767,7 @@ lab L79
 	pnull
 	var	1
 	int	0
-	line	3019
+	line	3018
 	colm	26
 	synt	any
 	numeq
@@ -38776,94 +38776,94 @@ lab L79
 	pnull
 	var	2
 	int	14
-	line	3021
+	line	3020
 	colm	15
 	synt	any
 	asgn
 	unmark
 lab L82
 	mark	L83
+	var	12
 	var	13
-	var	14
 	int	14
-	line	3022
+	line	3021
 	colm	11
 	synt	any
 	invoke	2
 	unmark
 lab L83
 	mark	L84
-	var	13
-	var	21
-	var	30
-	line	3023
+	var	12
+	var	20
+	var	29
+	line	3022
 	colm	11
 	synt	any
 	invoke	2
 	unmark
 lab L84
 	mark	L85
-	line	3024
+	line	3023
 	colm	7
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	3024
+	line	3023
 	colm	17
 	synt	any
 	numlt
 	unmark
 	mark	L86
 	pnull
-	var	12
-	var	16
-	line	3025
+	var	11
+	var	15
+	line	3024
 	colm	24
 	synt	any
 	invoke	0
-	line	3025
+	line	3024
 	colm	16
 	synt	any
 	asgn
 	unmark
 lab L86
-	line	3026
+	line	3025
 	colm	9
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	3026
+	line	3025
 	colm	19
 	synt	any
 	numlt
 	unmark
 	pnull
-	var	12
+	var	11
 	int	0
-	line	3026
+	line	3025
 	colm	35
 	synt	any
 	asgn
-	line	3026
+	line	3025
 	colm	9
 	synt	endif
-	line	3024
+	line	3023
 	colm	7
 	synt	endif
 	unmark
 lab L85
-	line	3028
+	line	3027
 	colm	7
 	synt	if
 	mark0
 	pnull
-	var	12
+	var	11
 	int	0
-	line	3028
+	line	3027
 	colm	17
 	synt	any
 	numeq
@@ -38871,7 +38871,7 @@ lab L85
 	unmark
 	pnull
 	goto	L11
-	line	3028
+	line	3027
 	colm	7
 	synt	endif
 	goto	L81
@@ -38884,29 +38884,29 @@ lab L80
 	pnull
 	var	1
 	int	1
-	line	3033
+	line	3032
 	colm	26
 	synt	any
 	plus
-	line	3033
+	line	3032
 	colm	22
 	synt	any
 	subsc
-	line	3033
+	line	3032
 	colm	11
 	synt	any
 	asgn
 	unmark
 lab L87
 	mark	L88
-	line	3034
+	line	3033
 	colm	7
 	synt	ifelse
 	mark	L89
 	pnull
 	var	0
 	int	0
-	line	3034
+	line	3033
 	colm	15
 	synt	any
 	numne
@@ -38916,13 +38916,13 @@ lab L87
 	var	0
 	dup
 	var	2
-	line	3034
+	line	3033
 	colm	39
 	synt	any
 	plus
 	asgn
 	int	0
-	line	3034
+	line	3033
 	colm	52
 	synt	any
 	numge
@@ -38930,27 +38930,27 @@ lab L87
 	pnull
 	var	0
 	int	2
-	line	3035
+	line	3034
 	colm	15
 	synt	any
 	numle
 	pop
 	pnull
 	pnull
-	var	20
+	var	19
 	pnull
 	var	0
 	int	1
-	line	3035
+	line	3034
 	colm	38
 	synt	any
 	plus
-	line	3035
+	line	3034
 	colm	34
 	synt	any
 	subsc
 	var	2
-	line	3035
+	line	3034
 	colm	42
 	synt	any
 	numeq
@@ -38958,19 +38958,19 @@ lab L87
 	pnull
 	var	2
 	pnull
-	var	7
+	var	6
 	pnull
 	var	0
 	int	1
-	line	3036
+	line	3035
 	colm	31
 	synt	any
 	plus
-	line	3036
+	line	3035
 	colm	27
 	synt	any
 	subsc
-	line	3036
+	line	3035
 	colm	17
 	synt	any
 	asgn
@@ -38983,50 +38983,50 @@ lab L89
 	pnull
 	var	1
 	int	1
-	line	3039
+	line	3038
 	colm	31
 	synt	any
 	plus
-	line	3039
+	line	3038
 	colm	27
 	synt	any
 	subsc
-	line	3039
+	line	3038
 	colm	17
 	synt	any
 	asgn
 lab L90
-	line	3034
+	line	3033
 	colm	7
 	synt	endifelse
 	unmark
 lab L88
 	mark	L91
+	var	12
 	var	13
-	var	14
 	var	2
-	line	3041
+	line	3040
 	colm	11
 	synt	any
 	invoke	2
 	unmark
 lab L91
-	var	13
-	var	21
-	var	30
-	line	3042
+	var	12
+	var	20
+	var	29
+	line	3041
 	colm	11
 	synt	any
 	invoke	2
 lab L81
-	line	3019
+	line	3018
 	colm	5
 	synt	endifelse
 lab L10
 	unmark
 	goto	L9
 lab L11
-	line	2917
+	line	2916
 	colm	3
 	synt	endrepeat
 	unmark
@@ -39034,7 +39034,7 @@ lab L8
 	mark	L92
 	mark	L93
 	int	0
-	line	3046
+	line	3045
 	colm	3
 	synt	any
 	pret
@@ -39044,17 +39044,17 @@ lab L93
 	unmark
 lab L92
 	pnull
-	line	3047
-	colm	2
+	line	3046
+	colm	1
 	synt	any
 	pfail
 	end
 proc action_null
 	declend
-	line	3053
-	colm	12
+	line	3052
+	colm	11
 	synt	any
-	line	3055
+	line	3054
 	colm	1
 	synt	any
 	pfail
@@ -39064,8 +39064,8 @@ proc action_1
 	local	1,000000,valstk
 	con	0,002000,1,2
 	declend
-	line	3057
-	colm	12
+	line	3056
+	colm	11
 	synt	any
 	mark	L1
 	var	0
@@ -39093,7 +39093,7 @@ proc action_2
 	local	0,000000,yyval
 	declend
 	line	305
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39110,7 +39110,7 @@ proc action_2
 lab L1
 	pnull
 	line	305
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -39127,7 +39127,7 @@ proc action_3
 	con	4,002000,1,1
 	declend
 	line	307
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	306
@@ -39215,7 +39215,7 @@ proc action_12
 	local	0,000000,yyval
 	declend
 	line	311
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39232,7 +39232,7 @@ proc action_12
 lab L1
 	pnull
 	line	321
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -39250,7 +39250,7 @@ proc action_13
 	con	7,002000,1,1
 	declend
 	line	323
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39370,7 +39370,7 @@ proc action_14
 	con	8,002000,1,1
 	declend
 	line	329
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39482,24 +39482,22 @@ proc action_15
 	local	0,000000,yyval
 	declend
 	line	335
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
 	var	0
-	line	335
-	colm	31
 	synt	any
 	keywd	null
 	line	335
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
 lab L1
 	pnull
 	line	336
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -39513,7 +39511,7 @@ proc action_17
 	con	3,002000,1,2
 	declend
 	line	338
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39585,18 +39583,18 @@ proc action_18
 	con	9,002000,1,1
 	declend
 	line	343
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
 	var	0
 	var	1
 	line	343
-	colm	36
+	colm	18
 	synt	any
 	invoke	0
 	line	343
-	colm	29
+	colm	10
 	synt	any
 	asgn
 	unmark
@@ -39682,8 +39680,8 @@ lab L4
 	mark	L5
 	line	347
 	colm	4
-	synt	ifelse
-	mark	L6
+	synt	if
+	mark0
 	var	4
 	pnull
 	var	0
@@ -39720,37 +39718,41 @@ lab L4
 	colm	14
 	synt	any
 	invoke	1
-	goto	L7
-lab L6
+	line	347
+	colm	4
+	synt	endif
+	unmark
+lab L5
+	mark	L6
 	line	349
-	colm	9
+	colm	4
 	synt	ifelse
-	mark	L8
+	mark	L7
 	pnull
 	pnull
 	var	6
 	pnull
 	var	7
 	line	349
-	colm	32
+	colm	27
 	synt	any
 	field	lookup
 	pnull
 	var	0
 	line	349
-	colm	45
+	colm	40
 	synt	any
 	field	name
 	line	349
-	colm	39
+	colm	34
 	synt	any
 	invoke	1
 	line	349
-	colm	22
+	colm	17
 	synt	any
 	asgn
 	line	349
-	colm	12
+	colm	7
 	synt	any
 	nonnull
 	unmark
@@ -39771,8 +39773,8 @@ lab L6
 	colm	14
 	synt	any
 	invoke	1
-	goto	L9
-lab L8
+	goto	L8
+lab L7
 	pnull
 	var	7
 	line	353
@@ -39790,17 +39792,13 @@ lab L8
 	colm	21
 	synt	any
 	invoke	2
-lab L9
+lab L8
 	line	349
-	colm	9
-	synt	endifelse
-lab L7
-	line	347
 	colm	4
 	synt	endifelse
 	unmark
-lab L5
-	mark	L10
+lab L6
+	mark	L9
 	pnull
 	pnull
 	var	0
@@ -39820,8 +39818,8 @@ lab L5
 	synt	any
 	asgn
 	unmark
-lab L10
-	mark	L11
+lab L9
+	mark	L10
 	pnull
 	pnull
 	var	0
@@ -39841,8 +39839,8 @@ lab L10
 	synt	any
 	asgn
 	unmark
-lab L11
-	mark	L12
+lab L10
+	mark	L11
 	pnull
 	pnull
 	var	0
@@ -39862,8 +39860,8 @@ lab L11
 	synt	any
 	asgn
 	unmark
-lab L12
-	mark	L13
+lab L11
+	mark	L12
 	pnull
 	pnull
 	var	0
@@ -39883,7 +39881,7 @@ lab L12
 	synt	any
 	asgn
 	unmark
-lab L13
+lab L12
 	pnull
 	line	360
 	colm	1
@@ -39894,7 +39892,7 @@ proc action_19
 	local	0,000000,yyval
 	declend
 	line	362
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39911,7 +39909,7 @@ proc action_19
 lab L1
 	pnull
 	line	362
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -39925,7 +39923,7 @@ proc action_20
 	con	3,002000,1,1
 	declend
 	line	364
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -39979,7 +39977,7 @@ proc action_21
 	con	3,002000,1,1
 	declend
 	line	365
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40033,7 +40031,7 @@ proc action_22
 	con	3,002000,1,1
 	declend
 	line	366
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40044,29 +40042,29 @@ proc action_22
 	var	2
 	int	1
 	line	366
-	colm	55
+	colm	36
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	366
-	colm	65
+	colm	46
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	366
-	colm	75
+	colm	56
 	synt	any
 	subsc
 	line	366
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	366
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -40086,7 +40084,7 @@ proc action_23
 	con	2,002000,1,1
 	declend
 	line	369
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40127,24 +40125,22 @@ proc action_24
 	local	0,000000,yyval
 	declend
 	line	370
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
 	var	0
-	line	370
-	colm	31
 	synt	any
 	keywd	null
 	line	370
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
 lab L1
 	pnull
 	line	371
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -40157,7 +40153,7 @@ proc action_25
 	con	2,002000,1,1
 	declend
 	line	373
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40203,7 +40199,7 @@ proc action_26
 	con	2,002000,1,1
 	declend
 	line	374
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40249,7 +40245,7 @@ proc action_27
 	con	2,002000,1,1
 	declend
 	line	375
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40295,7 +40291,7 @@ proc action_28
 	con	2,002000,1,1
 	declend
 	line	376
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40306,22 +40302,22 @@ proc action_28
 	var	2
 	int	1
 	line	376
-	colm	54
+	colm	35
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	376
-	colm	64
+	colm	46
 	synt	any
 	subsc
 	line	376
-	colm	35
+	colm	15
 	synt	any
 	invoke	3
 	line	376
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -40342,7 +40338,7 @@ proc action_30
 	con	3,002000,1,1
 	declend
 	line	379
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40353,29 +40349,29 @@ proc action_30
 	var	2
 	int	1
 	line	379
-	colm	54
+	colm	35
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	379
-	colm	64
+	colm	45
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	379
-	colm	74
+	colm	55
 	synt	any
 	subsc
 	line	379
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	379
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -40396,7 +40392,7 @@ proc action_33
 	con	3,002000,1,1
 	declend
 	line	382
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40455,17 +40451,17 @@ proc action_34
 	con	4,002000,1,2
 	declend
 	line	386
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	386
-	colm	24
+	colm	4
 	synt	ifelse
 	mark	L2
 	pnull
 	var	0
 	line	386
-	colm	26
+	colm	7
 	synt	any
 	nonnull
 	unmark
@@ -40674,7 +40670,7 @@ lab L11
 	invoke	0
 lab L3
 	line	386
-	colm	24
+	colm	4
 	synt	endifelse
 	unmark
 lab L1
@@ -40695,7 +40691,7 @@ proc action_35
 	con	3,010000,1,040
 	declend
 	line	406
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40706,23 +40702,23 @@ proc action_35
 	var	2
 	int	1
 	line	406
-	colm	51
+	colm	34
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	406
-	colm	61
+	colm	44
 	synt	any
 	subsc
 	str	3
 	line	406
-	colm	35
+	colm	17
 	synt	any
 	invoke	4
 	line	406
-	colm	29
+	colm	10
 	synt	any
 	asgn
 	unmark
@@ -40758,7 +40754,7 @@ proc action_36
 	con	3,010000,1,040
 	declend
 	line	411
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40806,7 +40802,7 @@ proc action_38
 	con	3,002000,1,1
 	declend
 	line	413
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40817,29 +40813,29 @@ proc action_38
 	var	2
 	int	1
 	line	413
-	colm	52
+	colm	33
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	413
-	colm	62
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	413
-	colm	72
+	colm	53
 	synt	any
 	subsc
 	line	413
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	413
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -40860,7 +40856,7 @@ proc action_40
 	con	3,002000,1,1
 	declend
 	line	416
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40871,29 +40867,29 @@ proc action_40
 	var	2
 	int	1
 	line	416
-	colm	52
+	colm	33
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	416
-	colm	62
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	416
-	colm	72
+	colm	53
 	synt	any
 	subsc
 	line	416
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	416
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -40913,7 +40909,7 @@ proc action_43
 	con	2,002000,1,1
 	declend
 	line	419
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40964,7 +40960,7 @@ proc action_44
 	con	4,002000,1,1
 	declend
 	line	424
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -40974,43 +40970,43 @@ proc action_44
 	var	2
 	int	0
 	line	424
-	colm	49
+	colm	44
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	1
 	line	424
-	colm	59
+	colm	54
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	424
-	colm	69
+	colm	64
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	424
-	colm	79
+	colm	74
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	4
 	line	424
-	colm	89
+	colm	84
 	synt	any
 	subsc
 	line	424
-	colm	42
+	colm	37
 	synt	any
 	invoke	5
 	line	424
-	colm	29
+	colm	23
 	synt	any
 	asgn
 	unmark
@@ -41060,7 +41056,7 @@ proc action_45
 	local	0,000000,yyval
 	declend
 	line	430
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41077,7 +41073,7 @@ proc action_45
 lab L1
 	pnull
 	line	430
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -41095,7 +41091,7 @@ proc action_47
 	con	6,002000,1,1
 	declend
 	line	432
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41197,7 +41193,7 @@ proc action_48
 	con	3,002000,1,2
 	declend
 	line	439
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41206,11 +41202,11 @@ proc action_48
 	var	1
 	int	0
 	line	439
-	colm	37
+	colm	32
 	synt	any
 	subsc
 	line	439
-	colm	29
+	colm	23
 	synt	any
 	asgn
 	unmark
@@ -41290,7 +41286,7 @@ proc action_49
 	con	0,002000,1,1
 	declend
 	line	446
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41325,7 +41321,7 @@ lab L1
 lab L2
 	pnull
 	line	448
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -41343,7 +41339,7 @@ proc action_50
 	con	4,002000,1,1
 	declend
 	line	450
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41353,43 +41349,43 @@ proc action_50
 	var	2
 	int	0
 	line	450
-	colm	49
+	colm	44
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	1
 	line	450
-	colm	59
+	colm	55
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	450
-	colm	69
+	colm	66
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	450
-	colm	79
+	colm	77
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	4
 	line	450
-	colm	89
+	colm	88
 	synt	any
 	subsc
 	line	450
-	colm	42
+	colm	37
 	synt	any
 	invoke	5
 	line	450
-	colm	29
+	colm	23
 	synt	any
 	asgn
 	unmark
@@ -41446,7 +41442,7 @@ proc action_51
 	con	4,002000,1,1
 	declend
 	line	456
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41461,7 +41457,7 @@ proc action_51
 	var	2
 	int	0
 	line	456
-	colm	51
+	colm	50
 	synt	any
 	subsc
 	pnull
@@ -41469,18 +41465,18 @@ proc action_51
 	var	2
 	int	1
 	line	456
-	colm	62
+	colm	61
 	synt	any
 	subsc
 	line	456
-	colm	65
+	colm	64
 	synt	any
 	field	s
 	pnull
 	var	2
 	int	2
 	line	456
-	colm	75
+	colm	74
 	synt	any
 	subsc
 	pnull
@@ -41488,33 +41484,33 @@ proc action_51
 	var	2
 	int	0
 	line	456
-	colm	86
+	colm	85
 	synt	any
 	subsc
 	line	456
-	colm	89
+	colm	88
 	synt	any
 	field	s
 	pnull
 	var	2
 	int	3
 	line	456
-	colm	99
+	colm	98
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	4
 	line	456
-	colm	110
+	colm	109
 	synt	any
 	subsc
 	line	456
-	colm	37
+	colm	32
 	synt	any
 	invoke	11
 	line	456
-	colm	29
+	colm	23
 	synt	any
 	asgn
 	unmark
@@ -41530,7 +41526,7 @@ proc action_52
 	local	1,000000,argList
 	declend
 	line	460
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41539,15 +41535,15 @@ proc action_52
 	pnull
 	pnull
 	line	460
-	colm	41
+	colm	24
 	synt	any
 	keywd	null
 	line	460
-	colm	38
+	colm	18
 	synt	any
 	invoke	3
 	line	460
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -41565,7 +41561,7 @@ proc action_53
 	con	0,002000,1,1
 	declend
 	line	463
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41604,7 +41600,7 @@ proc action_54
 	con	1,002000,1,3
 	declend
 	line	464
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41640,7 +41636,7 @@ proc action_55
 	local	1,000000,argList
 	declend
 	line	465
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41675,7 +41671,7 @@ proc action_56
 	con	0,002000,1,1
 	declend
 	line	467
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41714,7 +41710,7 @@ proc action_57
 	con	1,002000,1,3
 	declend
 	line	468
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41755,7 +41751,7 @@ proc action_59
 	con	3,002000,1,1
 	declend
 	line	469
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41809,7 +41805,7 @@ proc action_61
 	con	3,002000,1,1
 	declend
 	line	473
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41820,29 +41816,29 @@ proc action_61
 	var	2
 	int	1
 	line	473
-	colm	53
+	colm	34
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	473
-	colm	63
+	colm	45
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	473
-	colm	73
+	colm	56
 	synt	any
 	subsc
 	line	473
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	473
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -41863,7 +41859,7 @@ proc action_62
 	con	3,002000,1,1
 	declend
 	line	476
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41919,7 +41915,7 @@ proc action_63
 	con	5,002000,1,1
 	declend
 	line	477
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41987,7 +41983,7 @@ proc action_65
 	con	3,002000,1,1
 	declend
 	line	478
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -41998,29 +41994,29 @@ proc action_65
 	var	2
 	int	1
 	line	478
-	colm	53
+	colm	34
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	478
-	colm	63
+	colm	45
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	478
-	colm	73
+	colm	56
 	synt	any
 	subsc
 	line	478
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	478
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -42041,7 +42037,7 @@ proc action_66
 	con	3,002000,1,1
 	declend
 	line	481
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42097,7 +42093,7 @@ proc action_67
 	con	5,002000,1,1
 	declend
 	line	482
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42165,7 +42161,7 @@ proc action_69
 	con	3,002000,1,1
 	declend
 	line	483
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42176,29 +42172,29 @@ proc action_69
 	var	2
 	int	1
 	line	483
-	colm	53
+	colm	34
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	483
-	colm	63
+	colm	44
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	483
-	colm	73
+	colm	54
 	synt	any
 	subsc
 	line	483
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	483
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -42219,7 +42215,7 @@ proc action_71
 	con	3,002000,1,1
 	declend
 	line	486
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42230,29 +42226,29 @@ proc action_71
 	var	2
 	int	1
 	line	486
-	colm	53
+	colm	34
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	486
-	colm	63
+	colm	44
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	486
-	colm	73
+	colm	54
 	synt	any
 	subsc
 	line	486
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	486
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -42273,7 +42269,7 @@ proc action_73
 	con	3,002000,1,1
 	declend
 	line	489
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42284,29 +42280,29 @@ proc action_73
 	var	2
 	int	1
 	line	489
-	colm	49
+	colm	30
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	489
-	colm	59
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	489
-	colm	69
+	colm	52
 	synt	any
 	subsc
 	line	489
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	489
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -42327,7 +42323,7 @@ proc action_74
 	con	3,002000,1,1
 	declend
 	line	492
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42383,7 +42379,7 @@ proc action_75
 	con	5,002000,1,1
 	declend
 	line	493
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42453,7 +42449,7 @@ proc action_76
 	con	4,002000,1,1
 	declend
 	line	494
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42523,7 +42519,7 @@ proc action_77
 	con	6,002000,1,1
 	declend
 	line	495
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42603,7 +42599,7 @@ proc action_78
 	con	3,010000,2,133,135
 	declend
 	line	496
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42653,7 +42649,7 @@ proc action_79
 	con	5,010000,2,133,135
 	declend
 	line	497
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42711,7 +42707,7 @@ proc action_80
 	con	0,002000,1,1
 	declend
 	line	498
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42720,11 +42716,11 @@ proc action_80
 	var	1
 	int	0
 	line	498
-	colm	37
+	colm	17
 	synt	any
 	subsc
 	line	498
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -42739,7 +42735,7 @@ proc action_81
 	local	0,000000,yyval
 	declend
 	line	501
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42756,7 +42752,7 @@ proc action_81
 lab L1
 	pnull
 	line	501
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -42764,7 +42760,7 @@ proc action_84
 	local	0,000000,yyval
 	declend
 	line	503
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42781,7 +42777,7 @@ proc action_84
 lab L1
 	pnull
 	line	505
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -42796,7 +42792,7 @@ proc action_85
 	con	4,010000,1,073
 	declend
 	line	507
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42845,7 +42841,7 @@ proc action_86
 	local	0,000000,yyval
 	declend
 	line	508
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42862,7 +42858,7 @@ proc action_86
 lab L1
 	pnull
 	line	508
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -42877,7 +42873,7 @@ proc action_87
 	con	4,010000,1,073
 	declend
 	line	510
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42933,7 +42929,7 @@ proc action_88
 	con	4,010000,1,073
 	declend
 	line	511
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42982,7 +42978,7 @@ proc action_89
 	local	0,000000,yyval
 	declend
 	line	512
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -42999,7 +42995,7 @@ proc action_89
 lab L1
 	pnull
 	line	512
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -43013,7 +43009,7 @@ proc action_90
 	con	3,010000,1,073
 	declend
 	line	514
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43055,7 +43051,7 @@ proc action_91
 	local	0,000000,yyval
 	declend
 	line	517
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43072,7 +43068,7 @@ proc action_91
 lab L1
 	pnull
 	line	517
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -43086,7 +43082,7 @@ proc action_92
 	con	3,002000,1,1
 	declend
 	line	519
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43128,7 +43124,7 @@ proc action_93
 	local	0,000000,yyval
 	declend
 	line	520
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43145,7 +43141,7 @@ proc action_93
 lab L1
 	pnull
 	line	520
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -43159,7 +43155,7 @@ proc action_96
 	con	3,002000,1,1
 	declend
 	line	522
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43213,7 +43209,7 @@ proc action_98
 	con	3,002000,1,1
 	declend
 	line	526
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43224,29 +43220,29 @@ proc action_98
 	var	2
 	int	1
 	line	526
-	colm	52
+	colm	33
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	526
-	colm	62
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	526
-	colm	72
+	colm	53
 	synt	any
 	subsc
 	line	526
-	colm	35
+	colm	15
 	synt	any
 	invoke	4
 	line	526
-	colm	29
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -43267,7 +43263,7 @@ proc action_100
 	con	3,002000,1,1
 	declend
 	line	529
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43278,29 +43274,29 @@ proc action_100
 	var	2
 	int	1
 	line	529
-	colm	50
+	colm	30
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	529
-	colm	60
+	colm	40
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	529
-	colm	70
+	colm	50
 	synt	any
 	subsc
 	line	529
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	529
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -43322,7 +43318,7 @@ proc action_101
 	con	3,002000,1,1
 	declend
 	line	532
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43381,7 +43377,7 @@ proc action_102
 	con	3,002000,1,1
 	declend
 	line	535
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43435,7 +43431,7 @@ proc action_103
 	con	3,002000,1,1
 	declend
 	line	536
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43489,7 +43485,7 @@ proc action_104
 	con	3,002000,1,1
 	declend
 	line	537
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43543,7 +43539,7 @@ proc action_105
 	con	3,002000,1,1
 	declend
 	line	538
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43597,7 +43593,7 @@ proc action_106
 	con	3,002000,1,1
 	declend
 	line	539
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43651,7 +43647,7 @@ proc action_107
 	con	3,002000,1,1
 	declend
 	line	540
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43705,7 +43701,7 @@ proc action_108
 	con	3,002000,1,1
 	declend
 	line	541
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43759,7 +43755,7 @@ proc action_109
 	con	3,002000,1,1
 	declend
 	line	542
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43813,7 +43809,7 @@ proc action_110
 	con	3,002000,1,1
 	declend
 	line	543
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43867,7 +43863,7 @@ proc action_111
 	con	3,002000,1,1
 	declend
 	line	544
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43921,7 +43917,7 @@ proc action_112
 	con	3,002000,1,1
 	declend
 	line	545
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -43975,7 +43971,7 @@ proc action_113
 	con	3,002000,1,1
 	declend
 	line	546
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44029,7 +44025,7 @@ proc action_114
 	con	3,002000,1,1
 	declend
 	line	547
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44083,7 +44079,7 @@ proc action_115
 	con	3,002000,1,1
 	declend
 	line	548
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44137,7 +44133,7 @@ proc action_116
 	con	3,002000,1,1
 	declend
 	line	549
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44191,7 +44187,7 @@ proc action_117
 	con	3,002000,1,1
 	declend
 	line	550
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44245,7 +44241,7 @@ proc action_118
 	con	3,002000,1,1
 	declend
 	line	551
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44299,7 +44295,7 @@ proc action_119
 	con	3,002000,1,1
 	declend
 	line	552
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44353,7 +44349,7 @@ proc action_120
 	con	3,002000,1,1
 	declend
 	line	553
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44407,7 +44403,7 @@ proc action_121
 	con	3,002000,1,1
 	declend
 	line	554
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44461,7 +44457,7 @@ proc action_122
 	con	3,002000,1,1
 	declend
 	line	555
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44515,7 +44511,7 @@ proc action_123
 	con	3,002000,1,1
 	declend
 	line	556
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44569,7 +44565,7 @@ proc action_124
 	con	3,002000,1,1
 	declend
 	line	557
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44623,7 +44619,7 @@ proc action_125
 	con	3,002000,1,1
 	declend
 	line	558
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44677,7 +44673,7 @@ proc action_126
 	con	3,002000,1,1
 	declend
 	line	559
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44731,7 +44727,7 @@ proc action_127
 	con	3,002000,1,1
 	declend
 	line	560
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44785,7 +44781,7 @@ proc action_128
 	con	3,002000,1,1
 	declend
 	line	561
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44839,7 +44835,7 @@ proc action_129
 	con	3,002000,1,1
 	declend
 	line	562
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44893,7 +44889,7 @@ proc action_130
 	con	3,002000,1,1
 	declend
 	line	563
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -44947,7 +44943,7 @@ proc action_131
 	con	3,002000,1,1
 	declend
 	line	564
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45001,7 +44997,7 @@ proc action_133
 	con	3,002000,1,1
 	declend
 	line	565
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45012,29 +45008,29 @@ proc action_133
 	var	2
 	int	1
 	line	565
-	colm	53
+	colm	33
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	565
-	colm	63
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	565
-	colm	73
+	colm	53
 	synt	any
 	subsc
 	line	565
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	565
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -45055,7 +45051,7 @@ proc action_135
 	con	3,002000,1,1
 	declend
 	line	568
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45066,29 +45062,29 @@ proc action_135
 	var	2
 	int	1
 	line	568
-	colm	48
+	colm	28
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	568
-	colm	58
+	colm	38
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	568
-	colm	68
+	colm	48
 	synt	any
 	subsc
 	line	568
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	568
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -45111,7 +45107,7 @@ proc action_136
 	con	5,002000,1,1
 	declend
 	line	571
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45179,7 +45175,7 @@ proc action_137
 	con	3,002000,1,1
 	declend
 	line	572
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45233,7 +45229,7 @@ proc action_139
 	con	3,002000,1,1
 	declend
 	line	573
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45244,29 +45240,29 @@ proc action_139
 	var	2
 	int	1
 	line	573
-	colm	51
+	colm	31
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	573
-	colm	61
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	573
-	colm	71
+	colm	51
 	synt	any
 	subsc
 	line	573
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	573
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -45287,7 +45283,7 @@ proc action_140
 	con	3,002000,1,1
 	declend
 	line	576
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45341,7 +45337,7 @@ proc action_142
 	con	3,002000,1,1
 	declend
 	line	577
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45352,29 +45348,29 @@ proc action_142
 	var	2
 	int	1
 	line	577
-	colm	50
+	colm	30
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	577
-	colm	60
+	colm	40
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	577
-	colm	70
+	colm	50
 	synt	any
 	subsc
 	line	577
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	577
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -45395,7 +45391,7 @@ proc action_143
 	con	3,002000,1,1
 	declend
 	line	580
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45449,7 +45445,7 @@ proc action_144
 	con	3,002000,1,1
 	declend
 	line	581
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45503,7 +45499,7 @@ proc action_145
 	con	3,002000,1,1
 	declend
 	line	582
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45557,7 +45553,7 @@ proc action_146
 	con	3,002000,1,1
 	declend
 	line	583
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45611,7 +45607,7 @@ proc action_147
 	con	3,002000,1,1
 	declend
 	line	584
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45665,7 +45661,7 @@ proc action_148
 	con	3,002000,1,1
 	declend
 	line	585
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45719,7 +45715,7 @@ proc action_149
 	con	3,002000,1,1
 	declend
 	line	586
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45773,7 +45769,7 @@ proc action_150
 	con	3,002000,1,1
 	declend
 	line	587
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45827,7 +45823,7 @@ proc action_151
 	con	3,002000,1,1
 	declend
 	line	588
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45881,7 +45877,7 @@ proc action_152
 	con	3,002000,1,1
 	declend
 	line	589
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45935,7 +45931,7 @@ proc action_153
 	con	3,002000,1,1
 	declend
 	line	590
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -45989,7 +45985,7 @@ proc action_154
 	con	3,002000,1,1
 	declend
 	line	591
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46043,7 +46039,7 @@ proc action_155
 	con	3,002000,1,1
 	declend
 	line	592
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46097,7 +46093,7 @@ proc action_157
 	con	3,002000,1,1
 	declend
 	line	593
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46108,29 +46104,29 @@ proc action_157
 	var	2
 	int	1
 	line	593
-	colm	50
+	colm	30
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	593
-	colm	60
+	colm	40
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	593
-	colm	70
+	colm	50
 	synt	any
 	subsc
 	line	593
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	593
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -46151,7 +46147,7 @@ proc action_158
 	con	3,002000,1,1
 	declend
 	line	596
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46205,7 +46201,7 @@ proc action_160
 	con	3,002000,1,1
 	declend
 	line	597
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46216,29 +46212,29 @@ proc action_160
 	var	2
 	int	1
 	line	597
-	colm	51
+	colm	31
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	597
-	colm	61
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	597
-	colm	71
+	colm	51
 	synt	any
 	subsc
 	line	597
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	597
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -46259,7 +46255,7 @@ proc action_161
 	con	3,002000,1,1
 	declend
 	line	600
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46313,7 +46309,7 @@ proc action_162
 	con	3,002000,1,1
 	declend
 	line	601
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46367,7 +46363,7 @@ proc action_163
 	con	3,002000,1,1
 	declend
 	line	602
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46421,7 +46417,7 @@ proc action_164
 	con	3,002000,1,1
 	declend
 	line	603
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46475,7 +46471,7 @@ proc action_165
 	con	3,002000,1,1
 	declend
 	line	604
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46529,7 +46525,7 @@ proc action_167
 	con	3,002000,1,1
 	declend
 	line	605
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46540,29 +46536,29 @@ proc action_167
 	var	2
 	int	1
 	line	605
-	colm	51
+	colm	31
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	605
-	colm	61
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	605
-	colm	71
+	colm	51
 	synt	any
 	subsc
 	line	605
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	605
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -46583,7 +46579,7 @@ proc action_168
 	con	3,002000,1,1
 	declend
 	line	608
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46637,7 +46633,7 @@ proc action_169
 	con	3,002000,1,1
 	declend
 	line	609
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46691,7 +46687,7 @@ proc action_170
 	con	3,002000,1,1
 	declend
 	line	610
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46745,7 +46741,7 @@ proc action_173
 	con	3,002000,1,1
 	declend
 	line	611
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46798,7 +46794,7 @@ proc action_174
 	con	2,002000,1,1
 	declend
 	line	615
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46809,26 +46805,26 @@ proc action_174
 	var	2
 	int	1
 	line	615
-	colm	50
+	colm	30
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	615
-	colm	60
+	colm	40
 	synt	any
 	subsc
 	line	615
-	colm	64
+	colm	44
 	synt	any
 	keywd	null
 	line	615
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	615
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -46848,7 +46844,7 @@ proc action_175
 	con	2,002000,1,1
 	declend
 	line	618
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46898,7 +46894,7 @@ proc action_176
 	con	2,002000,1,1
 	declend
 	line	619
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46948,7 +46944,7 @@ proc action_177
 	con	2,002000,1,1
 	declend
 	line	620
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -46999,7 +46995,7 @@ proc action_179
 	con	3,002000,1,1
 	declend
 	line	621
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47010,29 +47006,29 @@ proc action_179
 	var	2
 	int	1
 	line	621
-	colm	51
+	colm	31
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	621
-	colm	61
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	621
-	colm	71
+	colm	51
 	synt	any
 	subsc
 	line	621
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	621
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -47053,7 +47049,7 @@ proc action_180
 	con	3,002000,1,1
 	declend
 	line	624
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47107,7 +47103,7 @@ proc action_181
 	con	3,002000,1,1
 	declend
 	line	625
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47161,7 +47157,7 @@ proc action_182
 	con	3,002000,1,1
 	declend
 	line	626
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47215,7 +47211,7 @@ proc action_183
 	con	3,002000,1,1
 	declend
 	line	627
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47269,7 +47265,7 @@ proc action_184
 	con	3,002000,1,1
 	declend
 	line	628
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47323,7 +47319,7 @@ proc action_185
 	con	3,002000,1,1
 	declend
 	line	629
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47376,7 +47372,7 @@ proc action_187
 	con	2,002000,1,1
 	declend
 	line	630
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47387,22 +47383,22 @@ proc action_187
 	var	2
 	int	1
 	line	630
-	colm	49
+	colm	29
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	630
-	colm	59
+	colm	39
 	synt	any
 	subsc
 	line	630
-	colm	36
+	colm	15
 	synt	any
 	invoke	3
 	line	630
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -47422,7 +47418,7 @@ proc action_188
 	con	2,002000,1,1
 	declend
 	line	633
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47472,7 +47468,7 @@ proc action_189
 	con	2,002000,1,1
 	declend
 	line	634
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47522,7 +47518,7 @@ proc action_190
 	con	2,002000,1,1
 	declend
 	line	635
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47572,7 +47568,7 @@ proc action_191
 	con	2,002000,1,1
 	declend
 	line	636
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47622,7 +47618,7 @@ proc action_192
 	con	2,002000,1,1
 	declend
 	line	637
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47668,7 +47664,7 @@ proc action_193
 	con	2,002000,1,1
 	declend
 	line	638
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47714,7 +47710,7 @@ proc action_194
 	con	2,002000,1,1
 	declend
 	line	639
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47760,7 +47756,7 @@ proc action_195
 	con	2,002000,1,1
 	declend
 	line	640
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47806,7 +47802,7 @@ proc action_196
 	con	2,002000,1,1
 	declend
 	line	641
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47852,7 +47848,7 @@ proc action_197
 	con	2,002000,1,1
 	declend
 	line	642
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47898,7 +47894,7 @@ proc action_198
 	con	2,002000,1,1
 	declend
 	line	643
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47944,7 +47940,7 @@ proc action_199
 	con	2,002000,1,1
 	declend
 	line	644
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -47990,7 +47986,7 @@ proc action_200
 	con	2,002000,1,1
 	declend
 	line	645
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48036,7 +48032,7 @@ proc action_201
 	con	2,002000,1,1
 	declend
 	line	646
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48082,7 +48078,7 @@ proc action_202
 	con	2,002000,1,1
 	declend
 	line	647
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48128,7 +48124,7 @@ proc action_203
 	con	2,002000,1,1
 	declend
 	line	648
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48174,7 +48170,7 @@ proc action_204
 	con	2,002000,1,1
 	declend
 	line	649
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48220,7 +48216,7 @@ proc action_205
 	con	2,002000,1,1
 	declend
 	line	650
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48266,7 +48262,7 @@ proc action_206
 	con	2,002000,1,1
 	declend
 	line	651
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48312,7 +48308,7 @@ proc action_207
 	con	2,002000,1,1
 	declend
 	line	652
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48358,7 +48354,7 @@ proc action_208
 	con	2,002000,1,1
 	declend
 	line	653
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48404,7 +48400,7 @@ proc action_209
 	con	2,002000,1,1
 	declend
 	line	654
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48450,7 +48446,7 @@ proc action_210
 	con	2,002000,1,1
 	declend
 	line	655
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48496,7 +48492,7 @@ proc action_211
 	con	2,002000,1,1
 	declend
 	line	656
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48542,7 +48538,7 @@ proc action_212
 	con	2,002000,1,1
 	declend
 	line	657
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48588,7 +48584,7 @@ proc action_213
 	con	2,002000,1,1
 	declend
 	line	658
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48634,7 +48630,7 @@ proc action_214
 	con	2,002000,1,1
 	declend
 	line	659
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48680,7 +48676,7 @@ proc action_215
 	con	2,002000,1,1
 	declend
 	line	660
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48722,21 +48718,21 @@ proc action_217
 	con	0,002000,1,1
 	declend
 	line	661
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
 	var	0
 	int	0
 	line	661
-	colm	41
+	colm	19
 	synt	any
 	asgn
 	unmark
 lab L1
 	pnull
 	line	662
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -48748,7 +48744,7 @@ proc action_218
 	con	1,002000,1,2
 	declend
 	line	664
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48786,7 +48782,7 @@ proc action_227
 	con	1,002000,1,1
 	declend
 	line	664
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48832,7 +48828,7 @@ proc action_228
 	con	1,002000,1,1
 	declend
 	line	673
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48878,7 +48874,7 @@ proc action_229
 	con	1,002000,1,1
 	declend
 	line	674
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48924,7 +48920,7 @@ proc action_230
 	con	1,002000,1,1
 	declend
 	line	675
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -48970,7 +48966,7 @@ proc action_231
 	con	1,002000,1,1
 	declend
 	line	676
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49009,7 +49005,7 @@ proc action_232
 	con	2,002000,1,1
 	declend
 	line	677
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49068,7 +49064,7 @@ proc action_233
 	con	9,002000,1,1
 	declend
 	line	678
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49322,7 +49318,7 @@ proc action_234
 	con	4,002000,1,1
 	declend
 	line	696
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49381,7 +49377,7 @@ proc action_236
 	con	1,002000,1,1
 	declend
 	line	697
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49420,7 +49416,7 @@ proc action_237
 	con	2,002000,1,1
 	declend
 	line	699
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49467,7 +49463,7 @@ proc action_238
 	con	3,002000,1,1
 	declend
 	line	700
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49521,7 +49517,7 @@ proc action_239
 	con	3,002000,1,1
 	declend
 	line	701
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49574,7 +49570,7 @@ proc action_240
 	con	2,002000,1,1
 	declend
 	line	702
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49627,7 +49623,7 @@ proc action_241
 	con	3,002000,1,1
 	declend
 	line	703
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49678,7 +49674,7 @@ proc action_242
 	con	0,002000,1,3
 	declend
 	line	704
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49718,7 +49714,7 @@ proc action_243
 	con	4,002000,1,1
 	declend
 	line	705
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49779,7 +49775,7 @@ proc action_244
 	con	3,002000,1,1
 	declend
 	line	706
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49834,7 +49830,7 @@ proc action_245
 	con	4,002000,1,1
 	declend
 	line	707
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49895,7 +49891,7 @@ proc action_246
 	con	3,002000,1,1
 	declend
 	line	708
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -49957,7 +49953,7 @@ proc action_247
 	con	5,002000,1,1
 	declend
 	line	711
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50033,7 +50029,7 @@ proc action_248
 	con	5,002000,1,1
 	declend
 	line	714
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50111,7 +50107,7 @@ proc action_249
 	con	7,002000,1,1
 	declend
 	line	717
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50203,7 +50199,7 @@ proc action_250
 	con	7,002000,1,1
 	declend
 	line	720
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50290,7 +50286,7 @@ proc action_251
 	con	2,002000,1,1
 	declend
 	line	723
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50342,7 +50338,7 @@ proc action_253
 	con	2,002000,1,1
 	declend
 	line	726
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50394,7 +50390,7 @@ proc action_254
 	con	2,002000,1,1
 	declend
 	line	728
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50439,7 +50435,7 @@ proc action_255
 	con	1,002000,1,1
 	declend
 	line	729
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50484,7 +50480,7 @@ proc action_256
 	con	2,002000,1,1
 	declend
 	line	730
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -50495,22 +50491,22 @@ proc action_256
 	var	2
 	int	1
 	line	730
-	colm	52
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	730
-	colm	62
+	colm	53
 	synt	any
 	subsc
 	line	730
-	colm	36
+	colm	26
 	synt	any
 	invoke	3
 	line	730
-	colm	30
+	colm	19
 	synt	any
 	asgn
 	unmark
@@ -50540,7 +50536,7 @@ proc action_257
 	con	10,002000,1,2
 	declend
 	line	734
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	737
@@ -51043,7 +51039,7 @@ proc action_258
 	con	2,002000,1,1
 	declend
 	line	754
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51091,7 +51087,7 @@ proc action_259
 	con	4,002000,1,1
 	declend
 	line	756
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51151,7 +51147,7 @@ proc action_260
 	con	2,002000,1,1
 	declend
 	line	757
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51199,7 +51195,7 @@ proc action_261
 	con	4,002000,1,1
 	declend
 	line	759
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51259,7 +51255,7 @@ proc action_262
 	con	2,002000,1,1
 	declend
 	line	760
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51305,7 +51301,7 @@ proc action_264
 	con	2,002000,1,1
 	declend
 	line	762
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51316,22 +51312,22 @@ proc action_264
 	var	2
 	int	1
 	line	762
-	colm	52
+	colm	32
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	762
-	colm	62
+	colm	43
 	synt	any
 	subsc
 	line	762
-	colm	36
+	colm	15
 	synt	any
 	invoke	3
 	line	762
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -51351,7 +51347,7 @@ proc action_265
 	con	2,002000,1,1
 	declend
 	line	765
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51399,7 +51395,7 @@ proc action_266
 	con	4,002000,1,1
 	declend
 	line	766
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51461,7 +51457,7 @@ proc action_267
 	con	4,002000,1,1
 	declend
 	line	767
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51525,7 +51521,7 @@ proc action_268
 	con	6,002000,1,1
 	declend
 	line	769
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51603,7 +51599,7 @@ proc action_269
 	con	6,002000,1,1
 	declend
 	line	770
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51678,7 +51674,7 @@ proc action_271
 	con	3,002000,1,1
 	declend
 	line	772
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51689,7 +51685,7 @@ proc action_271
 	var	2
 	int	1
 	line	772
-	colm	54
+	colm	34
 	synt	any
 	subsc
 	str	2
@@ -51697,15 +51693,15 @@ proc action_271
 	var	2
 	int	3
 	line	772
-	colm	68
+	colm	48
 	synt	any
 	subsc
 	line	772
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	772
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -51726,7 +51722,7 @@ proc action_272
 	con	3,002000,1,1
 	declend
 	line	775
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51780,7 +51776,7 @@ proc action_273
 	con	3,002000,1,1
 	declend
 	line	777
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -51837,7 +51833,7 @@ proc action_275
 	con	4,002000,1,1
 	declend
 	line	778
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	779
@@ -51978,7 +51974,7 @@ proc action_276
 	con	1,002000,1,1
 	declend
 	line	787
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52018,7 +52014,7 @@ proc action_277
 	con	3,002000,1,1
 	declend
 	line	789
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52069,7 +52065,7 @@ proc action_282
 	con	0,002000,1,1
 	declend
 	line	790
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52103,7 +52099,7 @@ proc action_283
 	con	0,010000,10,145,155,160,164,171,162,145,147,145,170
 	declend
 	line	797
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52131,7 +52127,7 @@ proc action_285
 	con	3,002000,1,1
 	declend
 	line	798
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52184,7 +52180,7 @@ proc action_287
 	con	2,002000,1,1
 	declend
 	line	803
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52230,7 +52226,7 @@ proc action_289
 	con	2,002000,1,1
 	declend
 	line	807
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52276,7 +52272,7 @@ proc action_290
 	con	2,002000,1,1
 	declend
 	line	811
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52322,7 +52318,7 @@ proc action_291
 	con	2,002000,1,1
 	declend
 	line	812
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52375,7 +52371,7 @@ proc action_292
 	con	7,010000,11,162,145,147,145,170,143,157,156,143,141,164
 	declend
 	line	813
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	812
@@ -52609,7 +52605,7 @@ proc action_294
 	con	1,002000,3,257
 	declend
 	line	830
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52644,7 +52640,7 @@ lab L1
 lab L2
 	pnull
 	line	832
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -52655,7 +52651,7 @@ proc action_295
 	con	1,002000,3,257
 	declend
 	line	834
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52690,7 +52686,7 @@ lab L1
 lab L2
 	pnull
 	line	833
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -52701,7 +52697,7 @@ proc action_296
 	con	1,002000,3,257
 	declend
 	line	835
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52736,7 +52732,7 @@ lab L1
 lab L2
 	pnull
 	line	834
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -52750,7 +52746,7 @@ proc action_302
 	con	3,002000,1,1
 	declend
 	line	836
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -52810,7 +52806,7 @@ proc action_303
 	con	7,010000,26,040,163,157,040,156,157,164,040,143,150,145,143,153,151,156,147,040,146,157,162,040,163,160,141,143,145
 	declend
 	line	842
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53029,7 +53025,7 @@ proc action_304
 	con	4,002000,1,1
 	declend
 	line	853
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53089,7 +53085,7 @@ proc action_305
 	con	2,002000,1,1
 	declend
 	line	854
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53136,7 +53132,7 @@ proc action_307
 	con	3,002000,1,1
 	declend
 	line	855
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53197,7 +53193,7 @@ proc action_308
 	con	4,010000,11,162,145,147,145,170,040,164,171,160,145,040
 	declend
 	line	859
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	line	858
@@ -53489,7 +53485,7 @@ lab L12
 lab L10
 	pnull
 	line	873
-	colm	2
+	colm	1
 	synt	any
 	pfail
 	end
@@ -53512,7 +53508,7 @@ proc action_313
 	con	12,010000,26,165,156,162,145,143,157,147,156,151,172,145,144,040,145,163,143,141,160,145,040,143,150,141,162,040,134
 	declend
 	line	875
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53741,7 +53737,7 @@ proc action_314
 	con	11,010000,31,156,157,156,055,157,143,164,141,154,040,156,165,155,145,162,151,143,040,145,163,143,141,160,145,040,143,150,141,162,040,134
 	declend
 	line	886
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53956,7 +53952,7 @@ proc action_315
 	con	6,002000,1,1
 	declend
 	line	894
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -53967,50 +53963,50 @@ proc action_315
 	var	2
 	int	1
 	line	894
-	colm	53
+	colm	33
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	894
-	colm	63
+	colm	43
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	894
-	colm	73
+	colm	53
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	4
 	line	894
-	colm	83
+	colm	63
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	5
 	line	894
-	colm	93
+	colm	73
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	6
 	line	894
-	colm	103
+	colm	83
 	synt	any
 	subsc
 	line	894
-	colm	36
+	colm	15
 	synt	any
 	invoke	7
 	line	894
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -54031,7 +54027,7 @@ proc action_320
 	con	3,002000,1,1
 	declend
 	line	897
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -54079,7 +54075,7 @@ proc action_322
 	con	3,002000,1,1
 	declend
 	line	904
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull
@@ -54090,29 +54086,29 @@ proc action_322
 	var	2
 	int	1
 	line	904
-	colm	51
+	colm	31
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	2
 	line	904
-	colm	61
+	colm	41
 	synt	any
 	subsc
 	pnull
 	var	2
 	int	3
 	line	904
-	colm	71
+	colm	51
 	synt	any
 	subsc
 	line	904
-	colm	36
+	colm	15
 	synt	any
 	invoke	4
 	line	904
-	colm	30
+	colm	8
 	synt	any
 	asgn
 	unmark
@@ -54129,7 +54125,7 @@ proc action_323
 	con	0,010000,5,145,162,162,157,162
 	declend
 	line	907
-	colm	12
+	colm	11
 	synt	any
 	mark	L1
 	pnull

--- a/uni/unicon/unigram.y
+++ b/uni/unicon/unigram.y
@@ -346,7 +346,7 @@ classhead : CLASS IDENT supers LPAREN carglist RPAREN {
    $$.name := package_mangled_symbol($2.s)
    if proc($$.name, 0) then
       warning("Warning: class "|| $$.name ||" overrides the built-in function")
-   else if \ (foobar := classes.lookup($$.name)) then {
+   if \ (foobar := classes.lookup($$.name)) then {
       yyerror("redeclaration of class " || $$.name)
       }
    else


### PR DESCRIPTION
Details: There is an else in unigram.y (on line 346) that needs to be
removed so that after the warning, the class is still looked up, inserted, etc.