### PR TITLE
Add Appendix G to the Unicon Book

### DIFF
--- a/doc/book/diffs.tex
+++ b/doc/book/diffs.tex
@@ -1,5 +1,6 @@
 \chapter{Differences between Icon and Unicon}
 
+\label{Unicon-Icon}
 This appendix summarizes the known differences between Arizona Icon and
 Unicon. Since the language has myriad additions covered by the whole book,
 the emphasis of this page is on {\em incompatibilities\/} that might

--- a/doc/book/experimental.tex
+++ b/doc/book/experimental.tex
@@ -1,0 +1,48 @@
+\chapter{Experimental Features}
+
+The designers of Unicon have taken a very conservative approach when adding to
+the language and when changing existing features. With the small number of
+exceptions that have been previously noted on page \pageref{Unicon-Icon}, an
+Icon program that runs on the final version of Icon (version 9.5, first released
+in 1996) will run on the current Unicon system {\em and give the same results\/}
+a quarter of a century later. The conservative approach is continued when
+dealing with additions to Unicon; breaking existing Unicon programs by making an
+incompatible change to the language is, in most circumstances, considered to be
+a very bad thing to do.
+
+Most of the development of Unicon starting from it's progenitor has already been
+discussed but there are some more experimental features that are waiting in the
+wings. Some of them may never see the light of day in their present form -- or,
+perhaps, in any form -- so the most cautious approach is not to rely on any of
+them until they make their way from this appendix into the definition of the
+language in Appendix A.
+
+Without exception, the experimental features are not enabled by default in a
+release build of Unicon -- they can only be accessed by making the appropriate
+pre-processor definitions (or, in some cases, by specifying additional arguments
+to \texttt{configure}) and rebuilding the system from the source code. Some
+features that are now part of the language -- for example, the array extension
+to lists that makes them faster in many cases -- are still guarded by
+pre-processor definitions, showing their pedigree as experimental additions, but
+are now enabled by default.
+
+%% Candidates for inclusion
+%%
+%% Plugins
+%% User defined operators
+%% UTF-8
+%% Extensions to &random
+
+\section{User defined operators}
+This feature extends the syntax of classes to allow the built-in operator
+symbols to be redefined when their operands are objects. It may be enabled by
+using the \texttt{-{}-enable-ovld} option to \texttt{configure} before
+rebuilding the Unicon system.
+
+\section{Extensions to \texttt{\&random}}
+This feature allows the programmer to choose from a portfolio of different
+random number generators (in addition to the one provided by Icon). It is also
+possible to implement other generators and use them without rebuilding Unicon.
+More than one generator may be in use at the same time.
+It may be enabled by defining the C preprocessor symbol \texttt{RngLibrary}
+before rebuilding the Unicon system.

--- a/doc/book/ub.tex
+++ b/doc/book/ub.tex
@@ -204,7 +204,7 @@ This document was prepared using \LaTeX.
 \include{port}
 \include{install}
 % \include{resourc}
-
+\include{experimental}
 \backmatter
 
 \include{referenc}


### PR DESCRIPTION
Appendix G contains a summary of the experimental features of Unicon
that are not (and perhaps never will be) part of the standard build.