### PR TITLE
remove defs of sys functions before we do 'include'

### DIFF
--- a/src/h/sys.h
+++ b/src/h/sys.h
@@ -4,6 +4,9 @@
 
 #ifdef ConsoleWindow
 #undef putc
+#undef printf
+#undef fprintf
+#undef fflush
 #endif					/* ConsoleWindow */
 
 /*


### PR DESCRIPTION
Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>