### PR TITLE
Add a short description of testndbm and testgdbm to the IB.

### DIFF
--- a/doc/ib/p3-unicon.tex
+++ b/doc/ib/p3-unicon.tex
@@ -1923,6 +1923,19 @@ resolve}
 {\ttfamily\mdseries
 end}
 
+\goodbreak
+The database routines used by Unicon are {\em ancient}.
+The version string is
+\begin{quote}
+{\ttfamily\mdseries This is GDBM version 1.7.3, as of May 19,1994.}
+\end{quote}
+and modern GDBM tools cannot be used to display the contents of
+uniclass.dir (they complain of a ``Malformed database file header'').
+However, in the src/gdbm directory, there are two utilities that will
+display the contents of uniclass.dir: testgdbm and testndbm. They are
+not built by default but, if needed, can be built using the Makefile
+in src/gdbm.
+
 \subsection{Unicon's Progend() revisited}
 
 Having presented scope resolution, inheritance, and importing packages


### PR DESCRIPTION
Modern gdbm tools don't work on uniclass.dir. Add a paragraph noting
the existence of testndbm and testgdbm.