### PR TITLE
Fix Fedora CI build failure.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
               ;;
            fedora*)
               dnf -y update
-              dnf -y install gcc make
+              dnf -y install gcc make diffutils
               ;;
            centos*)
               yum update -y


### PR DESCRIPTION
The build failed because the diff program was missing from the Fedora
container used to perform the build (patch supplied by Jafar).