### PR TITLE
Fix listener sockets

### DIFF
--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -971,7 +971,7 @@ Deliberate Syntax Error
 #endif					/* Graphics || Messaging || ISQL */
 	       /* connect to a port */
       	       DEC_NARTHREADS;
-	       fd = sock_connect(fnamestr, is_udp_or_listener, timeout, af_fam);
+	       fd = sock_connect(fnamestr, is_udp_or_listener == 1, timeout, af_fam);
       	       INC_NARTHREADS_CONTROLLED;
 	    }
 	    /*

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1270,7 +1270,7 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
 
       if ((p=strrchr(addr, ':')) != NULL) {
 	 *p = 0;
-	 res0 = uni_getaddrinfo(addr, p+1, is_udp_or_listener, af_fam);
+	 res0 = uni_getaddrinfo(addr, p+1, is_udp_or_listener == 1, af_fam);
 	 *p = ':';
 
 	 if (!res0)
@@ -1330,13 +1330,14 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
 	 }
       }
 
-      if (is_udp_or_listener)
-	return s;
-
-      if (listen(s, SOMAXCONN) < 0)
-	return 0;
+      if (is_udp_or_listener == 2)
+	if (listen(s, SOMAXCONN) < 0)
+	  return 0;
       /* Save s for future calls to listen */
       sock_put(addr, s);
+
+      if (is_udp_or_listener)
+	return s;
    }
     
    {

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1258,6 +1258,9 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
    int fd, s, len;
    struct addrinfo *res0, *res;
    struct sockaddr *sa;
+   unsigned int fromlen;
+   struct sockaddr_storage from;
+
 
    if ((s = sock_get(addr)) < 0) {
      char *p;
@@ -1329,24 +1332,20 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
 	   return 0;
 	 }
       }
-
-      if (is_udp_or_listener == 2)
-	if (listen(s, SOMAXCONN) < 0)
-	  return 0;
-      /* Save s for future calls to listen */
-      sock_put(addr, s);
-
-      if (is_udp_or_listener)
-	return s;
    }
     
-   {
-     unsigned int fromlen;
-     struct sockaddr_storage from;
-     fromlen = sizeof(from);
-     if ((fd = accept(s, (struct sockaddr*) &from, &fromlen)) < 0)
+   if (is_udp_or_listener == 2)
+     if (listen(s, SOMAXCONN) < 0)
        return 0;
-   }
+   /* Save s for future calls to listen */
+   sock_put(addr, s);
+
+   if (is_udp_or_listener)
+     return s;
+
+   fromlen = sizeof(from);
+   if ((fd = accept(s, (struct sockaddr*) &from, &fromlen)) < 0)
+     return 0;
 
    return fd;
 }


### PR DESCRIPTION
When IPv6 support was added I was passing `is_udp_or_listener` to mean udp. It is only upd 
 if `is_udp_or_listener == 1`

I tested a tcp server with listener socket and it works now.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>