### PR TITLE
Fix for object.icn to obtain class names with package.

### DIFF
--- a/uni/lib/object.icn
+++ b/uni/lib/object.icn
@@ -91,7 +91,18 @@ class Object()
    # <[returns the classname for the current class in package::class format]>
    # </p>
    method className()
-      return mapPackageInt2Ext(::classname(self))
+      local cl, cn
+
+      cl := ::image(self)
+      cl := cl[8:(::find("(", cl))]
+      cn := ::classname(self)
+      if ::match(cn, cl) then {
+         cl := cn
+      } else {
+         cl := ::reverse(cl)
+         cl := ::reverse(cl[::find("_", cl) + 1:0])
+      }
+      return lang::mapPackageInt2Ext(cl)
    end
 
    # <p>


### PR DESCRIPTION
The Unicon function classname does not return the package that a class is in.
This affects UniDoc and causes an abort in the operation of UniDoc.

The change to object.icn in the lib has been adjusted to fix this error.

Signed-off-by: Bruce Rennie <brennie@dcsi.net.au>