### PR TITLE
Fix fossil in section 10.4 of the Unicon book.

### DIFF
--- a/doc/book/classes.tex
+++ b/doc/book/classes.tex
@@ -349,7 +349,7 @@ that class. The method has access to an implicit
 \index{self}\texttt{self} that is a record containing fields whose
 names are the attributes given in the class declaration. Fields from
 the \texttt{self} variable are directly accessible by name. In addition
-to methods, classes may also contain regular procedure, global, and
+to methods, classes may also contain global and
 record declarations; such declarations have the standard semantics and
 exist in the global name space. 
 


### PR DESCRIPTION
It suggested that procedure declarations are permissible inside a
class declaration: they aren't.