### PR TITLE
Fix exercise numbering in part 1 of the IB.

### DIFF
--- a/doc/ib/app-solutions.tex
+++ b/doc/ib/app-solutions.tex
@@ -1,23 +1,24 @@
 \chapter{Solutions to Selected Exercises}
 
 \begin{itemize}
-\item[2.2]
+\item[\ref*{ILO-Chapter}.2]
 The expression
 \iconline{write("hello" \textbar\ "howdy")}
 just writes \texttt{hello}; there is no context to cause the second argument of the
 alternation to be produced.
 
-\goodbreak\item[2.3]
+\goodbreak\item[\ref*{ILO-Chapter}.3]
 The expression
 \iconline{\textbar\ (1 to 3) > 10}
 is an evaluation "black hole." The left argument produces 1, 2, 3, 1, 2, 3,
 1, 2, 3, ... indefinitely, since the comparison always fails.
 
-\goodbreak\item[3.1] The difference in execution time between interpretation and the execution
+\goodbreak\item[\ref*{Org-Chapter}.1]
+The difference in execution time between interpretation and the execution
 of compiled code is comparatively small, since most of the time in execution is spent
 in subroutines that are called in either case.
 
-\goodbreak\item[3.3]
+\goodbreak\item[\ref*{Org-Chapter}.3]
 The lexical analyzer inserts a semicolon between the lines
 \begin{iconcode}
 s1 := s2\\
@@ -27,7 +28,7 @@ because an identifier is legal at the end of an expression, and the unary
 operator for repeated alternation is legal at the beginning of an expression. 
 Thus, the second line consists of two applications of repeated alternation to \texttt{s3}.
 
-\goodbreak\item[4.6]
+\goodbreak\item[\ref*{VV-Chapter}.6]
 Type checking is a byproduct of conversion. If conversion were not
 automatic, type checking would be simple, but the conversion routines
 would still be needed for explicit type conversion. Without implicit type
@@ -42,20 +43,20 @@ while x := read() do\\
 \end{iconcode}
 This illustrates why the failure of an implicit conversion is an error.
 
-\goodbreak\item[4.7]
+\goodbreak\item[\ref*{VV-Chapter}.7]
 A test is necessary to distinguish between qualifiers and other descriptors,
 regardless of which has the flags. However, if qualifiers had flags, it
 would be necessary to mask them out in order to extract their lengths.
 Since masking is needed anyway to extract the type codes of other
 descriptors, it is more efficient to relegate the flags to them.
 
-\goodbreak\item[4.9]
+\goodbreak\item[\ref*{VV-Chapter}.9]
  The basic approach to designing one-word descriptors is to have them
 point to intermediate data that otherwise would be contained in two-word
 descriptors. In the simplest form, one-word descriptors would point to
 two-word blocks corresponding to two-word descriptors (Hanson 1980).
 
-\goodbreak\item[5.1]
+\goodbreak\item[\ref*{SC-Chapter}.1]
  If Icon is implemented on a computer whose collating sequence is different 
 from ASCII, such as EBCDIC, it still uses the ASCII collating
 sequence for comparison and sorting. Consequently, these operations may
@@ -64,7 +65,7 @@ EBCDIC environment. If the native character set of a computer is smaller
 than 256, there may be problems implementing Icon, since the size of a C
 char may be less than expected in some routines.
 
-\goodbreak\item[5.4]
+\goodbreak\item[\ref*{SC-Chapter}.4]
 Even if a newly created string exists in string space, the code to find it
 would be complex and the time required probably would outweigh any
 advantages of avoiding duplicate allocation. Furthermore, the new string
@@ -72,7 +73,7 @@ must be constructed somewhere first in order to know what to look for.
 This construction often is most conveniently performed in allocated string
 space, so most of the work is done already.
 
-\goodbreak\item[5.7]
+\goodbreak\item[\ref*{SC-Chapter}.7]
 If the context in which a subscripting expression is used can be determined
 by the translator, different virtual machine instructions could be
 generated for the different contexts. If the context is dereferencing, a virtual
@@ -82,7 +83,7 @@ space that might have to be reclaimed during garbage collection. Similarly,
 if the context is assignment, virtual machine instructions for the
 appropriate concatenation could be produced.
 
-\goodbreak\item[5.10]
+\goodbreak\item[\ref*{SC-Chapter}.10]
 The following procedure illustrates the usefulness of polymorphic subscripting:
 \begin{iconcode}
 procedure shuffle(x)\\
@@ -94,7 +95,7 @@ This procedure can shuffle strings, lists, and records. Note that subscripting
 is implicit in the element-generation and random-selection operations.
 The same principle applies to explicit subscripting, however.
 
-\goodbreak\item[6.2]
+\goodbreak\item[\ref*{List-Chapter}.2]
 An empty list consists of a list-header block and one list-element block.
 For convenience in diagramming, the list-element blocks in Chapter 6
 have space for only four elements, but the normal number is eight. Therefore,
@@ -106,7 +107,7 @@ of space for "nothing," but an empty list usually is created so that elements
 can be added to it, in which case the overhead becomes progressively
 less significant.
 
-\goodbreak\item[6.4]
+\goodbreak\item[\ref*{List-Chapter}.4]
 Just because a list element is removed from a list by a stack or queue
 operation does not mean that the element is inaccessible. Consider the
 expression
@@ -118,13 +119,13 @@ that list accesses behave coherently and consistently. One way to view
 the handling of this situation is that the pop does not remove an element
 but only makes it unavailable for {\em subsequent} access.
 
-\goodbreak\item[6.5]
+\goodbreak\item[\ref*{List-Chapter}.5]
 As indicated by the preceding solution, references to list elements that are
 removed by stack or queue operations may remain. It is easy to construct
 examples in which there are such references to unlinked list-element
 blocks.
 
-\goodbreak\item[7.3]
+\goodbreak\item[\ref*{ST-Chapter}.3]
 An empty set consists of just a set-header block. There are two words for
 the title and size. A computer with 16-bit words has thirteen 4-byte slots,
 while a computer with 32-bit words has thirty-seven 8-byte slots. Thus,
@@ -133,39 +134,39 @@ on a computer with 32-bit words, an empty set occupies 304 bytes. Each
 member added to a set occupies 12 bytes on a computer with 16-bit words
 and 24 bytes on a computer with 32-bit words.
 
-\goodbreak\item[7.8]
+\goodbreak\item[\ref*{ST-Chapter}.8]
 It is necessary to access a table to determine whether an element is
 already in it. Since the table contains the default value, it is readily available
 when it is needed. Because the default value may not be needed, it is
 not worth the trouble always to put it in table-element trapped-variable
 blocks.
 
-\goodbreak\item[7.12]
+\goodbreak\item[\ref*{ST-Chapter}.12]
 The default value of a table is constant and could be used for computing
 its hash number.
 
-\goodbreak\item[7.13]
+\goodbreak\item[\ref*{ST-Chapter}.13]
 If hashing is based on an attribute of a value that can change, two hash
 computations on that value may produce different results. If this happens,
 the value appears to be different in the two cases. Thus, the same value
 might be inserted in a set twice, an element that is in a table might not be
 found, and so on.
 
-\goodbreak\item[8.1]
+\goodbreak\item[\ref*{IX-Chapter}.1]
 The \texttt{str} instruction pushes a descriptor on the interpreter stack. 
 The d-word of this descriptor is the string length, and the v-word is a pointer
 to its location. Since the interpreter stack grows toward increasing memory
 addresses, it is natural and convenient to push the v-word first and to have its
 value as the first operand of the str instruction.
 
-\goodbreak\item[8.3]
+\goodbreak\item[\ref*{IX-Chapter}.3]
 The two expressions
 \iconline{a[?i] := a[?i] + 1}
 and
 \iconline{a[?i] +:= 1}
 generally produce different results.
 
-\goodbreak\item[8.4]
+\goodbreak\item[\ref*{IX-Chapter}.4]
 A new operator requires new syntax, which must be handled in the translator.
 Since each operator has its own virtual machine instruction, a new
 instruction must be added for the new operator. The translator, linker, and
@@ -174,7 +175,7 @@ the run-time system, the code for this instruction must be added to the
 main switch statement in the interpreter, with an appropriate call to a C
 routine to implement the operation.
 
-\goodbreak\item[9.2]
+\goodbreak\item[\ref*{EV-Chapter}.2]
 Suspension of functions and operations (but not procedures) increases the
 interpreter level. This occurs both in nested generators and generators in
 mutual evaluation. Thus, if $expr_i$ is a function or operator that suspends,
@@ -183,11 +184,11 @@ the interpreter level is increased by its evaluation in both
 and
 \iconline{$expr_1$ \& $expr_2$}
 
-\goodbreak\item[9.5]
-Exercise 2.3 contains an example of a "black hole" as a result of
+\goodbreak\item[\ref*{EV-Chapter}.5]
+Exercise \ref*{ILO-Chapter}.3 contains an example of a "black hole" as a result of
 repeated alternation.
 
-\goodbreak\item[9.7]
+\goodbreak\item[\ref*{EV-Chapter}.7]
 If the result of $expr_1$ in
 \iconline{every $expr_1$ do $expr_2$}
 is not popped, the interpreter stack builds up for every value produced by
@@ -195,18 +196,18 @@ $expr_1$. While these descriptors are removed when the loop terminates,
 interpreter stack overflow would result in expressions like
 \iconline{every 1 to 100000 do $expr_2$}
 
-\goodbreak\item[9.8]
+\goodbreak\item[\ref*{EV-Chapter}.8]
 The expressions
 \iconline{every $expr_1$}
 and
 \iconline{$expr_1$ \& \&fail}
 are equivalent unless $expr_1$ contains a \texttt{break} or \texttt{next} expression.
 
-\goodbreak\item[10.1]
+\goodbreak\item[\ref*{FPC-Chapter}.1]
 If a procedure or function call contains an extra argument that fails, the
 call is not performed (more accurately, the previous argument is resumed).
 
-\goodbreak\item[10.3]
+\goodbreak\item[\ref*{FPC-Chapter}.3]
 If a variable whose value is on the interpreter stack is returned from a procedure,
 the variable must be dereferenced, since the value on the stack
 may be overwritten. Thus, arguments and dynamic local identifiers are
@@ -227,7 +228,7 @@ that calls it. This would violate the semantic concept of "local,"
 although, as mentioned previously, static local identifiers are not dereferenced.
 This may be viewed as a bug.
 
-\goodbreak\item[10.4]
+\goodbreak\item[\ref*{FPC-Chapter}.4]
 The interpreter stack grows upward, regardless of the architecture of the
 computer on which Icon is implemented. On a computer with an
 upward-growing C stack, the C stack base is in the middle of the co-expression
@@ -238,53 +239,53 @@ when they collide. For an upward-growing C stack, either the interpreter
 stack or the C stack may run out of space, even if there is unused space in
 the other.
 
-\goodbreak\item[11.1]
+\goodbreak\item[\ref*{SM-Chapter}.1]
 Having the type code in the d-word of a descriptor allows its type to be
 determined without a level of indirection to the block title through its v-word.
 
-\goodbreak\item[11.2]
+\goodbreak\item[\ref*{SM-Chapter}.2]
 {\em Answer removed: the question no longer applies.}
 %% The keyword trapped-variable block for \texttt{\&subject} is statically allocated in
 %% the run-time system, so any scanning operation or assignment to \texttt{\&subject}
 %% changes the contents of a block in the statically allocated portion of the
 %% run-time system.
 
-\goodbreak\item[11.3]
+\goodbreak\item[\ref*{SM-Chapter}.3]
 The values of global and static identifiers are in the icode region, so any
 assignment to one of them changes data in the icode region.
 
-\goodbreak\item[11.4]
+\goodbreak\item[\ref*{SM-Chapter}.4]
 Global and static identifiers could be in a single array in the icode region.
 It is simply more convenient to handle them separately in the translator
 and linker.
 
-\goodbreak\item[11.5]
+\goodbreak\item[\ref*{SM-Chapter}.5]
 The names of global identifiers are needed for the display function and for
-the string invocation of functions as described in Exercise 10.2.
+the string invocation of functions as described in Exercise \ref*{FPC-Chapter}.2.
 
-\goodbreak\item[11.6]
+\goodbreak\item[\ref*{SM-Chapter}.6]
 The names of static identifiers are in their procedure blocks.
 
-\goodbreak\item[11.17]
+\goodbreak\item[\ref*{SM-Chapter}.17]
 The maximum type code is a small integer. Therefore, it is only necessary
 that the allocated block region be at an address larger than this value. This
 happens automatically because of the way the code for the run-time system
 is arranged, although it would be trivially easy to force.
 
-\goodbreak\item[11.19]
+\goodbreak\item[\ref*{SM-Chapter}.19]
 If there were more than one pointer on \texttt{quallist} to the same qualifier, the
 v-word of that qualifier would be relocated more than once, with an
 erroneous result. Such an error would show up when the qualifier was
 used in subsequent program execution after garbage collection.
 
-\goodbreak\item[11.21]
+\goodbreak\item[\ref*{SM-Chapter}.21]
 {\em Answer removed: the question no longer applies.}
 %% The keyword trapped-variable block for \texttt{\&subject} may contain a pointer to
 %% the allocated string region. This pointer is processed because the keyword
 %% trapped-variable block for \texttt{\&subject} is in the basis. Other such cases
 %% could be handled the same way.
 
-\goodbreak\item[11.26]
+\goodbreak\item[\ref*{SM-Chapter}.26]
 Recursion in markblock occurs when a block contains a pointer to another
 block. Thus, pointer chains cause recursion of corresponding depth. The
 following program builds a linked list whose length is the number of lines
@@ -305,7 +306,7 @@ end
 In the case of a garbage collection, the depth of recursion in \texttt{markblock}
 is the length of the linked list.
 
-\goodbreak\item[11.31]
+\goodbreak\item[\ref*{SM-Chapter}.31]
 An excessively large predictive need request may trigger a garbage collection
 unnecessarily or possibly cause error termination if there is not
 enough memory, although this is unlikely unless the request is enormous.
@@ -315,14 +316,14 @@ not enough space in the region to satisfy the allocation request, the allocation
 routine terminates program execution with a message indicating that
 there is an error in the implementation of Icon.
 
-\goodbreak\item[11.32]
+\goodbreak\item[\ref*{SM-Chapter}.32]
 As indicated in the solution to Exercise 6.5, an unlinked list-element
 block may still be referenced by a variable. As long as this is the case, the
 list-element block cannot be reclaimed by garbage collection. In general,
 as long as there is a pointer to a block that is reachable from the basis, the
 block cannot be reclaimed.
 
-\goodbreak\item[11.33]
+\goodbreak\item[\ref*{SM-Chapter}.33]
 A variable could point to the head of the block, with an offset referred to
 the location of the corresponding value. The advantage of having a variable
 point directly to its value is efficiency during expression evaluation.
@@ -333,7 +334,7 @@ may be accessed repeatedly during expression evaluation. Furthermore,
 many programs use such variables frequently but never require garbage
 collection.
 
-\goodbreak\item[11.38]
+\goodbreak\item[\ref*{SM-Chapter}.38]
 In the case of a type, such as real, for which all blocks are the same size, a
 separate allocation region can be efficiently managed by a free-list
 mechanism. No relocation is needed in such a region, and since all blocks
@@ -342,7 +343,7 @@ many allocation regions complicates the storage-management system, of
 course. The implementation of an early version of Icon employed several
 regions in which the space for freed blocks was reused (Hanson 1980).
 
-\goodbreak\item[11.39]
+\goodbreak\item[\ref*{SM-Chapter}.39]
 It is not possible to determine, in general, if storage is needed only temporarily
 or if it must be retained for an arbitrarily long time. For example, in
 \iconline{while process(read)}
@@ -354,7 +355,7 @@ Since allocation is fast and garbage collection has little work to do
 for space that is not accessible, storage throughput has a comparatively
 small impact on performance.
 
-\goodbreak\item[12.2]
+\goodbreak\item[\ref*{RT-Chapter}.2]
 On computers with 16-bit words, tests for the two types of integers must
 be made in all situations where type checking and conversion are performed.
 Furthermore, all computations that may produce a source-language
@@ -362,14 +363,14 @@ integer that requires more than 16 bits must provide for the
 creation of long-integer blocks. Since integers occur in many contexts, a
 substantial amount of code is required to handle the two types of integers.
 
-\goodbreak\item[12.4]
+\goodbreak\item[\ref*{RT-Chapter}.4]
 The value of \texttt{MaxCvtLen} must be sufficient to handle a string whose
 length is the size of the character set. Thus, if Icon had 512 different characters,
 \texttt{MaxCvtLen} would have to be 512. Even if the number of different
 characters were small, it is unlikely that some other type of conversion,
 such as real-to-string, would dominate.
 
-\goodbreak\item[12.14]
+\goodbreak\item[\ref*{RT-Chapter}.14]
 {\em Answer removed: the question no longer applies.}
 %% In \texttt{write(x1,x2,\ \dots,\ xn)}, the arguments are converted to strings,
 %% if necessary, for the purposes of output. With the exception of \texttt{xn},

--- a/doc/ib/p1-exprEval.tex
+++ b/doc/ib/p1-exprEval.tex
@@ -1,4 +1,5 @@
 \chapter{Expression Evaluation}
+\label{EV-Chapter}
 
 \textsc{Perspective}: The preceding chapter presents the essentials of
 the interpreter and expression evaluation as it might take place in a
@@ -1588,7 +1589,8 @@ matching.{\textquotedbl}
 
 \noindent\textbf{EXERCISES}
 
-\textbf{9.1} Circle all the bounded expressions in the following segments of code:
+\textbf{\ref*{EV-Chapter}.1}
+Circle all the bounded expressions in the following segments of code:
 
 \begin{iconcode}
 \>while line := read() do\\
@@ -1603,38 +1605,45 @@ matching.{\textquotedbl}
 \>\>\>move(1)
 \end{iconcode}
 
-\textbf{9.2} Describe the effect of nested generators and generators in mutual
+\textbf{\ref*{EV-Chapter}.2}
+Describe the effect of nested generators and generators in mutual
 evaluation on the interpreter level.
 
-\textbf{9.3} Consider a hypothetical control structure called
+\textbf{\ref*{EV-Chapter}.3}
+Consider a hypothetical control structure called
 \textit{exclusive alternation} that is the same as regular
 alternation, except that if the first argument produces at least one
 result, the results from the second argument are not produced. Show
 the virtual machine instructions that should be generated for
 exclusive alternation.
 
-\textbf{9.4} The expression \texttt{read(f)} is an example of an expression
+\textbf{\ref*{EV-Chapter}.4}
+The expression \texttt{read(f)} is an example of an expression
 that may produce result at one time and fail at another. This is
 possible because of a side effect of evaluating it{---}changing the
 position in the file f. Give an example of an expression that may fail
 at one time and produce a result at a subsequent time.
 
-\textbf{9.5} There are potential ``black holes'' in
+\textbf{\ref*{EV-Chapter}.5}
+There are potential ``black holes'' in
 the expression-evaluation mechanism of Icon, despite the termination
 condition for repeated alternation. Give an example of one.
 
-\textbf{9.6} The expression frame marker produced by limit makes it easy to
+\textbf{\ref*{EV-Chapter}.6}
+The expression frame marker produced by limit makes it easy to
 locate the limitation counter. Show how the counter could be located
 without the marker.
 
-\textbf{9.7} Suppose that the virtual machine instructions for
+\textbf{\ref*{EV-Chapter}.7}
+Suppose that the virtual machine instructions for
 
 \iconline{ \>every \textit{expr1} do \textit{expr2} }
 
 \noindent did not pop the result produced by \textit{expr1}. What
 effect would this have?
 
-\textbf{9.8} The virtual machine instructions for
+\textbf{\ref*{EV-Chapter}.8}
+The virtual machine instructions for
 
 \iconline{ \>every expr }
 
@@ -1666,10 +1675,12 @@ second expression could be used for the first expression. Explain why
 the two expressions are not equivalent, in general, and give an
 example in which they are different.
 
-\textbf{9.9} Diagram the states of the stack for the example given in
-Sec. 9.6, showing all generator frames.
+\textbf{\ref*{EV-Chapter}.9}
+Diagram the states of the stack for the example given in
+Sec. \ref*{EV-Chapter}.6, showing all generator frames.
 
-\textbf{9.10} Show the successive stack states for the evaluation of the
+\textbf{\ref*{EV-Chapter}.10}
+Show the successive stack states for the evaluation of the
 following expressions, assuming that the values of \texttt{\&subject}
 and \texttt{\&pos} are \texttt{"the"} and
 2 respectively, and that \texttt{read()} produces
@@ -1685,7 +1696,8 @@ and \texttt{\&pos} are \texttt{"the"} and
 \\
 \end{tabular}
 
-\textbf{9.11} Write Icon procedures to emulate string
+\textbf{\ref*{EV-Chapter}.11}
+Write Icon procedures to emulate string
 scanning. \textit{Hint:} consider the virtual machine instructions for
 
 \iconline{ \textit{\ \ expr1 }? \textit{expr2} }

--- a/doc/ib/p1-iconOverview.tex
+++ b/doc/ib/p1-iconOverview.tex
@@ -1,4 +1,5 @@
 \chapter{Icon Language Overview}
+\label{ILO-Chapter}
 
 \textsc{Perspective}: The implementer of a programming language needs
 a considerably different understanding of the language from the
@@ -2232,7 +2233,8 @@ to the balance of the implementation.
 
 \noindent \textbf{EXERCISES}
 
-\noindent \textbf{2.1} What is the outcome of the following expression if the
+\noindent \textbf{\ref*{ILO-Chapter}.1}
+What is the outcome of the following expression if the
 file f contains a line consisting of ``end'', or if it does not?
 
 \begin{iconcode}
@@ -2241,7 +2243,8 @@ file f contains a line consisting of ``end'', or if it does not?
 \>\>\>\ else write(line)
 \end{iconcode}
 
-\noindent \textbf{2.2} What does
+\noindent \textbf{\ref*{ILO-Chapter}.2}
+What does
 
 \iconline{
 \>write("hello" | "howdy")
@@ -2250,15 +2253,18 @@ file f contains a line consisting of ``end'', or if it does not?
 \noindent write?
 
 \noindent
-\textbf{2.3} What is the result of evaluating the following expression:
+\textbf{\ref*{ILO-Chapter}.3}
+What is the result of evaluating the following expression:
 
 \iconline{
 \>\ \ 1(1 to 3) > 10
 }
 
-\noindent \textbf{2.4} Explain the rationale for dereferencing of
+\noindent \textbf{\ref*{ILO-Chapter}.4}
+Explain the rationale for dereferencing of
 variables when a procedure call returns.
 
-\noindent \textbf{2.5} Give an example of a situation in which it
+\noindent \textbf{\ref*{ILO-Chapter}.5}
+Give an example of a situation in which it
 cannot be determined until run time whether a string subscripting
 expression is used in an assignment or a dereferencing context.

--- a/doc/ib/p1-interpreter.tex
+++ b/doc/ib/p1-interpreter.tex
@@ -1,4 +1,5 @@
 \chapter{The Interpreter}
+\label{IX-Chapter}
 
 \textsc{Perspective}: The interpreter provides a software realization
 of Icon's virtual machine. This machine is stack-based. The basic
@@ -888,7 +889,8 @@ Chapter 9. Pointers to frames are themselves i-state variables.
 The proper maintenance of i-state variables is a central aspect of the
 interpreter and is discussed in detail in the next two chapters.
 
-Retrospective: The interpreter models, in software, the hardware of a
+\bigskip\bigskip
+\textsc{Retrospective}: The interpreter models, in software, the hardware of a
 cpu. The instruction fetch, the execution of operations, and the flow
 of control are basically the same as that in hardware execution, as is
 the use of a stack.
@@ -904,12 +906,19 @@ software.
 
 \noindent\textbf{EXERCISES}
 
-\liststyleLvi
-\begin{enumerate}
-\item Why is it advantageous for the first argument of str to be the
+%% [DonW] Replace this list (which didn't give the right chapter
+%%        number anyway) with the same system as is used in the
+%%        rest of part 1
+%% \liststyleLvi
+%% \begin{enumerate}
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.1}
+Why is it advantageous for the first argument of str to be the
 length of the string, rather than its address?
 
-\item Show the states of the stack for the execution of the virtual
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.2}
+Show the states of the stack for the execution of the virtual
 machine instructions for the following Icon expressions:
 
 \begin{iconcode}
@@ -917,7 +926,9 @@ machine instructions for the following Icon expressions:
 \>   l := ???j
 \end{iconcode}
 
-\item Give an example for which
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.3}
+Give an example for which
 
 \iconline{
 \> expr1 := expr1 + expr2
@@ -929,15 +940,21 @@ produces a different result from
 \> expr1 +:= expr2
 }
 
-\item Describe, in general terms, what would be involved in adding a
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.4}
+Describe, in general terms, what would be involved in adding a
 new operator to Icon.
 
-\item Describe, in general terms, what would be involved in adding a
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.5}
+Describe, in general terms, what would be involved in adding a
 new kind of literal to Icon.
 
-\item Suppose that functions were bound at translation time instead of
+%%\item
+\noindent\textbf{\ref*{IX-Chapter}.6}
+Suppose that functions were bound at translation time instead of
 being source-language values. How might the virtual machine be
 modified to take advantage of such a feature?  What effect would this
 have on the interpreter?
 
-\end{enumerate}
+%%\end{enumerate}

--- a/doc/ib/p1-intro.tex
+++ b/doc/ib/p1-intro.tex
@@ -1,4 +1,5 @@
 \chapter{Introduction}
+\label{Intro-Chapter}
 
 \textsc{Perspective}: The implementation of complex software systems
 is a fascinating subject --- and an important one. Its theoretical and

--- a/doc/ib/p1-lists.tex
+++ b/doc/ib/p1-lists.tex
@@ -1,5 +1,5 @@
 \chapter{Lists}
-
+\label{List-Chapter}
 \textsc{Perspective}:Most programming languages support some form of
 vector or array data type in which elements can be referenced by
 position. Icon's list data type fills this need, but it differs from
@@ -966,18 +966,26 @@ numeric and the list does not grow or shrink.
 
 \noindent\textbf{EXERCISES}
 
-\liststyleLvi
-\begin{enumerate}
-\item \begin{enumerate}
-\item 
+%% [DonW] Replace these lists (which didn't give the right chapter
+%%        number anyway) with the same system as is used in the
+%%        rest of part 1
+%% \liststyleLvi
+%% \begin{enumerate}
+%% \item \begin{enumerate}
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.1}
 Diagram the structures that result from the evaluation of the
 following expressions:\newline
  graph := [{\textquotedbl}a{\textquotedbl},,]\newline
  graph[2] := graph[3] := graph
 
-\item How much space does an empty list occupy?
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.2}
+How much space does an empty list occupy?
 
-\item The portions of the structures for a list that are not occupied
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.3}
+The portions of the structures for a list that are not occupied
 by elements of the list constitute overhead. Calculate the percentage
 of overhead in the following lists. Assume that the minimum number of
 slots in a list-element block is eight.\newline
@@ -989,32 +997,44 @@ slots in a list-element block is eight.\newline
 How do these figures vary as a function of the minimum number of slots
 in a list-element block?
 
-\item What are the implications of not ``zeroing'' list elements when
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.4}
+What are the implications of not ``zeroing'' list elements when
 they are logically removed by a pop, get, or pull?
 
-\item When a list-element block is unlinked as the result of a pop,
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.5}
+When a list-element block is unlinked as the result of a pop,
 get, or pull, are the elements in it really inaccessible to the
 source program?
 
-\item There is considerable overhead involved in the implementation of
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.6}
+There is considerable overhead involved in the implementation of
 \textit{lists }to support both positional access and stack and queue
 access mechanisms. Suppose the language were changed so that stack and
 queue access mechanisms applied only to lists that were initially
 empty. What would the likely impact be on existing Icon programs? How
 could the implementation take advantage of this change?
 
-\item As elements are added to lists, more list-element blocks are
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.7}
+As elements are added to lists, more list-element blocks are
 added and they tend to become ``fragmented.'' Is it feasible to
 reorganize such lists, combining the elements in many list-element
 blocks into one large block? If when and how could this be done?
 
-\item A suggested alternative to maintaining a chain of list-element
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.8}
+A suggested alternative to maintaining a chain of list-element
 blocks is to allocate a larger block when space is needed and copy
 elements from the previous block into it. Criticize this proposal.
 
-\item Suppose it were possible to insert elements in the middle of
+%% \item 
+\noindent\textbf{\ref*{List-Chapter}.9}
+Suppose it were possible to insert elements in the middle of
 lists, rather than only at the ends. How might this feature be
 implemented?
 
-\end{enumerate}
-\end{enumerate}
+%% \end{enumerate}
+%% \end{enumerate}

--- a/doc/ib/p1-organization.tex
+++ b/doc/ib/p1-organization.tex
@@ -1,4 +1,5 @@
 \chapter{Organization of the Implementation}
+\label{Org-Chapter}
 
 \textsc{Perspective}: Many factors influence the implementation of a
 programming language. The properties of the language itself, of
@@ -343,16 +344,19 @@ this book.
 
 \noindent\textbf{EXERCISES}
 
-\textbf{3.1} Explain why there is only a comparatively small difference
+\textbf{\ref*{Org-Chapter}.1}
+Explain why there is only a comparatively small difference
 in execution times between a version of Icon that generates
 assembly-language code and one that generates virtual machine code
 that is interpreted.
 
-\textbf{3.2} List all the tokens in the Icon grammar that are legal as the
+\textbf{\ref*{Org-Chapter}.2}
+List all the tokens in the Icon grammar that are legal as the
 beginning of an expression and as the end of an expression. Are there
 any tokens that are legal as both? As neither?
 
-\textbf{3.3} Is a semicolon inserted by the lexical analyzer between the
+\textbf{\ref*{Org-Chapter}.3}
+Is a semicolon inserted by the lexical analyzer between the
 following two program lines?
 
 \begin{iconcode}
@@ -360,7 +364,8 @@ following two program lines?
 \>|| s3
 \end{iconcode}
 
-\textbf{3.4} Is it possible for semicolon insertion to introduce
+\textbf{\ref*{Org-Chapter}.4}
+Is it possible for semicolon insertion to introduce
 syntactic errors into a program that would be syntactically correct
 without semicolon insertion?
 

--- a/doc/ib/p1-procs-coexprs.tex
+++ b/doc/ib/p1-procs-coexprs.tex
@@ -1,4 +1,5 @@
 \chapter{Functions, Procedures, and Co-Expressions}
+\label{FPC-Chapter}
 
 \textsc{Perspective}: The invocation of functions and procedures is
 central to the evaluation of expressions in most programming
@@ -857,11 +858,13 @@ including a machine-dependent context switch.
 
 \noindent\textbf{EXERCISES}
 
-\textbf{10.1} What happens if a call of a procedure or function
+\textbf{\ref*{FPC-Chapter}.1}
+What happens if a call of a procedure or function
 contains an extra argument expression, but the evaluation of that
 expression fails?
 
-\textbf{10.2} Sometimes it is useful to be able to specify a function
+\textbf{\ref*{FPC-Chapter}.2}
+Sometimes it is useful to be able to specify a function
 or procedure by means of its string name. Icon supports
 {\textquotedbl}string invocation,{\textquotedbl} which allows the
 value of \textit{expr\TextSubscript{0}} in
@@ -891,14 +894,16 @@ invocation. Operators also may be invoked by their string names, as in
 What is needed in the implementation to support this facility? Can a
 control structure be invoked by a string name?
 
-\textbf{10.3} If the result returned by a procedure is a variable, it
+\textbf{\ref*{FPC-Chapter}.3}
+If the result returned by a procedure is a variable, it
 may need to be dereferenced. This is done in the code for
 \texttt{pret} and \texttt{psusp}. For example, if the result being
 returned is a local identifier, it must be replaced by its value What
 other kinds of variables must be dereferenced? Is there any difference
 in the dereferencing done by \texttt{pret} and \texttt{psusp}?
 
-\textbf{10.4} How is the structure of a co-expression block different
+\textbf{\ref*{FPC-Chapter}.4}
+How is the structure of a co-expression block different
 on a computer with an upward-growing C stack compared to one with a
 downward-growing C stack? What is the difference between the two cases
 in terms of potential storage fragmentation?

--- a/doc/ib/p1-runTime.tex
+++ b/doc/ib/p1-runTime.tex
@@ -1,4 +1,5 @@
 \chapter{Run-Time Support Operations}
+\label{RT-Chapter}
 
 \textsc{Perspective}: Several features of Icon's run-time system
 cannot be compartmentalized as neatly as storage management but
@@ -874,26 +875,32 @@ large.
 
 \noindent\textbf{EXERCISES}
 
-\noindent {\bf 12.1} It is possible to conceive of meaningful ways to convert
+\noindent {\bf \ref*{RT-Chapter}.1}
+It is possible to conceive of meaningful ways to convert
 \textit{any} type of data in Icon to any other. For example, a
 procedure might be converted to a string that consists of the
 procedure declaration. How would such a general conversion feature
 affect the way that types are converted in the run-time system?
 
-\noindent {\bf 12.2} On computers with 16-bit words, Icon has two
+\noindent {\bf \ref*{RT-Chapter}.2}
+On computers with 16-bit words, Icon has two
 representations for integers internally (see Sec. 4.1.3). Describe how
 this complicates type conversion.
 
-\noindent {\bf 12.3} How would the addition of a new numeric type,
+\noindent {\bf \ref*{RT-Chapter}.3}
+How would the addition of a new numeric type,
 such as complex numbers, affect type conversion?
 
-\noindent {\bf 12.4} How big would \texttt{MaxCvtLen} be if Icon had 512
+\noindent {\bf \ref*{RT-Chapter}.4}
+How big would \texttt{MaxCvtLen} be if Icon had 512
 different characters?  128? 64?
 
-\noindent {\bf 12.5} List all the source-language operations that
+\noindent {\bf \ref*{RT-Chapter}.5}
+List all the source-language operations that
 perform assignment.
 
-\noindent {\bf 12.6} Assuming that \texttt{x}, \texttt{y}, \texttt{z},
+\noindent {\bf \ref*{RT-Chapter}.6}
+Assuming that \texttt{x}, \texttt{y}, \texttt{z},
 and \texttt{w} all have string values, diagram the structures that are
 produced in the course of evaluating the following expressions:
 \begin{iconcode}
@@ -904,34 +911,39 @@ x[y][z] := w
 \end{iconcode}
 Repeat this exercise for the case where all the identifiers have tables as values.
 
-\noindent {\bf 12.7} Give an expression in which a table-element
+\noindent {\bf \ref*{RT-Chapter}.7}
+Give an expression in which a table-element
 trapped variable points to a table-element block rather than to a
 table-element trapped-variable block.
 
-\noindent {\bf 12.8} Give an expression in which a table-element
+\noindent {\bf \ref*{RT-Chapter}.8}
+Give an expression in which a table-element
 trapped variable points to a table-element trapped-variable block, but
 where there is a table-element block in the table with the same entry
 value.
 
-\noindent {\bf 12.9} 
+\noindent {\bf \ref*{RT-Chapter}.9} 
 Why are tended descriptors needed in assignment but not in dereferencing?
 
-\noindent {\bf 12.10} Show an expression in which, at the end of the case for
+\noindent {\bf \ref*{RT-Chapter}.10}
+Show an expression in which, at the end of the case for
 assignment to a substring trapped variable, the variable to which the
 assignment is to be made is a trapped variable. Can such a trapped
 variable be of any of the three types?
 
-\noindent {\bf 12.11} Why is the string produced by \texttt{read(f)}
+\noindent {\bf \ref*{RT-Chapter}.11}
+Why is the string produced by \texttt{read(f)}
 not read directly into the allocated string region?
 
-\noindent {\bf 12.12} Are there any circumstances in which
+\noindent {\bf \ref*{RT-Chapter}.12}
+Are there any circumstances in which
 \texttt{write(x1, x2, ..., xn)} requires the allocation of storage?
 
-\noindent {\bf 12.13} Identify all the portions of blocks for
+\noindent {\bf \ref*{RT-Chapter}.13} Identify all the portions of blocks for
 source-language values that are necessary only for diagnostic
 output. How significant is the amount of space involved?
 
-\noindent {\bf 12.14}
+\noindent {\bf \ref*{RT-Chapter}.14}
 {\em Question removed: it has been overtaken by subsequent versions after Version 6.}
 %% The use of trapped variables for keywords that
 %% require special processing for assignment suggests that a similar

--- a/doc/ib/p1-sets-tables.tex
+++ b/doc/ib/p1-sets-tables.tex
@@ -1,4 +1,5 @@
 \chapter{Sets and Tables}
+\label{ST-Chapter}
 
 \textsc{Perspective}: Sets and tables are data aggregates that are
 very useful for a number of common programming tasks.  Nevertheless,
@@ -751,43 +752,60 @@ are difficult to evaluate, however.
 
 \noindent\textbf{EXERCISES}
 
-\liststyleLvii
-\begin{enumerate}
-\item \begin{enumerate}
+%% [DonW] Replace these lists (which didn't give the right chapter
+%%        number anyway) with the same system as is used in the
+%%        rest of part 1
+%% \liststyleLvii
+%% \begin{enumerate}
+%% \item \begin{enumerate}
 
-\item Contrast sets and csets with respect to their implementation,
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.1}
+Contrast sets and csets with respect to their implementation,
 their usefulness in programming, and the efficiency of operations on
 them.
 
-\item Give an example of a situation in which the heterogeneity of
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.2}
+Give an example of a situation in which the heterogeneity of
 sets is useful in programming.
 
-\item How much space does an empty set occupy?
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.3}
+How much space does an empty set occupy?
 
-\item Diagram the structures resulting from the evaluation of the
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.4}
+Diagram the structures resulting from the evaluation of the
 following expressions:\newline
  t := table()\newline
  t[t] := t
 
-\item There are many sophisticated data structures that are designed
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.5}
+There are many sophisticated data structures that are designed
 to ensure efficient lookup in data aggregates like sets and tables
 (Gonnet 1984). Consider the importance of speed of lookup in sets and
 tables in Icon and the advantages that these more sophisticated data
 structures might supply.
 
-\item Some of the more sophisticated data structures mentioned in the
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.6}
+Some of the more sophisticated data structures mentioned in the
 preceding exercise have been tried experimentally in Icon and either
 have introduced unexpected implementation problems or have not
 provided a significant improvement in performance. What are possible
 reasons for these disappointing results?
 
-\item Icon goes to a lot of trouble to avoid adding table-element
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.7}
+Icon goes to a lot of trouble to avoid adding table-element
 blocks to a table unless an assignment is made to them.  Suppose a
 table-element block were simply added when a reference was made to an
 entry value that is not in the table.
-\end{enumerate}
-\end{enumerate}
-\liststyleLviii
+%% \end{enumerate}
+%% \end{enumerate}
+%% \liststyleLviii
 \begin{itemize}
 \item How would this simplify the implementation?
 
@@ -800,17 +818,20 @@ have positive and negative effects on performance, respectively.
 \item Would this change be transparent to the Icon programmer, not
 counting possible time and space differences?
 \end{itemize}
-\liststyleLix
-\begin{enumerate}
-\item \begin{enumerate}
+%% \liststyleLix
+%% \begin{enumerate}
+%% \item \begin{enumerate}
 
-\item There is space in a table-element trapped-variable block to put
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.8}
+There is space in a table-element trapped-variable block to put
 the default value for the table. Why is this not done?
 
-\item 
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.9} 
 What is the consequence of evaluating the following expressions?
-\end{enumerate}
-\end{enumerate}
+%% \end{enumerate}
+%% \end{enumerate}
 \begin{iconcode}
 \>t := table(0)\\
 \>t[37] := 2\\
@@ -829,19 +850,27 @@ or
 \>write(t[37], t := "hello")
 }
 
-\liststyleLx
-\begin{enumerate}
-\item \begin{enumerate}
+%% \liststyleLx
+%% \begin{enumerate}
+%% \item \begin{enumerate}
 
-\item Give examples of different strings that have the same hash numbers.
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.10}
+Give examples of different strings that have the same hash numbers.
 
-\item Design a method for hashing strings that produces a better
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.11}
+Design a method for hashing strings that produces a better
 distribution than the the current one.
 
-\item What attribute of a table is time-invariant?
+%%\item
+\noindent\textbf{\ref*{ST-Chapter}.12}
+What attribute of a table is time-invariant?
 
-\item What kinds of symptoms might result from a hashing computation
+%%\item
+ \noindent\textbf{\ref*{ST-Chapter}.13}
+ What kinds of symptoms might result from a hashing computation
  based on an attribute of a value that is not time-invariant?
 
-\end{enumerate}
-\end{enumerate}
+%% \end{enumerate}
+%% \end{enumerate}

--- a/doc/ib/p1-storage.tex
+++ b/doc/ib/p1-storage.tex
@@ -1,4 +1,5 @@
 \chapter{Storage Management}
+\label{SM-Chapter}
 
 \begin{quote}
 Editorial Note: the implementation of storage management has transformed
@@ -1994,31 +1995,38 @@ collection is fast.
 
 \noindent\textbf{EXERCISES}
 
-\noindent {\bf 11.1} Since the first word of a block contains its type
+\noindent {\bf \ref*{SM-Chapter}.1}
+Since the first word of a block contains its type
 code, why is there also a type code in a descriptor that points to it?
 
-\noindent {\bf 11.2}
+\noindent {\bf \ref*{SM-Chapter}.2}
 {\em Question removed: it no longer applies.}
 %% Give an example of an Icon expression that
 %% changes the contents of a block that is allocated statically in the
 %% run-time system.
 
-\noindent {\bf 11.3} Give an example of an Icon expression that
+\noindent {\bf \ref*{SM-Chapter}.3}
+Give an example of an Icon expression that
 changes data in the icode region.
 
-\noindent {\bf 11.4} Why not combine global and static identifiers in
+\noindent {\bf \ref*{SM-Chapter}.4}
+Why not combine global and static identifiers in
 a single array of descriptors in the icode region?
 
-\noindent {\bf 11.5} Why are the names of global identifiers needed?
+\noindent {\bf \ref*{SM-Chapter}.5}
+Why are the names of global identifiers needed?
 
-\noindent {\bf 11.6} Why is there no array for the names of static identifiers?
+\noindent {\bf \ref*{SM-Chapter}.6}
+Why is there no array for the names of static identifiers?
 
-\noindent {\bf 11.7} How long can a string be?
+\noindent {\bf \ref*{SM-Chapter}.7}
+How long can a string be?
 
-\noindent {\bf 11.8} How many elements can a single list-element block
-hold?
+\noindent {\bf \ref*{SM-Chapter}.8}
+How many elements can a single list-element block hold?
 
-\noindent {\bf 11.9} List all the regions of memory in which the
+\noindent {\bf \ref*{SM-Chapter}.9}
+List all the regions of memory in which the
 following Icon data objects can occur:
 \begin{itemize}
 \item 
@@ -2031,41 +2039,52 @@ co-expression blocks
 other blocks
 \end{itemize}
 
-\noindent {\bf 11.10} List all the source-language operations in Icon
+\noindent {\bf \ref*{SM-Chapter}.10}
+List all the source-language operations in Icon
 that may cause the allocation of storage.
 
-\noindent {\bf 11.11} Give an example of an expression for which it
+\noindent {\bf \ref*{SM-Chapter}.11}
+Give an example of an expression for which it
 cannot be determined from the expression itself whether or not it
 allocates storage.
 
-\noindent {\bf 11.12} List the block types for which block size may
+\noindent {\bf \ref*{SM-Chapter}.12}
+List the block types for which block size may
 vary from one block to another.
 
-\noindent {\bf 11.13} List all the types of blocks that may occur in
+\noindent {\bf \ref*{SM-Chapter}.13}
+List all the types of blocks that may occur in
 the allocated block region.
 
-\noindent {\bf 11.14} List all the types of blocks that may occur
+\noindent {\bf \ref*{SM-Chapter}.14}
+List all the types of blocks that may occur
 outside of the allocated block region.
 
-\noindent {\bf 11.15} Give an example of an Icon program in which the
+\noindent {\bf \ref*{SM-Chapter}.15}
+Give an example of an Icon program in which the
 only access path to a live object during garbage collection is a
 variable that points to an element in a structure.
 
-\noindent {\bf 11.16} Give an example of an Icon program that
+\noindent {\bf \ref*{SM-Chapter}.16}
+Give an example of an Icon program that
 constructs a circular pointer chain.
 
-\noindent {\bf 11.17} Explain how it can be assured that all blocks in
+\noindent {\bf \ref*{SM-Chapter}.17}
+Explain how it can be assured that all blocks in
 the allocated block region are at addresses that are larger than the
 maximum type code.
 
-\noindent {\bf 11.18} Aside from the possibility of looping in the
+\noindent {\bf \ref*{SM-Chapter}.18}
+Aside from the possibility of looping in the
 location phase of garbage collection, what are the possible
 consequences of processing the descriptors in a block more than once?
 
-\noindent {\bf 11.19} What would happen if there were more than one
+\noindent {\bf \ref*{SM-Chapter}.19}
+What would happen if there were more than one
 pointer on quallist to the \textit{same} qualifier?
 
-\noindent {\bf 11.20} Because of the way that the Icon run-time system
+\noindent {\bf \ref*{SM-Chapter}.20}
+Because of the way that the Icon run-time system
 is written, blocks that are not in the allocated block region do not
 contain pointers to allocated objects. Consequently, the descriptors
 in such blocks do not have to be processed during garbage collection.
@@ -2078,23 +2097,25 @@ such blocks could contain pointers to allocated objects?
 
 \end{itemize}
 
-\noindent {\bf 11.21}
+\noindent {\bf \ref*{SM-Chapter}.21}
 {\em Question removed: it no longer applies.}
 %% There is one exception to the statement in the
 %% preceding exercise that blocks that are not in the allocated data
 %% region do not contain pointers to allocated objects. Identify this
 %% exception and explain how it is handled during garbage collection.
 
-\noindent {\bf 11.22} In the allocated string region, pointer
+\noindent {\bf \ref*{SM-Chapter}.22}
+In the allocated string region, pointer
 adjustment and compaction are done in one pass, while two passes are
 used in the allocated block region. Why are pointer adjustment and
 compaction not done in a single pass over the allocated block region?
 
-\noindent {\bf 11.23} What would be the effect of failing to remove
+\noindent {\bf \ref*{SM-Chapter}.23}
+What would be the effect of failing to remove
 the m flag from a block title during the compaction of the allocated
 block region?
 
-\noindent {\bf 11.24}
+\noindent {\bf \ref*{SM-Chapter}.24}
 {\em Question removed: it no longer applies.}
 %% If garbage collection cannot produce enough free
 %% space in the region for which the collection was triggered, program
@@ -2102,30 +2123,36 @@ block region?
 %% region. Describe how to modify the garbage collector to avoid this
 %% problem.
 
-\noindent {\bf 11.25} Write a program that requires an arbitrarily
+\noindent {\bf \ref*{SM-Chapter}.25}
+Write a program that requires an arbitrarily
 large amount of space for quallist.
 
-\noindent {\bf 11.26} Write a program that causes an arbitrary amount
+\noindent {\bf \ref*{SM-Chapter}.26}
+Write a program that causes an arbitrary amount
 of recursion in markblock during garbage collection.
 
-\noindent {\bf 11.27} Write a program that produces an arbitrarily
+\noindent {\bf \ref*{SM-Chapter}.27}
+Write a program that produces an arbitrarily
 large amount of data that must be saved by garbage collection, and
 observe the results.
 
-\noindent {\bf 11.28} Devise a more sophisticated method of preventing
+\noindent {\bf \ref*{SM-Chapter}.28} Devise a more sophisticated method of preventing
 thrashing in allocation and garbage collection than the fixed
 breathing-room method.
 
-\noindent {\bf 11.29} There is no mechanism to reduce the size of an
+\noindent {\bf \ref*{SM-Chapter}.29}
+There is no mechanism to reduce the size of an
 allocated region that may be expanded during one garbage collection,
 but which has an excessive amount of free space after another garbage
 collection. Describe how to implement such a mechanism.
 
-\noindent {\bf 11.30} Suppose that a garbage collection could occur
+\noindent {\bf \ref*{SM-Chapter}.30}
+Suppose that a garbage collection could occur
 during a call of any C routine from any other C routine. How would
 this complicate the way C routines are written?
 
-\noindent {\bf 11.31} What might happen if
+\noindent {\bf \ref*{SM-Chapter}.31}
+What might happen if
 
 \begin{itemize}
 
@@ -2137,47 +2164,56 @@ were smaller than the amount subsequently allocated?
 
 \end{itemize}
 
-\noindent {\bf 11.32} When a list-element block is unlinked as the
+\noindent {\bf \ref*{SM-Chapter}.32}
+When a list-element block is unlinked as the
 result of a pop, get, or pull, can the space it occupies always be
 reclaimed by a garbage collection? What are the general considerations
 in answering questions such as these?
 
-\noindent {\bf 11.33} A variable that refers to a descriptor in a
+\noindent {\bf \ref*{SM-Chapter}.33}
+A variable that refers to a descriptor in a
 block points directly to the descriptor, with an offset in its d-word
 to the head of the block in which the descriptor resides. Could it be
 the other way around, with a variable pointing to the head of the
 block and an offset to the descriptor? If so, what are the advantages
 and disadvantages of the two methods?
 
-\noindent {\bf 11.34} Why does sweep process an interpreter stack from
+\noindent {\bf \ref*{SM-Chapter}.34}
+Why does sweep process an interpreter stack from
 its sp to its base, rather than the other way around?
 
-\noindent {\bf 11.35} As mentioned in Sec. 11.3, all regions are
+\noindent {\bf \ref*{SM-Chapter}.35}
+As mentioned in Sec. \ref*{SM-Chapter}.3, all regions are
 collected, regardless of the region in which space is needed. Discuss
 the pros and cons of this approach.
 
-\noindent {\bf 11.36} Evaluate the cost of using two-word descriptors
+\noindent {\bf \ref*{SM-Chapter}.36}
+Evaluate the cost of using two-word descriptors
 for all pointers to blocks, even when these pointers do not correspond
 to source-language values (as, for example, in the links among
 list-element blocks).
 
-\noindent {\bf 11.37} The need to garbage-collect blocks that are
+\noindent {\bf \ref*{SM-Chapter}.37}
+The need to garbage-collect blocks that are
 allocated during program execution significantly affects the structure
 and organization of such blocks. Suppose that garbage collection were
 never needed. How could the structure and organizations of blocks be
 revised to save space?
 
-\noindent {\bf 11.38} Discuss the pros and cons of having different
+\noindent {\bf \ref*{SM-Chapter}.38}
+Discuss the pros and cons of having different
 regions for allocating blocks of different types.
 
-\noindent {\bf 11.39} Some expressions, such as
+\noindent {\bf \ref*{SM-Chapter}.39}
+Some expressions, such as
 \iconline{\texttt{while write(read())}}
 \noindent result in a substantial amount of ``storage
 throughput,'' even though no space really needs to be
 allocated. Explain why this effect cannot be avoided in general and
 discuss its impact on program performance.
 
-\noindent {\bf 11.40} Physical memory is becoming less and less
+\noindent {\bf \ref*{SM-Chapter}.40}
+Physical memory is becoming less and less
 expensive, and more computer architectures and operating systems are
 providing larger user address spaces. Discuss how very large user
 address spaces might affect allocation and garbage-collection

--- a/doc/ib/p1-strings-csets.tex
+++ b/doc/ib/p1-strings-csets.tex
@@ -1,4 +1,5 @@
 \chapter{Strings and Csets}
+\label{SC-Chapter}
 \PrimaryIndexBegin{Strings}
 
 \textsc{Perspective}: Several aspects of strings as a language feature
@@ -742,25 +743,29 @@ is not made to a subscripted string.
 
 \noindent\textbf{EXERCISES}
 
-\noindent\textbf{5.1} What are the ramifications of Icon's use of the
+\noindent\textbf{\ref*{SC-Chapter}.1}
+What are the ramifications of Icon's use of the
 256-bit ASCII character set, regardless of the ``native'' character
 set of the computer on which Icon is implemented?
 
-\noindent\textbf{5.2} Catalog all the operations on strings in Icon
+\noindent\textbf{\ref*{SC-Chapter}.2}
+Catalog all the operations on strings in Icon
 and point out any that might cause special implementation problems.
 Indicate the aspects of strings and string operations in Icon that are
 the most important in terms of memory requirements and processing
 speed.
 
-\noindent\textbf{5.3} List all the operations in Icon that require the
+\noindent\textbf{\ref*{SC-Chapter}.3}
+List all the operations in Icon that require the
 allocation of space for the construction of strings.
 
-\noindent\textbf{5.4} It has been suggested that it would be worth
+\noindent\textbf{\ref*{SC-Chapter}.4}
+It has been suggested that it would be worth
 trying to avoid duplicate allocation of the same string by searching
 the string region for a newly created string to see if it already
 exists before allocating the space for it. Evaluate this proposal.
 
-\noindent\textbf{5.5} 
+\noindent\textbf{\ref*{SC-Chapter}.5} 
 Consider the following four expressions:
 
 \begin{iconcode}
@@ -775,35 +780,41 @@ and \texttt{a2} have list values. Describe the essential differences
 between the string and list cases. Explain why these differences
 indicate flaws in language design. Suggest an alternative.
 
-\noindent\textbf{5.6} The substring trapped-variable concept has the
+\noindent\textbf{\ref*{SC-Chapter}.6}
+The substring trapped-variable concept has the
 advantage of making it possible to handle all the contexts in which
 string-subscripting expressions can occur. It is expensive, however,
 in terms of storage utilization. Analyze the impact of this feature on
 the performance of ``typical'' Icon programs.
 
-\noindent\textbf{5.7} Since the contexts in which most subscripting
+\noindent\textbf{\ref*{SC-Chapter}.7}
+Since the contexts in which most subscripting
 expressions occur can be determined, describe how to handle these
 without using trapped variables.
 
-\noindent\textbf{5.8} If a subscripting expression is applied to a
+\noindent\textbf{\ref*{SC-Chapter}.8}
+If a subscripting expression is applied to a
 result that is not a variable, it is erroneous to use such an
 expression in an assignment context. In what situations can the
 translator detect this error? Are there any situations in which a
 subscripting expression is applied to a variable but in which the
 expression cannot be used in an assignment context?
 
-\noindent\textbf{5.9} There are some potential advantages to unifying
+\noindent\textbf{\ref*{SC-Chapter}.9}
+There are some potential advantages to unifying
 the keyword and substring trapped-variable mechanisms into a single
 mechanism in which all trapped variables would have pointers to
 functions for dereferencing and assignment. What are the disadvantages
 of such a unification?
 
-\noindent\textbf{5.10} Presumably, it is unlikely for a programmer to
+\noindent\textbf{\ref*{SC-Chapter}.10}
+Presumably, it is unlikely for a programmer to
 have a constructive need for the polymorphic aspect of subscripting
 expressions. Or is it? If it is unlikely, provide a supporting
 argument. On the other hand, if there are situations in which this
 capability is useful, describe them and give examples.
 
-\noindent\textbf{5.11} In some uses of \texttt{map(s1, s2, s3)}, \texttt{s1}
+\noindent\textbf{\ref*{SC-Chapter}.11}
+In some uses of \texttt{map(s1, s2, s3)}, \texttt{s1}
 and \texttt{s2} remain fixed while \texttt{s3} varies (Griswold
 1980b). Devise a heuristic that takes advantage of such usage.

--- a/doc/ib/p1-values.tex
+++ b/doc/ib/p1-values.tex
@@ -1,4 +1,5 @@
 \chapter{Values and Variables}
+\label{VV-Chapter}
 
 \textsc{Perspective}: No feature of the Icon programming language has
 a greater impact on the implementation than untyped
@@ -280,6 +281,7 @@ the record declaration
 
 \noindent the value of \texttt{point} is
 
+\label{ComplexRecord}
 \begin{picture}(300,150)(-20,0)
 \put(0,112){\dvboxptr{record}{np}{60}{}}
 \put(140,96){\blkbox{record}{32}}
@@ -290,8 +292,9 @@ the record declaration
 \put(140,0){\dvbox{integer}{n}{3}}
 \end{picture}
 
-The record-constructor block contains information that is needed to
-resolve field references.
+The record-constructor block contains information that was used to
+resolve field references, but has now been mostly superseded -- see
+chapter \ref{Records-Classes} for further details.
 
 \label{Block-Id-Definition}
 The \textit{id} field is present in many blocks. Its purpose is to
@@ -899,10 +902,12 @@ way. See Chapters 6 and 7.
 
 \noindent\textbf{EXERCISES}
 
-\noindent\textbf{4.1} Give examples of Icon programs in which
+\noindent\textbf{\ref*{VV-Chapter}.1}
+Give examples of Icon programs in which
 heterogeneous aggregates are used in significant ways.
 
-\noindent\textbf{4.2} Design a system of type declarations for Icon so
+\noindent\textbf{\ref*{VV-Chapter}.2}
+Design a system of type declarations for Icon so
 that the translator could do type checking. Give special consideration
 to aggregates, especially those that may change in size during program
 execution. Do this from two perspectives: (a) changing the semantics
@@ -910,51 +915,62 @@ of Icon as little as possible, and (b) maximizing ,the type checking
 that can be done by the translator at the expense of flexibility in
 programming.
 
-\noindent\textbf{4.3} Suppose that functions in Icon were not
+\noindent\textbf{\ref*{VV-Chapter}.3}
+Suppose that functions in Icon were not
 first-class values and that their meanings were bound at translation
 time. How much could the translator do in the way of error checking?
 
-\noindent\textbf{4.4} Compile a list of all Icon functions and
+\noindent\textbf{\ref*{VV-Chapter}.4}
+Compile a list of all Icon functions and
 operators. Are there any that do not require argument type checking?
 Are there any that require type checking but not conversion? Identify
 those that are polymorphic. For the polymorphic ones, identify the
 different kinds of computations that are performed depending on the
 types of the arguments.
 
-\noindent\textbf{4.5} Compose a table of all type checks and
+\noindent\textbf{\ref*{VV-Chapter}.5}
+Compose a table of all type checks and
 conversions that are required for Icon functions and operators.
 
-\noindent\textbf{4.6} To what extent would the implementation of Icon
+\noindent\textbf{\ref*{VV-Chapter}.6}
+To what extent would the implementation of Icon
 be simplified if automatic type conversion were not supported? How
 would this affect the programmer?
 
-\noindent\textbf{4.7} Why is it desirable for string qualifiers not to have
+\noindent\textbf{\ref*{VV-Chapter}.7}
+Why is it desirable for string qualifiers not to have
 flags and for all other kinds of descriptors to have flags indicating they
 are not qualifiers, rather than the other way around?
 
-\noindent\textbf{4.8} Is the n flag that distinguishes string qualifiers
+\noindent\textbf{\ref*{VV-Chapter}.8}
+Is the n flag that distinguishes string qualifiers
 from all other descriptors really necessary? If not, explain how to
 distinguish the different types of descriptors without this flag.
 
-\noindent\textbf{4.9} On computers with extremely limited address
+\noindent\textbf{\ref*{VV-Chapter}.9}
+On computers with extremely limited address
 space, two-word descriptors may be impractically large. Describe how
 one-word descriptors might be designed, discuss how various types
 might be represented, and describe the ramifications for storage
 utilization and execution speed.
 
-\noindent\textbf{4.10} Identify the diagrams in this chapter that
+\noindent\textbf{\ref*{VV-Chapter}.10}
+Identify the diagrams in this chapter that
 would be different if they were drawn for a computer with 16-bit
 words.  Indicate the differences.
 
-\noindent\textbf{4.11} There is nothing in the nature of keywords that
+\noindent\textbf{\ref*{VV-Chapter}.11}
+There is nothing in the nature of keywords that
 requires them to be processed in a special way for assignment but not
 for dereferencing. Invent a new keyword that is a variable that
 requires processing when it is dereferenced. Show how to generalize
 the keyword trapped-variable mechanism to handle such cases.
 
-\noindent\textbf{4.12} List all the syntactically distinct cases in which the
+\noindent\textbf{\ref*{VV-Chapter}.12}
+List all the syntactically distinct cases in which the
 translator can determine whether a keyword variable is used in an
 assignment or dereferencing context.
 
-\noindent\textbf{4.13} What would be gained if special code were compiled for
+\noindent\textbf{\ref*{VV-Chapter}.13}
+What would be gained if special code were compiled for
 those cases in which the context for keyword variables could be determined?


### PR DESCRIPTION
Replace the hard coded chapter numbering used in the exercises (and
answers) in part 1 by LaTeX \labels and \ref*. This makes it easier to
introduce new material or to rearrange the order of the chapters.