### PR TITLE
Fix build failure after make Pure.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -65,6 +65,9 @@ FreshIconc:
 .PHONY: Common Icont Iconx Iconc Clean Pure tp gdbm xpm iyacc libs
 
 clean Clean:
+	if [ -f iyacc/Makefile ] ; then \
+		cd iyacc; $(MAKE) Clean;\
+	fi
 	cd iconc;	$(RM) *.o $(UNICONC)$(EXE)
 	cd common;	$(RM) *.o doincl$(EXE) patchstr$(EXE)
 	cd preproc;	$(RM) *.o pp$(EXE)

--- a/uni/Makefile
+++ b/uni/Makefile
@@ -41,9 +41,6 @@ graphics: gui
 	cd 3d; $(MAKE)
 
 clean Clean Pure:
-	if [ -f iyacc/Makefile ] ; then \
-		cd iyacc; $(MAKE) Clean;\
-	fi
 	cd unicon && $(MAKE) Clean
 	cd udb && $(MAKE) Clean
 	cd udb && $(MAKE) cleantools


### PR DESCRIPTION
When iyacc moved from uni to src we forgot to amend make Pure. The result is
on a subsequent build make thinks that there is nothing to be done for iyacc
and doesn't move the iyacc binary to the bin directory. The build then fails
because iyacc isn't available.