### PR TITLE
Add a bit manipulation plugin.

### DIFF
--- a/plugins/src/bitman/Makefile
+++ b/plugins/src/bitman/Makefile
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------------------------
+# 
+# This file is released under the terms of the GNU LIBRARY GENERAL PUBLIC LICENSE
+# (LGPL) version 2. The licence may be found in the root directory of the Unicon
+# source directory in the file COPYING.
+#
+#-------------------------------------------------------------------------------
+# Makefile for the bit manipulation plugin
+#
+# Look for @Replace and change the line(s) that follow(s)  
+#
+
+# @Replace: What is the name of this library?
+LNAME=bitman
+
+# @Replace: add any additionl (non-standard name) c source file(s) here
+COBJ = $(LNAME).o 
+CSRC = $(LNAME).c
+
+# @Replace: If additinal libraries need to be linked in append them here:
+MYLIBS=$(LIBS)
+
+# Relative to top level
+TOPDIR=../../..
+
+# lib relative to top
+TDIR=../..
+
+include ../Makedefs
+
+default:	 $(LIBD)/$(LNAME).u

--- a/plugins/src/bitman/bitman.c
+++ b/plugins/src/bitman/bitman.c
@@ -1,0 +1,193 @@
+/* ---------------------------------------------------------------------------
+ *
+ * This file is released under the terms of the GNU LIBRARY GENERAL PUBLIC LICENSE
+ * (LGPL) version 2. The licence may be found in the root directory of the Unicon
+ * source directory in the file COPYING.
+ *
+ * ---------------------------------------------------------------------------
+ * Low level bit manipulation routines
+ *
+ * Author  :    Don Ward
+ * Date    :    March 2021
+ *
+ *
+ * These routines are the equivalent of the Unicon built-in functions
+ * except they never produce a large integer and there is no special
+ * case for the sign bit.
+ *    bor      bitwise inclusive or       (ior)
+ *    bxor     bitwise exclusive or       (ixor)
+ *    band     bitwise and                (iand)
+ *    bcom     bitwise one's complement   (icom)
+ *    bshift   bitwise shift              (ishift)
+ * plus
+ *    bits     enquiry and bit extraction
+ *    bit      single bit extraction
+ *    brot     bit rotation
+ *
+ * bit(x,n) works the same way as string indexing (but indexing bits instead
+ * of characters, including negative indices meaning "from the end").
+ *   bit(x,1) is the ls bit of x,      (analogous to s[1]).
+ *   bit(x,n) is the nth bit of x      (analogous to s[n] when n is +ve).
+ *   bit(x,0) is the ms bit of x       (analogous to s[0]).
+ *   bit(x,-n) is analogous to s[-n] i.e indexes from the ms end of x.
+ *
+ * bits(x,n,m) works the same way as substring indexing s[n:m].
+ * Note that, as with substrings, the bits are not reversed if m < n.
+ *    bits(x,n,m) = bits(x,m,n)
+ *
+ * The routines are not portable by design (i.e. on machines with different
+ * word lengths they will give different results) which is, presumably, why
+ * you're using them in place of ior and friends.
+ */
+#include "bitman.h"
+
+#define NBITS (sizeof(word)*8)
+
+/* ---------------------------------------- */
+RTEX
+int bor(UARGS)    /* bitwise inclusive or */
+{
+  if (argc != 2) Fail;
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  RetInteger(IntegerVal(argv[1]) | IntegerVal(argv[2]));
+}
+
+/* ---------------------------------------- */
+RTEX
+int bxor(UARGS)    /* bitwise exclusive or */
+{
+  if (argc != 2) Fail;
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  RetInteger(IntegerVal(argv[1]) ^ IntegerVal(argv[2]));
+}
+
+/* ---------------------------------------- */
+RTEX
+int band(UARGS)    /* bitwise and */
+{
+  if (argc != 2) Fail;
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  RetInteger(IntegerVal(argv[1]) & IntegerVal(argv[2]));
+}
+
+/* ---------------------------------------- */
+RTEX
+int bcom(UARGS)    /* bitwise one's complement */
+{
+  if (argc != 1) Fail;
+  ArgNativeInteger(1);
+
+  RetInteger(~IntegerVal(argv[1]));
+}
+
+/* ---------------------------------------- */
+RTEX
+int bshift(UARGS)    /* bitwise shift */
+{
+  word n;
+  if (argc != 2) Fail;
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  /* If the amount to shift is >= wordsize, the result is undefined. */
+  /* In that case we return a zero value. */
+  n = IntegerVal(argv[2]);
+  if (n == 0) {
+    RetInteger(IntegerVal(argv[1]));
+  } else if (n > 0) {
+    if (n < NBITS) {
+      RetInteger(IntegerVal(argv[1]) << n);
+    } else {
+      RetInteger(0);
+    }
+  } else {
+    n = -n;
+    if (n < NBITS) {
+      RetInteger(IntegerVal(argv[1]) >> n);
+    } else {
+      RetInteger(0);
+    }
+  }
+}
+
+/* ---------------------------------------- */
+RTEX
+int bits(UARGS)    /* enquiry and bit extraction */
+{
+  if (argc == 0) { /* return how many bits there are in a word */
+    RetInteger(NBITS);
+  } else { /* Extract some bits from a word */
+    word lo, hi;
+    if (argc != 3) Fail;
+
+    ArgNativeInteger(1);
+    ArgNativeInteger(2);
+    ArgNativeInteger(3);
+    lo = IntegerVal(argv[2]);
+    hi = IntegerVal(argv[3]);
+    if (lo <= 0) lo = 1 + NBITS + lo;
+    if (hi <= 0) hi = 1 + NBITS + hi;
+    if (hi < lo) {
+      word tmp = hi;
+      hi = lo; lo = tmp;
+    }
+    if ((lo < 1) || (hi < 1) || (lo > NBITS) || (hi > (1 + NBITS))) Fail;
+    if (lo == hi) Fail;         /* zero length bit string */
+
+     /* Check for the easy case */
+    if ((lo == 1) && (hi == (1 + NBITS))) {
+      RetArg(1);
+    } else {
+      word ans = IntegerVal(argv[1]);
+      if (lo > 1) ans >>= (lo - 1); /* Shift to the RHS */
+      ans &= (((uword)(-1)) >> (NBITS + lo - hi)); /* Clear unwanted bits */
+      RetInteger(ans);
+    }
+  }
+}
+
+/* ---------------------------------------- */
+RTEX
+int bit(UARGS)    /* single bit extraction */
+{
+  word bn;
+  if (argc != 2) Fail;
+
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  bn = IntegerVal(argv[2]);
+  if (bn == 0) Fail;
+  if (bn < 0) bn = NBITS + bn + 1; /* addressing from ms end */
+  if ((bn < 1) || (bn > NBITS)) Fail;
+  if (bn == 1) RetInteger(IntegerVal(argv[1]) & 1);
+  RetInteger( (IntegerVal(argv[1]) >> (bn - 1)) & 1);
+}
+
+/* ---------------------------------------- */
+RTEX
+int brot(UARGS)    /* bit rotation */
+{
+  word n;
+  if (argc != 2) Fail;
+  ArgNativeInteger(1);
+  ArgNativeInteger(2);
+
+  n = IntegerVal(argv[2]) % NBITS;
+  if (n == 0) {
+    RetArg(1);                  /* Easy! */
+  } else {
+    word ans = IntegerVal(argv[1]);
+    if (n < 0) n = NBITS + n;
+    RetInteger((ans << n) | ((ans >> (NBITS - n)) & (((uword)~0) >> (NBITS -n))));
+  }
+}
+
+
+

--- a/plugins/src/bitman/bitman.h
+++ b/plugins/src/bitman/bitman.h
@@ -1,0 +1,17 @@
+/* ---------------------------------------------------------------------------
+ *
+ * This file is released under the terms of the GNU LIBRARY GENERAL PUBLIC LICENSE
+ * (LGPL) version 2. The licence may be found in the root directory of the Unicon
+ * source directory in the file COPYING.
+ *
+ */
+#include "../icall.h"
+
+RTEX int bor(UARGS);
+RTEX int bxor(UARGS);
+RTEX int band(UARGS);
+RTEX int bcom(UARGS);
+RTEX int bshift(UARGS);
+RTEX int bits(UARGS);
+RTEX int bit(UARGS);
+RTEX int brot(UARGS);

--- a/plugins/src/bitman/bitman.icn
+++ b/plugins/src/bitman/bitman.icn
@@ -1,0 +1,211 @@
+#-------------------------------------------------------------------------------
+#
+# This file is released under the terms of the GNU LIBRARY GENERAL PUBLIC LICENSE
+# (LGPL) version 2. The licence may be found in the root directory of the Unicon
+# source directory in the file COPYING.
+#
+#-------------------------------------------------------------------------------
+package Bitman
+
+# ------------------------------------------------------------------------------
+# A plugin to do low level bit manipulation.
+#
+# Author  :    Don Ward
+# Date    :    March 2021
+#
+#
+# These routines are the equivalent of the Unicon built-in functions
+# except they never produce a large integer and there is no special
+# case for the sign bit.
+#    bor      bitwise inclusive or       (ior)
+#    bxor     bitwise exclusive or       (ixor)
+#    band     bitwise and                (iand)
+#    bcom     bitwise one's complement   (icom)
+#    bshift   bitwise shift              (ishift)
+# plus
+#    bits     enquiry and bit extraction
+#    bit      single bit extraction
+#    brot     bit rotation
+#
+# bit(x,n) works the same way as string indexing (but indexing bits instead
+# of characters, including negative indices meaning "from the end").
+#   bit(x,1) is the ls bit of x,      (analogous to s[1]).
+#   bit(x,n) is the nth bit of x      (analogous to s[n] when n is +ve).
+#   bit(x,0) is the ms bit of x       (analogous to s[0]).
+#   bit(x,-n) is analogous to s[-n] i.e indexes from the ms end of x.
+#
+# bits(x,n,m) works the same way as substring indexing s[n:m].
+# Note that, as with substrings, the bits are not reversed if m < n.
+#    bits(x,n,m) = bits(x,m,n)
+#
+# The routines are not portable by design (i.e. on machines with different
+# word lengths they will give different results) which is, presumably, why
+# you're using them in place of ior and friends.
+# ------------------------------------------------------------------------------
+
+class Bitman : uso::USO()
+   # ----------------------------------------
+   # bitwise inclusive or
+   method bor(v1:integer, v2:integer)
+      static Cbor
+      initial Cbor := loadfunc("bitman.so", "bor")
+
+      return \Cbor(v1,v2)
+   end
+
+   # ----------------------------------------
+   # bitwise exclusive or
+   method bxor(v1:integer, v2:integer)
+      static Cbxor
+      initial Cbxor := loadfunc("bitman.so", "bxor")
+
+      return \Cbxor(v1,v2)
+   end
+
+   # ----------------------------------------
+   # bitwise and
+   method band(v1:integer, v2:integer)
+      static Cband
+      initial Cband := loadfunc("bitman.so", "band")
+
+      return \Cband(v1,v2)
+   end
+
+   # ----------------------------------------
+   # bitwise one's complement
+   method bcom(v1:integer)
+      static Cbcom
+      initial Cbcom := loadfunc("bitman.so", "bcom")
+
+      return \Cbcom(v1)
+   end
+
+   # ----------------------------------------
+   # shift
+   method bshift(v1:integer, v2:integer)
+      static Cbshift
+      initial Cbshift := loadfunc("bitman.so", "bshift")
+
+      return \Cbshift(v1,v2)
+   end
+
+   # ----------------------------------------
+   # bit rotation
+   method brot(v1:integer, v2:integer)
+      static Cbrot
+      initial Cbrot := loadfunc("bitman.so", "brot")
+
+      return \Cbrot(v1,v2)
+   end
+
+   # ----------------------------------------
+   # single bit extraction
+   method bit(v:integer, n:integer)
+      static Cbit
+      initial Cbit := loadfunc("bitman.so", "bit")
+
+      return \Cbit(v, n)
+   end
+
+   # ----------------------------------------
+   # enquiry and bit extraction
+   # bits()      returns the number of bits in a word
+   # bits(x,n,m) returns a bit subset x[min(n,m) : max(n,m)]
+   method bits(args[])
+      static Cbits
+      initial Cbits := loadfunc("bitman.so", "bits")
+
+      case *args of {
+         0: return \Cbits()
+         3: return \Cbits(args[1], args[2], args[3])
+      }
+      # Fail
+   end
+
+   # ----------------------------------------
+   method api()
+      return [
+              lang::find_method("bor"),
+              lang::find_method("xbor"),
+              lang::find_method("band"),
+              lang::find_method("bcom"),
+              lang::find_method("bshift"),
+              lang::find_method("bit"),
+              lang::find_method("bits"),
+              lang::find_method("brot"),
+              lang::find_method("test")
+              ]
+   end
+
+$define FAIL_TEST put(failures, "Test failure at " || &file || ":"  || &line)
+
+   # ----------------------------------------
+   # Confidence testing
+   method test()
+      local failures := [], nbits
+      local n, val
+
+      # Check that every routine actually functions
+      if not bor(1,1) then FAIL_TEST
+      if not bxor(1,1) then FAIL_TEST
+      if not band(1,1) then FAIL_TEST
+      if not bcom(1,1) then FAIL_TEST
+      if not bshift(1,1) then FAIL_TEST
+      if not bit(1,1) then FAIL_TEST
+      if not bits(1,1,2) then FAIL_TEST
+
+      # Some simple confidence tests, mostly on the low 32 bits (so the
+      # tests work on 32-bit and 64-bit machines)
+      if bor (16RF0F0, 16RFF00) ~= 16RFFF0 then FAIL_TEST
+      if band(16RF0F0, 16RFF00) ~= 16RF000 then FAIL_TEST
+      if bxor(16RF0F0, 16RFF00) ~= 16R0FF0 then FAIL_TEST
+      if bcom(0) ~= -1 then FAIL_TEST
+      if bcom(42) ~= -43 then FAIL_TEST
+      if bshift(16R42,4) ~= 16R420 then FAIL_TEST
+      if bshift(16R678, -8) ~= 6 then FAIL_TEST
+      if (bit(16R123456,2) ~= 1) ||
+         (bit(16R123456,3) ~= 1) ||
+         (bit(16R123456,4) ~= 0) ||
+         (bit(16R123456,5) ~= 1)  then FAIL_TEST
+      if bits(16R123456,1,5) ~= 6 then FAIL_TEST
+      if bits(16R123456,5,1) ~= 6 then FAIL_TEST
+      if bits(16R12345678,30,33) ~= 0 then FAIL_TEST
+      if bits(16R12345678,29,33) ~= 1 then FAIL_TEST
+      if bits(16R123456,9,21) ~= 16R234 then FAIL_TEST
+
+      nbits := bits()
+      # tests that depend on the number of bits in a word
+      if \nbits = 32 then {
+         val := 16R55555555     # make sure this is not a large integer!
+         every n := 1 to 32 do {
+            if bit(val,n) ~= bit(n,1) then FAIL_TEST
+            if bit(val,n) ~= bit(val, n - 32 - 1) then FAIL_TEST
+         }
+         every n := 1 to 30 do {
+            if bits(val,n, n+3) ~= (2 + bit(n,1)*3) then FAIL_TEST
+            if bits(val, (n - 32), (n - 32 - 3)) ~= (2 + bit(n,1)*3) then FAIL_TEST
+         }
+         if brot(16R12345678,1) ~= 16R2468ACF0 then FAIL_TEST
+         if brot(16R12345678,4) ~= 16R23456781 then FAIL_TEST
+         if brot(16R76543210, -3) ~= 16R0ECA8642 then FAIL_TEST
+         if brot(16R4321,-1) ~= -2147475056 then FAIL_TEST
+      } else if \nbits = 64 then {
+         val := 16R5555555555555555 # make sure this is not a large integer!
+         every n := 1 to 64 do {
+            if bit(val,n) ~= bit(n,1) then FAIL_TEST
+            if bit(val,n) ~= bit(val, n - 64 - 1) then FAIL_TEST
+         }
+         every n := 1 to 62 do {
+            if bits(val,n, n+3) ~= (2 + bit(n,1)*3) then FAIL_TEST
+            if bits(val, (n - 64), (n - 64 - 3)) ~= (2 + bit(n,1)*3) then FAIL_TEST
+         }
+         # note different answers to 32-bit case
+         if brot(16R12345678,1) ~= 16R2468ACF0 then FAIL_TEST
+         if brot(16R7000000012345678,4) ~= 16R123456787 then FAIL_TEST
+         if brot(16R4321,-1) ~= -9223372036854767216 then FAIL_TEST
+      } else FAIL_TEST
+
+      return failures
+   end
+end
+

--- a/plugins/src/bitman/testbitman.icn
+++ b/plugins/src/bitman/testbitman.icn
@@ -1,0 +1,76 @@
+#-------------------------------------------------------------------------------
+#
+# This file is released under the terms of the GNU LIBRARY GENERAL PUBLIC LICENSE
+# (LGPL) version 2. The licence may be found in the root directory of the Unicon
+# source directory in the file COPYING.
+#
+#-------------------------------------------------------------------------------
+#
+# A brief test for the Bitman bit manipulation plugin
+#
+# Author  :    Don Ward
+# Date    :    March 2021
+#
+#-------------------------------------------------------------------------------
+import Bitman
+link numbers
+
+$define UFL &file || ":" || &line
+
+global failures
+
+procedure Fail(mess:string)
+   put(failures, "Test failure " || mess)
+end
+
+procedure main()
+   local p, L
+
+   &error := -1
+   p := Bitman()
+   failures := p.test()
+$ifdef _LARGE_INTEGERS
+   # This is a large integer on 32-bit and 64-bit systems
+   L := 16RFF1234567812345678
+
+   # Check that large integers fail
+   if large(L) then {
+      if \(p.bor(L,1)) then Fail(UFL || " (bor)")
+      if \(p.bor(1,L)) then Fail(UFL || " (bor)")
+      if \(p.bor(L,L)) then Fail(UFL || " (bor)")
+
+      if \(p.bxor(L,1)) then Fail(UFL || " (bxor)")
+      if \(p.bxor(1,L)) then Fail(UFL || " (bxor)")
+      if \(p.bxor(L,L)) then Fail(UFL || " (bxor)")
+
+      if \(p.band(L,1)) then Fail(UFL || " (band)")
+      if \(p.band(1,L)) then Fail(UFL || " (band)")
+      if \(p.band(L,L)) then Fail(UFL || " (band)")
+
+      if \(p.bcom(L)) then Fail(UFL || " (bcom)")
+
+      if \(p.bshift(L,1)) then Fail(UFL || " (bshift)")
+      if \(p.bshift(1,L)) then Fail(UFL || " (bshift)")
+
+      if \(p.bit(L,1)) then Fail(UFL || " (bit)")
+      if \(p.bit(1,L)) then Fail(UFL || " (bit)")
+
+      if \(p.bits(L,1,2)) then Fail(UFL || " (bits)")
+      if \(p.bits(1,L,2)) then Fail(UFL || " (bits)")
+      if \(p.bits(1,2,L)) then Fail(UFL || " (bits)")
+
+      if \(p.brot(L,1)) then Fail(UFL || " (brot)")
+      if \(p.brot(1,L)) then Fail(UFL || " (brot)")
+   } else {
+      Fail(UFL || " Neither 32-bit nor 64-bit machine")
+   }
+$endif
+
+   if *failures = 0 then {
+      write("Passed")
+   } else {
+      write(*failures, " failure", if *failures > 1 then "s" else "")
+      every write(!failures)
+   }
+
+end


### PR DESCRIPTION
The routines are the equivalent of the Unicon built-in functions
except they never produce a large integer and there is no special
case for the sign bit.
   bor      bitwise inclusive or       (ior)
   bxor     bitwise exclusive or       (ixor)
   band     bitwise and                (iand)
   bcom     bitwise one's complement   (icom)
   bshift   bitwise shift              (ishift)
plus
   bits     enquiry and bit extraction
   bit      single bit extraction
   brot     bit rotation

bit(x,n) works the same way as string indexing (but indexing bits instead
of characters, including negative indices meaning "from the end").
  bit(x,1) is the ls bit of x,      (analogous to s[1]).
  bit(x,n) is the nth bit of x      (analogous to s[n] when n is +ve).
  bit(x,0) is the ms bit of x       (analogous to s[0]).
  bit(x,-n) is analogous to s[-n] i.e indexes from the ms end of x.

bits(x,n,m) works the same way as substring indexing s[n:m].
Note that, as with substrings, the bits are not reversed if m < n.
   bits(x,n,m) = bits(x,m,n)

The routines are not portable by design (i.e. on machines with different
word lengths they may give different results), which is the entire point.