### PR TITLE
Allow directory names as arguments

### DIFF
--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -129,7 +129,16 @@ class UniAll : Object (files, packages,
         every delete(linkSet, !badFiles)
 
     end
-            
+
+    # <p>
+    #   Returns its argument if that argument ends in the specified suffix.
+    #   <[param s -- string to test]>
+    #   <[param suffix -- suffix to test against]>
+    #   <[returns <tt>s</tt> if it ends in <tt>suffix</tt>]>
+    # </p>
+    method hasSuffix(s, suffix)
+        return (s[-*suffix:0] == suffix, s)
+    end
 
     # <p>
     # This is the main entry point to the <b>UniAll</b> class.  When
@@ -138,9 +147,19 @@ class UniAll : Object (files, packages,
     # handled by this class instance.  May be called repeatedly to
     # process multiple files.
     # </p>
+    # <p>
+    # If the argument is a directory, then all files suffixed with ".icn"
+    # within that directory are processed.
+    # </p>
     method processFile(fName)
 
         if /fName | (*fName = 0) then fail
+
+        if stat(fName||"/") then {   # Handle source files in directory
+           every processFile(hasSuffix(!open(fName), ".icn"))
+           return
+           }
+
         fName := delSuffix(fName,".icn")||".icn"
         uniFile := UniFile(fName) |
                    UniFile(fName, genDirs(\sourcePath)) | {

--- a/uni/unidoc/UniDoc.icn
+++ b/uni/unidoc/UniDoc.icn
@@ -6,9 +6,12 @@
 # </tt>
 #</p>
 #<p>
-# where <i>arg</i> may be an option or a Unicon source file name.
+# where <i>arg</i> may be an option or a Unicon source file name
+# or a directory name.
 # Options apply from the point of occurrence until changed later
 # in the argument list.
+# When given a directory name, all Unicon source files in that directory
+# are processed as if they appeared at that point in the argument list.
 #</p>
 #<p>
 # Options:
@@ -191,11 +194,11 @@ end
 procedure helpMesg()
     write("Usage: unidoc [argument ...]")
     write()
-    write("  Arguments may be options or file names and are processed")
+    write("  Arguments may be options or file and directory names and are processed")
     write("  from left to right.  Some options remain in effect from the")
     write("  point they appear until negated by a later option.  Other")
-    write("  options affect all files.  At least one Unicon source file must")
-    write("  appear as an argument.")
+    write("  options affect all files.  At least one directory or Unicon source")
+    write("  file name must appear as an argument.")
     write()
     write("Options:")
     write()


### PR DESCRIPTION
When a directory name is given as an argument to UniDoc,  all Unicon/Icon source files in that directory
(but not subdirectories) are processed.

Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>