### PR TITLE
Fix socket accept mode

### DIFF
--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1333,8 +1333,8 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
 	 }
       }
    }
-    
-   if (is_udp_or_listener == 2)
+   /* No need to listen on UDP sockets */
+   if (is_udp_or_listener != 1)
      if (listen(s, SOMAXCONN) < 0)
        return 0;
    /* Save s for future calls to listen */


### PR DESCRIPTION
When calling open() n mode "na", we ask for a TCP socket but without
going through an explicit listen(). In that mode, the call to open()
should be blocking, unlick a listener "nl"  mode. In "na" case we
still want to call listen() first, then invoke acceptto block.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>