### PR TITLE
Fix typo in Appendix G of Unicon Book.

### DIFF
--- a/doc/book/experimental.tex
+++ b/doc/book/experimental.tex
@@ -10,7 +10,7 @@ dealing with additions to Unicon; breaking existing Unicon programs by making an
 incompatible change to the language is, in most circumstances, considered to be
 a very bad thing to do.
 
-Most of the development of Unicon starting from it's progenitor has already been
+Most of the development of Unicon starting from its progenitor has already been
 discussed but there are some more experimental features that are waiting in the
 wings. Some of them may never see the light of day in their present form -- or,
 perhaps, in any form -- so the most cautious approach is not to rely on any of


### PR DESCRIPTION
Everyone's favorite:  it's --> its