### PR TITLE
Reduce the number of warnings produced by gcc.

### DIFF
--- a/src/common/error.h
+++ b/src/common/error.h
@@ -11,9 +11,9 @@
  */
 
 extern int  __merr_errors;
+#ifndef SEPARATE_YYERROR
 static	char	*mapterm	(int typ,struct node *val);
 
-#ifndef SEPARATE_YYERROR
 /*
  * yyerror produces syntax error messages.  tok is the offending token
  *  (yychar), lval is yylval, and state is the parser's state.
@@ -70,7 +70,6 @@ nodeptr lval;
    __merr_errors++;
    nocode++;
    }
-#endif					/* SEPARATE_YYERROR */
 
 /*
  * mapterm finds a printable string for the given token type
@@ -96,6 +95,7 @@ nodeptr val;
          return ot->tok.t_word;
    return "???";
    }
+#endif					/* SEPARATE_YYERROR */
 
 /*
  * tfatal produces the translator error messages s1 and s2 (if nonnull).  The

--- a/src/common/xwindow.c
+++ b/src/common/xwindow.c
@@ -175,5 +175,8 @@ stringint cursorsyms[] = {
 };
 
 #else					/* XWindows */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
   static char x;
+#pragma GCC diagnostic pop
 #endif					/* XWindows */

--- a/src/gdbm/systems.h
+++ b/src/gdbm/systems.h
@@ -72,7 +72,8 @@
 /* Do we have flock?  (BSD...) */
 #if 1
 
-#define UNLOCK_FILE(dbf) 0
+/* void cast suppresses gcc warning: statement with no effect [-Wunused-value] */
+#define UNLOCK_FILE(dbf) (void) 0
 #define READLOCK_FILE(dbf) lock_val = 0
 #define WRITELOCK_FILE(dbf) lock_val = 0
 

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -100,8 +100,8 @@ int		cplist2realarray(dptr dp, dptr dp2, word i, word j,
 #endif					/* Arrays */
 int		bfunc		(void);
 struct b_proc	*bi_strprc	(dptr s, C_integer arity);
-#if __clang__
-/* Stop clang from warning "control may reach end of non-void function" when calling this function */
+#if __clang__ || __GNUC__
+/* Stop clang and gcc from warning "control may reach end of non-void function" when calling this function */
 void		c_exit		(int i)  __attribute__ ((noreturn,nothrow));
 #else
 void		c_exit		(int i);
@@ -244,12 +244,12 @@ int		equiv		(dptr dp1,dptr dp2);
 int		err		(void);
 void		err_msg		(int n, dptr v);
 void		error		(char *s1, char *s2);
-#if __clang__
-/* Stop clang from warning "control may reach end of non-void function" when calling this function */
+#if __clang__ || __GNUC__
+/* Stop clang and gcc from warning "control may reach end of non-void function" when calling this function */
 void		fatalerr 	(int n,dptr v) __attribute__ ((noreturn,nothrow));
 #else
 void		fatalerr	(int n,dptr v);
-#endif /* __clang__ */
+#endif /* __clang__ || __GNUC__ */
 int		findcol		(word *ipc_in);
 char		*findfile	(word *ipc_in);
 #ifdef MultiProgram
@@ -410,12 +410,12 @@ void rusage2rec(struct rusage *usg, struct descrip *dp, struct b_record **rp);
 void		segvtrap	(void);
 void		stkdump		(int);
 word		sub		(word a,word b, int *over_flowp);
-#if __clang__
-/* Stop clang from warning "control may reach end of non-void function" when calling this function */
+#if __clang__ || __GNUC__
+/* Stop clang and gcc from warning "control may reach end of non-void function" when calling this function */
 void		syserr		(char *s) __attribute__ ((noreturn,nothrow));
 #else
 void		syserr		(char *s);
-#endif /* __clang__ */
+#endif /* __clang__ || __GNUC__ */
 struct b_coexpr	*topact		(struct b_coexpr *ce);
 void		xmfree		(void);
 #ifdef MultiProgram

--- a/src/iconc/ccode.c
+++ b/src/iconc/ccode.c
@@ -3941,8 +3941,12 @@ field_ref(p, n, rslt)
       }
    /*
     * Generate code to compute the record value and dereference it.
+    * (Remove the pragmas if the deref issue referred to below is fixed)
     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
    deref = HasVar(varsubtyp(rec->type, &single));
+#pragma GCC diagnostic pop
    if (single != NULL) {
       /*
        * The record is in a named variable. Use value directly from

--- a/src/iconc/codegen.c
+++ b/src/iconc/codegen.c
@@ -170,7 +170,7 @@ void var_dcls()
             if (!(gptr->flag & F_SmplInv))
                fprintf(codefile, "   {%d, \"%s\"},\n",
 		       (int)strlen(gptr->name), gptr->name);
-         fprintf(codefile, "   };\n");
+      fprintf(codefile, "   };\n");
       }
 
    /*
@@ -194,7 +194,7 @@ void var_dcls()
                else
                   fprintf(codefile, "   0,\n");
                }
-         fprintf(codefile, "   };\n");
+      fprintf(codefile, "   };\n");
       }
 
    /*

--- a/src/iconc/incheck.c
+++ b/src/iconc/incheck.c
@@ -53,7 +53,6 @@ do_inlin(impl, p, n, cont_loc, symtab, n_va)
 {
    int i;
    int nsyms;
-   extern int num_dynrec_ctors;
 
    /*
     * Copy arguments needed by other functions into globals and
@@ -77,14 +76,6 @@ do_inlin(impl, p, n, cont_loc, symtab, n_va)
    if (!can_il(p, n, impl))
       return 0;
 
-   /*
-    * this is now performed in can_il...
-    *
-    * mdw: Don't perform inlining if this program is using dynamic records.
-    *
-   if (num_dynrec_ctors)
-      return 0;
-    */
    /*
     * Don't in-line if there is more than one decision made based on
     *  run-time type checks (this is a heuristic).

--- a/src/iconc/tv.c
+++ b/src/iconc/tv.c
@@ -675,7 +675,7 @@ tv_rng_get(tv, bgn, end, numset)
 {
    int n;
    vord tgt, msk;
-   int bidx, eidx;
+   int bidx;
 
    *numset = 0;
    if (end < bgn) {
@@ -684,7 +684,6 @@ tv_rng_get(tv, bgn, end, numset)
       }
    n = 0;
    bidx = DivVordBits(bgn);
-   eidx = DivVordBits(end);
    tgt = tv->ent->bits[bidx++];
    msk = 1;
    msk <<= ModVordBits(bgn);

--- a/src/icont/tmain.c
+++ b/src/icont/tmain.c
@@ -626,7 +626,7 @@ void iconx(int argc, char** argv){
    if (!errors && bundleiconx) {
       FILE *f, *f2;
       char tmp[MaxPath], *iconx, *iconx2, mesg[MaxPath+80];
-      char tmp2[MaxPath + 80];
+
       strcpy(tmp, ofile);
       strcpy(tmp+strlen(tmp)-4, ".bat");
       rename(ofile, tmp);
@@ -640,6 +640,7 @@ void iconx(int argc, char** argv){
        */
       if (Gflag) {
 	char *p;
+	char tmp2[MaxPath + 80];
 	strncpy(tmp2, iconxloc, MaxPath);
 	if (((p = strrchr(tmp2, '\\')) != 0)) {
 	  p++;

--- a/src/rtt/rttmain.c
+++ b/src/rtt/rttmain.c
@@ -479,12 +479,10 @@ char **argv;
       ccomp_line = alloc(strlen(CComp) + strlen(ccomp_opts) +
 			 strlen(curlst_string) + 6);
       sprintf(ccomp_line, "%s -c %s%s", CComp, ccomp_opts, curlst_string);
-      if (!silent)
-	fprintf(stdout, "%s\n", ccomp_line); fflush(stderr);
+      if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
       if (system(ccomp_line)) return EXIT_FAILURE;
       sprintf(ccomp_line, "%s%s", "rm", curlst_string);
-      if (!silent)
-	fprintf(stdout, "%s\n", ccomp_line); fflush(stderr);
+      if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
       if (system(ccomp_line)) return EXIT_FAILURE;
       }
 

--- a/src/runtime/cnv.r
+++ b/src/runtime/cnv.r
@@ -847,7 +847,9 @@ struct descrip *dp;
 struct b_proc *bi_strprc(dptr s, C_integer arity)
    {
    C_integer i;
+#if !COMPILER
    struct pstrnm *pp;
+#endif					/* !COMPILER */
 
    if (!StrLen(*s))
       return NULL;

--- a/src/runtime/fload.r
+++ b/src/runtime/fload.r
@@ -122,9 +122,7 @@ function{0,1} loadfunc(filename,funcname)
        */
       func = (int (*)())dlsym(handle, "init");
       if (func) {
-        int i;
-
-	/*
+ 	/*
 	 * Windows .dll's have to be informed of the addresses for functions
 	 * that are called from icall.h macros. FIXME: modify progstate to
 	 * provide a discrete struct of functions pointers so that Windows
@@ -152,7 +150,7 @@ function{0,1} loadfunc(filename,funcname)
  	 rtentryvector.Alcstr = alcstr;
  	 rtentryvector.Getdbl = getdbl;
 
-	 i = (*func)(&rtentryvector);
+	 (void) (*func)(&rtentryvector);
          }
 
       /*

--- a/src/runtime/fstruct.r
+++ b/src/runtime/fstruct.r
@@ -912,7 +912,9 @@ function{1} methods(r)
    type_case r of {
       record:
 	 body {
+#if !COMPILER
       char * suffix;
+#endif /* COMPILER */
       unsigned recnm_len;
       struct b_record * br;
       tended char * recnm_bgn;

--- a/src/runtime/fxpattrn.ri
+++ b/src/runtime/fxpattrn.ri
@@ -167,7 +167,7 @@ struct b_list *ResolveList(struct b_list *lp)
    for (i = 1; i < elsrc->nused; i++) {
       tended char * varname;
       struct descrip parm;
-      dptr pvar;
+      /* dptr pvar;  No longer used -- see below */
       if (is:string(elsrc->lslots[i])) {
          /*
 	  * if a string constant, drop double quotes,
@@ -218,7 +218,7 @@ struct b_list *ResolveList(struct b_list *lp)
 		  AsgnCStr(parm, varname);
 		  ReturnErrVal(160, parm, NULL);
 		  }
-	       pvar = VarLoc(parm);
+	       /* pvar = VarLoc(parm); */
 	       elsrc->lslots[i] = parm; /* = *pvar too aggressive */
 
 	       if (complement) {
@@ -1908,11 +1908,9 @@ dptr processMethodCallList(struct b_list *lp)
  * 3. remaining elements of the list are parameters to the method invocation
  */
 #begdef GetResultFromMethodCall()
-int nargs;
 tended struct descrip cresult;
 dptr call_result;
 tended struct b_list *lp = (struct b_list *)BlkLoc(Node->parameter);
-nargs = lp->size -1;
 
 if (is:list(Node->parameter)) {
    call_result = processMethodCallList(lp);

--- a/src/runtime/interp.r
+++ b/src/runtime/interp.r
@@ -2417,10 +2417,21 @@ interp_quit:
 #enddef
 
 #ifdef MultiProgram
+/*
+ * When all event codes are zero, interp_macro sets the value of the 
+ * variable lastdesc but never uses it (because the invocations of
+ * RealEVValD, which do use the variable, are elided by the preprocessor).
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 interp_macro(interp_0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+#pragma GCC diagnostic pop
 interp_macro(interp_1,E_Intcall,E_Stack,E_Fsusp,E_Osusp,E_Bsusp,E_Ocall,E_Ofail,E_Tick, E_Line,E_Loc,E_Opcode,E_Fcall,E_Prem,E_Erem,E_Intret,E_Psusp,E_Ssusp,E_Pret,E_Efail, E_Sresum,E_Fresum,E_Oresum,E_Eresum,E_Presum,E_Pfail,E_Ffail,E_Frem,E_Orem,E_Fret, E_Oret,E_Literal,E_Operand,E_Syntax,E_Cstack)
 #else					/* MultiProgram */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 interp_macro(interp,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+#pragma GCC diagnostic pop
 #endif					/* MultiProgram */
 
 

--- a/src/runtime/rdebug.r
+++ b/src/runtime/rdebug.r
@@ -10,7 +10,9 @@ static int     glbcmp    (char *pi, char *pj);
 static int     keyref    (union block *bp, dptr dp);
 static void showline  (char *f, int l);
 static void showlevel (register int n);
+#if !COMPILER
 static void ttrace	(FILE *f);
+#endif					/* !COMPILER */
 static void xtrace
    (struct b_proc *bp, word nargs, dptr arg, int pline, char *pfile, FILE *logfile);
 

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -888,11 +888,10 @@ int dump_addrinfo(struct addrinfo *ai)
 {
 	struct addrinfo *runp;
 	char hostbuf[50], portbuf[10];
-	int e;
 	for (runp = ai; runp != NULL; runp = runp->ai_next) {
 		printf("family: %d, socktype: %d, protocol: %d, ",
 		       runp->ai_family, runp->ai_socktype, runp->ai_protocol);
-		e = getnameinfo(
+		(void) getnameinfo(
 			runp->ai_addr, runp->ai_addrlen,
 			hostbuf, sizeof(hostbuf),
 			portbuf, sizeof(portbuf),
@@ -1989,8 +1988,7 @@ struct descrip handler;
 void signal_dispatcher(sig)
 int sig;
 {
-   struct descrip proc, val;
-   char *p;
+   struct descrip proc;
 
    proc = handlers[sig];
 #ifdef MultiProgram
@@ -2028,16 +2026,20 @@ int sig;
 #endif					/* MultiProgram */
       }
 
-   /* Invoke proc */
-   p = si_i2s(signalnames, sig);
-   StrLen(val) = strlen(p);
-   StrLoc(val) = p;
-
 #if COMPILER
    syserr("signal handlers are not supported by iconc");
 #else
-   (void) calliconproc(proc, &val, 1);
-#endif
+   {
+     char *p;
+     struct descrip val;
+     /* Invoke proc */
+     p = si_i2s(signalnames, sig);
+     StrLen(val) = strlen(p);
+     StrLoc(val) = p;
+
+     (void) calliconproc(proc, &val, 1);
+   }
+#endif					/* COMPILER */
    
    /* Restore signal just in case (for non-BSD systems) */
    signal(sig, signal_dispatcher);


### PR DESCRIPTION
Most of the warnings are dealt with by addressing the complaint(s),
rather than suppressing the warning messages.  Some of the more
difficult issues have been left for a later effort. This commit
eliminates approximately 70 warnings.