### PR TITLE
runtime: default to AF_UNSPEC if no specific IP protocol is selected

### DIFF
--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -735,8 +735,10 @@ Deliberate Syntax Error
 		    af_fam = AF_UNSPEC;
 		  else if (is_ipv6)
 		    af_fam = AF_INET6;
-		  else
+		  else if (is_ipv4)
 		    af_fam = AF_INET;
+		  else
+		    af_fam = AF_UNSPEC;
 
 		  /* Try to parse the filename as a URL and set the protocol family */
 		  puri = uri_parse(fnamestr, af_fam);
@@ -945,8 +947,10 @@ Deliberate Syntax Error
 	       af_fam = AF_UNSPEC;
 	    else if (is_ipv6)
 	       af_fam = AF_INET6;
-	    else
+	    else  if (is_ipv4)
 	       af_fam = AF_INET;
+	    else
+	       af_fam = AF_UNSPEC;
 
 	    /* The only allowed values for flags are "n" and "na" */
 	    if (status & ~(Fs_Read|Fs_Write|Fs_Socket|Fs_Append|Fs_Unbuf|Fs_Listen))

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1235,6 +1235,19 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
    return s;
 }
 
+
+int
+ip_version(const char *src) {
+    char buf[16];
+    if (inet_pton(AF_INET, src, buf)) {
+        return 4;
+    } else if (inet_pton(AF_INET6, src, buf)) {
+        return 6;
+    }
+    return -1;
+}
+
+
 /*
  * Although this function is named "listen", it opens all incoming sockets,
  * including UDP sockets and non-blocking "listener" sockets on which a


### PR DESCRIPTION
Setting the default IP address family to  AF_UNSPEC allows an application to work with both 
ipv4 and ipv6. The user can still specify 4 or 6 when opening a socket to force a specific 
address family.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>