### PR TITLE
Rename UniDoc executable to unidoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ UIPL=$(ULROT)/ipl
 UPLUGINS=$(ULROT)/plugins/lib
 INST=$(SHTOOL) install -c
 F=*.{u,icn}
-Tbins=unicon icont iconx iconc unicont uniconx uniconc udb uprof unidep UniDoc \
+Tbins=unicon icont iconx iconc unicont uniconx uniconc udb uprof unidep unidoc \
 	ui ivib patchstr iyacc rt.a rt.h
 
 Tdirs=$(DESTDIR)$(ULB) $(DESTDIR)$(UIPL) $(DESTDIR)$(UPLUGINS)

--- a/uni/unidoc/Makefile
+++ b/uni/unidoc/Makefile
@@ -16,12 +16,12 @@ UFILES := $(patsubst %.icn, %.u, $(SRCS))
 #    running it.
 #
 
-default: UniDoc$(EXE)
+default: unidoc$(EXE)
 
 help:
 	@echo "You may make: "
 	@echo ""
-	@echo "UniDoc ufiles depends doc clean list print printall"
+	@echo "unidoc ufiles depends doc clean list print printall"
 
 .PHONY: ufiles deps depends doc docs clean list print printall htmldoc
 
@@ -33,15 +33,15 @@ help:
 %.u:	%.icn
 	$(UNICON) $(UFLAGS) -c $?
 
-UniDoc$(EXE): $(UFILES)
-	$(UNICON) -o UniDoc $(UFILES)
-	$(CP) UniDoc$(EXE) $(BIN)
+unidoc$(EXE): $(UFILES)
+	$(UNICON) -o unidoc $(UFILES)
+	$(CP) unidoc$(EXE) $(BIN)
 	@date >.lastbuild        # remembers when things were last built.
 
 ufiles: $(SRCS)
 	$(UNICON) $(UFLAGS) -c $?
 
-doc docs:	UniDoc
+doc docs:	unidoc
 	./buildDocs.sh
 
 deps depends:
@@ -49,12 +49,12 @@ deps depends:
 
 
 htmldoc:
-	./UniDoc --title="UniDoc API" --linkSrc --sourcePath=. --resolve *.icn
+	./unidoc --title="UniDoc API" --linkSrc --sourcePath=. --resolve *.icn
 
 # Clean up the directory.
 #
 clean:
-	$(RM) UniDoc$(EXE) *.u uniclass.dir uniclass.pag uniclass.db *~
+	$(RM) unidoc$(EXE) *.u uniclass.dir uniclass.pag uniclass.db *~
 
 
 # List all source files that have been modified since the last build.

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -2,7 +2,7 @@
 # Generate HTML documentation from Unicon (<i>or Icon</i>) source files.
 #</p>
 #<p>Syntax:<tt>
-# <b>UniDoc</b> <i>arg...</i>
+# <b>unidoc</b> <i>arg...</i>
 # </tt>
 #</p>
 #<p>
@@ -189,7 +189,7 @@ end
 # Quit after displaying a short usage message.
 # </p>
 procedure helpMesg()
-    write("Usage: UniDoc [argument ...]")
+    write("Usage: unidoc [argument ...]")
     write()
     write("  Arguments may be options or file names and are processed")
     write("  from left to right.  Some options remain in effect from the")

--- a/uni/unidoc/buildDocs.sh
+++ b/uni/unidoc/buildDocs.sh
@@ -25,7 +25,7 @@ for dir in ${DIRS}; do
      TD=${TBASE}/${dir}
      mkdir -p ${TD}
      cd ${SD}
-     /opt/unicon/uni/unidoc/UniDoc --title="${title}" --linkSrc \
+     /opt/unicon/uni/unidoc/unidoc --title="${title}" --linkSrc \
             --sourcePath=${SDIRS} \
             --linkPath=${LDIRS} \
             --resolve --targetDir=${TD} *.icn

--- a/uni/unidoc/buildIPLdoc.sh
+++ b/uni/unidoc/buildIPLdoc.sh
@@ -25,7 +25,7 @@ for dir in ${DIRS}; do
      TD=${TBASE}/${dir}
      mkdir -p ${TD}
      cd ${SD}
-     UniDoc --title=\"${title}\" --resolve \
+     unidoc --title=\"${title}\" --resolve \
             --sourcePath=${SDIRS} --linkSrc --targetDir=${TD} *.icn
      echo
      echo


### PR DESCRIPTION
To be consistent with the naming convention used with other Unicon tools, this changes the name of the UniDoc tool to unidoc.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>
