### PR TITLE
Fix preprocessor to not retain definitions from previous files.

### DIFF
--- a/uni/unicon/preproce.icn
+++ b/uni/unicon/preproce.icn
@@ -167,7 +167,7 @@ procedure preproc_new(fname,predefined_syms)
       preproc_include_set := set([fname])
       preproc_filename := preproc_include_name := fname
       }
-   preproc_sym_table := \predefined_syms |table()
+   preproc_sym_table := copy(\predefined_syms) |table()
    preproc_if_stack := []
    preproc_file_stack := []
    preproc_if_state := &null


### PR DESCRIPTION
This patch from Clint fixes a Unicon preprocessor bug -- definitions from
previous files were still active on subsequent files on the command line.