### PR TITLE
Build SHA and bitman plugins by default. Allow plugin specific clean up.

### DIFF
--- a/plugins/src/Makedefs
+++ b/plugins/src/Makedefs
@@ -42,7 +42,7 @@ $(LIBD)/%.u: %.icn  $(TLIB)
 zip:
 	 zip $(LNAME).zip Makefile *.icn *.c *.h
 
-clean:
+clean::
 	$(RM) *.u *.o *.$(SO)  uniclass.* *~
 	$(RM) $(LIBD)/$(LNAME).u  $(LIBD)/$(LNAME).$(SO)
 

--- a/plugins/src/Makefile
+++ b/plugins/src/Makefile
@@ -16,7 +16,7 @@ UFLAGS=-s -u -c
 CFDYN2= $(CFDYN)
 
 # plaform independent  plugins
-PCMN=upexample SHA bitman
+PCMN=upexample bitman
 
 # Windows 
 PWIN=

--- a/plugins/src/Makefile
+++ b/plugins/src/Makefile
@@ -16,7 +16,7 @@ UFLAGS=-s -u -c
 CFDYN2= $(CFDYN)
 
 # plaform independent  plugins
-PCMN=upexample
+PCMN=upexample SHA bitman
 
 # Windows 
 PWIN=
@@ -73,3 +73,6 @@ clean:
 	echo $(SO)
 	$(RM) *.u *.o *.$(SO) uniclass.* *~
 	$(RM) ../lib/* */*.u */*.o */*.$(SO) */uniclass.*
+	for p in $(PCMN) $(PWIN) $(PNIX) $(PMOS); do \
+		$(MAKE) -C $$p $@; \
+	done

--- a/plugins/src/SHA/Makefile
+++ b/plugins/src/SHA/Makefile
@@ -17,7 +17,7 @@ RFCDIR = ./RFC6234
 RFC6234Files = $(RFCDIR)/sha1.o $(RFCDIR)/sha224-256.o ./$(RFCDIR)/sha384-512.o \
 			./$(RFCDIR)/usha.o ./$(RFCDIR)/hkdf.o ./$(RFCDIR)/hmac.o
 
-# @Replace: add any additionl (non-standard name) c source file(s) here
+# @Replace: add any additional (non-standard name) c source file(s) here
 COBJ = $(LNAME).o $(RFC6234Files)
 CSRC = $(LNAME).c
 
@@ -38,9 +38,10 @@ $(RFC6234Files):
 	cd $(RFCDIR); $(MAKE)
 
 shaPlugTest: shaPlugTest.icn
-	unicon -s $< -o $@
+	$(TOPDIR)/bin/unicon -s $< -o $@
 
-Clean: clean
+# @Replace: To add plugin specific clean up actions, include a clean:: target
+clean::
 	$(RM) shaPlugTest
 	cd $(RFCDIR); $(MAKE) $@
 

--- a/plugins/src/SHA/RFC6234/makefile
+++ b/plugins/src/SHA/RFC6234/makefile
@@ -4,7 +4,7 @@ All:	shatest
 
 shatest:	shatest.o sha1.o sha224-256.o sha384-512.o usha.o hkdf.o hmac.o
 
-Clean:
+clean::
 	rm -f shatest *.o 
 
 

--- a/plugins/src/bitman/Makefile
+++ b/plugins/src/bitman/Makefile
@@ -13,11 +13,11 @@
 # @Replace: What is the name of this library?
 LNAME=bitman
 
-# @Replace: add any additionl (non-standard name) c source file(s) here
+# @Replace: add any additional (non-standard name) c source file(s) here
 COBJ = $(LNAME).o 
 CSRC = $(LNAME).c
 
-# @Replace: If additinal libraries need to be linked in append them here:
+# @Replace: If additional libraries need to be linked in append them here:
 MYLIBS=$(LIBS)
 
 # Relative to top level
@@ -29,3 +29,5 @@ TDIR=../..
 include ../Makedefs
 
 default:	 $(LIBD)/$(LNAME).u
+
+# @Replace: To add plugin specific clean up actions, include a clean:: target

--- a/plugins/src/lxcunicon/Makefile
+++ b/plugins/src/lxcunicon/Makefile
@@ -6,13 +6,15 @@
 # @Replace: What is the name of this library?
 LNAME=lxcunicon
 
-# @Replace: add any additionl (non-standard name) c source files here
+# @Replace: add any additional (non-standard name) c source files here
 COBJ = $(LNAME).o 
 CSRC = $(LNAME).c
 
-# @Replace: If additinal libraries need to be linked in append them here:
+# @Replace: If additional libraries need to be linked in append them here:
 MYLIBS=$(LIBS) -llxc
 
+# Relative to top level
+TOPDIR=../../..
 # 
 BASE=../../..
 
@@ -23,3 +25,4 @@ include ../Makedefs
 
 default:	 $(LIBD)/$(LNAME).u
 
+# @Replace: To add plugin specific clean up actions, include a clean:: target

--- a/plugins/src/template/Makefile
+++ b/plugins/src/template/Makefile
@@ -6,15 +6,15 @@
 # @Replace: What is the name of this library?
 LNAME=template
 
-# @Replace: add any additionl (non-standard name) c source file(s) here
+# @Replace: add any additional (non-standard name) c source file(s) here
 COBJ = $(LNAME).o 
 CSRC = $(LNAME).c
 
-# @Replace: If additinal libraries need to be linked in append them here:
+# @Replace: If additional libraries need to be linked in append them here:
 MYLIBS=$(LIBS)
 
 # Relative to top level
-BASE=../../..
+TOPDIR=../../..
 
 # lib relative to top
 TDIR=../..
@@ -23,4 +23,8 @@ include ../Makedefs
 
 default:	$(LIBD)/$(LNAME).u
 
-
+# @Replace: To add plugin specific clean up actions, include a clean:: target
+# n.b. clean:: not clean:
+# For example
+#clean::
+#	$(RM) $(LNAME).test-results

--- a/plugins/src/upexample/Makefile
+++ b/plugins/src/upexample/Makefile
@@ -25,5 +25,4 @@ include ../Makedefs
 
 default:	 $(LIBD)/$(LNAME).u
 
-Clean: clean
-# @Replace: Add plugin specific clean up actions here.
+# @Replace: To add plugin specific clean up actions, include a clean:: target


### PR DESCRIPTION
SHA and bitman are now built by default.
Typos have been corrected.
Plugin specific clean up is now done via a clean:: target (the example
files have been corrected).