### PR TITLE
Fix documentation for ishift.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2537,10 +2537,10 @@ to an integer, or fails if the conversion cannot be performed.
 
 \noindent
 \index{shift}\texttt{ishift(i, j)} produces the value obtained by
-shifting \texttt{i} by \texttt{j} bit positions. Shifting is to the
-left if \texttt{j{\textgreater}0}, or to the right if
-\texttt{j{\textless}0}. \texttt{j} zero bits are introduced at the
-end opposite the shift direction.
+shifting \texttt{i} by \texttt{j} bit positions.
+If \texttt{j} is positive, the shift is to the left, and vacated bit
+positions are filled with zeros.
+If \texttt{j} is negative, the shift is to the right with sign extension. 
 
 \bigskip\hrule\vspace{0.1cm}
 \index{istate}


### PR DESCRIPTION
The current description for ishift is inaccurate (claiming that zeros
are introduced on both shift directions). Replace it with icon's description,
which also includes sign extension for negative shifts.