### PR TITLE
Update to Args class and UniDoc option handling.

### DIFF
--- a/uni/lib/args.icn
+++ b/uni/lib/args.icn
@@ -23,7 +23,14 @@ package util
 #   If an option is duplicated, the values (if any) are kept in order.
 #   Arguments are also kept in order.
 #</p>
-class Args : Object (optionMap, argList)
+#<p>
+# The class may also be given a set of valid option names (without the leading
+#   hyphens.  If given such a set, then any options that are not in the set are
+#   flagged to standard error and program execution is halted.  The class can
+#   also be given a procedure to call prior to program termination when bad
+#   options are found.  Usually, this is used to display a help message.
+#</p>
+class Args : Object (optionMap, argList, badOptions)
 
 
     #<p>
@@ -101,21 +108,35 @@ class Args : Object (optionMap, argList)
     #<p>
     #   Accept a list of arguments and process for efficient handling
     #</p>
-    initially (params # List of parametes
+    initially (params,       # List of parametes
+               validOptions, # Option set of valid option names
+               helpMesg      # Optional help message procedure to be
+                             #   called if any invalid options are found
               )
          optionMap := ::table()
          argList := []
+         badOptions := []
          every param := !params do {
              if doneWithOpts := ("--" == param) then next
              param ? {
                    if /doneWithOpts & ::tab(::many('-')) then {
                       oName := ::tab(::upto('=')|0)
-                      oValue := (="=", ::tab(0)) | &null
-                      /optionMap[oName] := []
-                      ::put(optionMap[oName], \oValue)
+                      if /validOptions | member(validOptions, oName) then {
+                          oValue := (="=", ::tab(0)) | &null
+                          /optionMap[oName] := []
+                          ::put(optionMap[oName], \oValue)
+                          }
+                      else {
+                          put(badOptions, oName)
+                          }
                       }
                    else ::put(argList, param)
                    }
              }
+        if *badOptions > 0 then {
+            every write(&errout, "Invalid option: '",!badOptions,"'")
+            \helpMesg()
+            stop()
+            }
         Args := create |self
 end

--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -64,7 +64,14 @@ class UniAll : Object (files, packages,
     # code for later linking.)
     # </p>
     method setTargetDir(tDir)
-        targetDir := tDir
+        targetDir := trim(tDir, '/\\')||"/"
+    end
+
+    # <p>
+    # Produce the target directory.
+    # <p>
+    method getTargetDir()
+        return targetDir
     end
 
     # <p>

--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -23,6 +23,8 @@ import util
 import lang
 import parser
 
+global fixName
+
 #<p>
 #  The UniAll class holds the entire internal form of a Unicon
 #    documentation set.

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -132,7 +132,6 @@ import lang
 import UniDoc
 
 global linkPath,  # Path to search when looking for already-generated HTML
-       targetDir, # Directory into which all generated HTML is placed
        title,     # Title for base document
        indexFile, # Name of base index file
        debug      # Debug flag
@@ -148,7 +147,7 @@ procedure main(args)
     processArgs(uniAll)
     uniAll.dumpStatistics("yes")
 
-    html := UniHTML(title, uniAll, targetDir, indexFile, linkPath, debug)
+    html := UniHTML(title, uniAll, indexFile, linkPath, debug)
     html.buildPages()
 
 end
@@ -161,14 +160,13 @@ procedure processArgs(uniAll # Unicon parser (instance of <tt>UniAll</tt>)
     local arg
 
     indexFile := "index.html"
-    targetDir := "./htmlDoc"
     # Some parameters are global, find them now.
     title     := Args().getOpt("title", "Generated API Docs")
     indexFile := Args().getOptDef("indexFile","index.html")
     linkPath  := []	# Default situation (no --linkPath option)
     linkPath  := [: genFields(\(Args().getOptDef("linkPath")),",") :]
     uniAll.setSourcePath(Args().getOptDef("sourcePath"))
-    uniAll.setTargetDir(targetDir := Args().getOptDef("targetDir","./htmlDoc"))
+    uniAll.setTargetDir(Args().getOptDef("targetDir","./htmlDoc"))
 
     every opt := Args().genOptNames() do {
         case opt of {

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -141,7 +141,8 @@ procedure main(args)
     local uniAll, html
 
     if *args = 0 then helpMesg()
-    Args(args)
+    Args(args,set("resolve","noresolve","linkSrc","nolinksrc","indexFile",
+                  "targetDir","sourcePath","linkPath","title"),helpMesg)
 
     uniAll := UniAll()
     processArgs(uniAll)
@@ -167,7 +168,7 @@ procedure processArgs(uniAll # Unicon parser (instance of <tt>UniAll</tt>)
     linkPath  := []	# Default situation (no --linkPath option)
     linkPath  := [: genFields(\(Args().getOptDef("linkPath")),",") :]
     uniAll.setSourcePath(Args().getOptDef("sourcePath"))
-    uniAll.setTargetDir(targetDir := Args().getOptDef("targetDir"))
+    uniAll.setTargetDir(targetDir := Args().getOptDef("targetDir","./htmlDoc"))
 
     every opt := Args().genOptNames() do {
         case opt of {
@@ -195,7 +196,8 @@ procedure helpMesg()
     write("  Arguments may be options or file names and are processed")
     write("  from left to right.  Some options remain in effect from the")
     write("  point they appear until negated by a later option.  Other")
-    write("  options affect all files.")
+    write("  options affect all files.  At least one Unicon source file must")
+    write("  appear as an argument.")
     write()
     write("Options:")
     write()

--- a/uni/unidoc/UniHTML.icn
+++ b/uni/unidoc/UniHTML.icn
@@ -21,8 +21,8 @@ global dirFlag
 #   the internal representation of Unicon programs that is produced
 #   by the <b>UniALL</b> class.
 # </p>
-class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath,
-                       debug)
+class UniHTML : Object (title, idoc, mainIndex, linkPath,
+                       debug, baseDir)
 
     # <p>
     # Construct all the needed HTML pages.  <i>All other methods are
@@ -579,8 +579,7 @@ class UniHTML : Object (title, idoc, baseDir, mainIndex, linkPath,
 
     initially
         /title     := "Generated Documentation"
-        /baseDir   := "./htmlDoc"
-        baseDir    := trim(baseDir, '/\\')||"/"
+        /baseDir   := idoc.getTargetDir()
         mkdir(baseDir) | close(open(baseDir)) |
             stop("Cannot access directory '",baseDir,"'.")
         /mainIndex := "index.html"


### PR DESCRIPTION
This adds the ability to detect bad command line options to the util::Args class and adds that detection to UniDoc.  A bug in UniDoc where the handling of a default target directory is incorrect has also been fixed.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>
