### PR TITLE
Update the methods list collection for supplied object

### DIFF
--- a/uni/lib/class.icn
+++ b/uni/lib/class.icn
@@ -141,7 +141,7 @@ initially(obj)
    #
    # the first entry will be the set of methods defined for the class
    #
-   cmeths[self.name] := ::set(::methods(self.name))
+   cmeths[self.name] := ::set(::methods(obj))
    #
    # Get the oprec, the field names of this record will be the method names
    # defined directly in the class as well as the superclass names applicable


### PR DESCRIPTION
There is a difference between what classname() returns and the original langprocs
procedure get_class_name(). This was discovered when trying to run the program ui.

The former does not return the package name as part of the classname() but did so
with the original get_class_name() langproc procedure.

A change has been made to the class Class to get the list of methods directly using
the obj supplied instead of the class name returned using the Unicon function classname().

The ui program works correctly with this change.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>