### PR TITLE
Fix key and data display of testgdbm and testndbm.

### DIFF
--- a/src/gdbm/testgdbm.c
+++ b/src/gdbm/testgdbm.c
@@ -317,9 +317,9 @@ main (argc, argv)
 	  if (return_data.dptr != NULL)
 	    {
 	      key_data = return_data;
-	      printf ("key is  ->%s\n", key_data.dptr);
+	      printf ("key is  ->%.*s\n", key_data.dsize, key_data.dptr);
 	      return_data = gdbm_fetch (gdbm_file, key_data);
-	      printf ("data is ->%s\n\n", return_data.dptr);
+	      printf ("data is ->%.*s\n\n", return_data.dsize, return_data.dptr);
 	      free (return_data.dptr);
 	    }
 	  else
@@ -353,9 +353,9 @@ main (argc, argv)
 	  key_data = gdbm_firstkey (gdbm_file);
 	  if (key_data.dptr != NULL)
 	    {
-	      printf ("key is  ->%s\n", key_data.dptr);
+	      printf ("key is  ->%.*s\n", key_data.dsize, key_data.dptr);
 	      return_data = gdbm_fetch (gdbm_file, key_data);
-	      printf ("data is ->%s\n\n", return_data.dptr);
+	      printf ("data is ->%.*s\n\n", return_data.dsize, return_data.dptr);
 	      free (return_data.dptr);
 	    }
 	  else
@@ -368,9 +368,9 @@ main (argc, argv)
 	    {
 	      free (key_data.dptr);
 	      key_data = return_data;
-	      printf ("key is  ->%s\n", key_data.dptr);
+	      printf ("key is  ->%.*s\n", key_data.dsize, key_data.dptr);
 	      return_data = gdbm_fetch (gdbm_file, key_data);
-	      printf ("data is ->%s\n\n", return_data.dptr);
+	      printf ("data is ->%.*s\n\n", return_data.dsize, return_data.dptr);
 	      free (return_data.dptr);
 	    }
 	  else

--- a/src/gdbm/testndbm.c
+++ b/src/gdbm/testndbm.c
@@ -155,8 +155,8 @@ main (argc, argv)
 	  if (key_data.dptr != NULL)
 	    {
 	      return_data = dbm_fetch (dbm_file, key_data);
-	      printf ("key is ->%s\n", key_data.dptr);
-	      printf ("data is ->%s\n\n", return_data.dptr);
+	      printf ("key is ->%.*s\n", key_data.dsize, key_data.dptr);
+	      printf ("data is ->%.*s\n\n", return_data.dsize, return_data.dptr);
 	    }
 	  else
 	    printf ("No such item found.\n\n");
@@ -168,8 +168,8 @@ main (argc, argv)
 	  if (key_data.dptr != NULL)
 	    {
 	      return_data = dbm_fetch (dbm_file, key_data);
-	      printf ("key is ->%s\n", key_data.dptr);
-	      printf ("data is ->%s\n\n", return_data.dptr);
+	      printf ("key is ->%.*s\n", key_data.dsize, key_data.dptr);
+	      printf ("data is ->%.*s\n\n", return_data.dsize, return_data.dptr);
 	    }
 	  else
 	    printf ("No such item found.\n\n");


### PR DESCRIPTION
Some (perhaps most?) key and data pairs in uniclass.dir are not null
terminated (there is a dsize field, which is correct, but testgdbm and
testndbm didn't use it) resulting in extra garbage characters being
displayed after the key and data. The fix is to use a precision spec
in the printf format strings.