### PR TITLE
Update to use repaired classname()

### DIFF
--- a/uni/lib/object.icn
+++ b/uni/lib/object.icn
@@ -91,18 +91,7 @@ class Object()
    # <[returns the classname for the current class in package::class format]>
    # </p>
    method className()
-      local cl, cn
-
-      cl := ::image(self)
-      cl := cl[8:(::find("(", cl))]
-      cn := ::classname(self)
-      if ::match(cn, cl) then {
-         cl := cn
-      } else {
-         cl := ::reverse(cl)
-         cl := ::reverse(cl[::find("_", cl) + 1:0])
-      }
-      return lang::mapPackageInt2Ext(cl)
+      return lang::mapPackageInt2Ext(::classname(self))       
    end
 
    # <p>

--- a/uni/lib/predicat.icn
+++ b/uni/lib/predicat.icn
@@ -46,9 +46,9 @@ end
 #</p>
 procedure Type(var)      # Object to examine
    if isClass(var) then {
-      suspend mapPackageInt2Ext(!get_class(var).get_supers())
+      suspend lang::mapPackageInt2Ext(::classname(var) | !get_class(var).get_supers())
       }
-   else return mapPackageInt2Ext(::type(var))
+   else return lang::mapPackageInt2Ext(::type(var))
 end
 
 #<p>


### PR DESCRIPTION
Simplify className() and Type() methods now that the classname procedure returns fully-qualified class names.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us