### PR TITLE
Make auto.h inclusion idempotent.

### DIFF
--- a/src/h/auto.in
+++ b/src/h/auto.in
@@ -1,4 +1,6 @@
 /* src/h/auto.in.  Generated from configure.ac by autoheader.  */
+#ifndef __AUTO_H
+#define __AUTO_H
 
 /* Define if building universal (internal helper macro) */
 #undef AC_APPLE_UNIVERSAL_BUILD
@@ -563,3 +565,5 @@
 
 /* Define as `fork' if `vfork' does not work. */
 #undef vfork
+
+#endif                     /* __AUTO_H */


### PR DESCRIPTION
Custom configuration decisions are usually made via src/h/define.h
But, if the customisation is dependent on the detected configuration,
then access is required to the definitions in auto.h. Unfortunately,
auto.h is normally included __after__ define.h. Making the inclusion
idempotetent means that define.h may include auto.h if it is required.

This also allows define.h to override the automatic configuration if
it is necessary to do so in some circumstances.