### PR TITLE
ci: install more dependencies for Fedora and CentOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,11 +80,13 @@ jobs:
               ;;
            fedora*)
               dnf -y update
-              dnf -y install gcc make diffutils
+              dnf -y install gcc make diffutils libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel
+              dnf -y install openal-devel freealut-devel libogg-devel libvorbis-devel openssl-devel unixODBC-devel freetype-devel libXft-devel
               ;;
            centos*)
               yum update -y
-              yum install -y gcc make
+              yum install -y gcc make libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel libXft-devel
+              yum install -y openal-devel freealut-devel libogg-devel libvorbis-devel openssl-devel unixODBC-devel freetype-devel
               ;;
            alpine*)
               apk update


### PR DESCRIPTION
Instaling more dependencies enables more features in the build
allowing for better test coverage

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>