### PR TITLE
Improve treatment of no output from a piped command.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2882,7 +2882,11 @@ untranslated mode\\
 
 Directories may only be opened for reading, and produce the names of all
 files, one per line. Pipes may be opened for reading or writing, but
-not both.
+not both. \texttt{open()} fails if the pipe is open for reading and
+the command line given by \texttt{s1} produces no output:
+\texttt{\&errornumber} may be used to distinguish between a successful
+command that produces no output and a command that returns a non zero
+(unsucessful) exit code.
 
 When opening a network socket: the first argument \texttt{s1} is the
 name of the socket to connect. If \texttt{s1} is of the form
@@ -4849,7 +4853,7 @@ platform dependent.
 124 \ \ \ \ \ \ \ table expected\\
 125 \ \ \ \ \ \ \ list, record, or set expected\\
 126 \ \ \ \ \ \ \ list or record expected\\
-127 \ \ \ \ \ \ \ invalid type to pattern operation\\
+127 \ \ \ \ \ \ \ pattern expected\\
 128 \ \ \ \ \ \ \ unevaluated variable or function call expected\\
 129 \ \ \ \ \ \ \ unable to convert unevaluated variable to pattern\\
 130 \ \ \ \ \ \ \ incorrect number of arguments\\
@@ -4863,6 +4867,7 @@ platform dependent.
 146 \ \ \ \ \ \ \ incorrect number of arguments to drawing
 function\\
 147 \ \ \ \ \ \ \ window attribute cannot be read or written as requested\\
+148 \ \ \ \ \ \ \ graphics is not enabled in this virtual machine\\
 150 \ \ \ \ \ \ \ drawing a 3D object while in 2D mode\\
 151 \ \ \ \ \ \ \ pushed/popped too many matrices\\
 152 \ \ \ \ \ \ \ modelview or projection expected\\
@@ -4876,6 +4881,7 @@ function\\
 unevaluated expression\\
 164 \ \ \ \ \ \ \ unsupported unevaluated expression\\
 165 \ \ \ \ \ \ \ null pattern argument where name was expected\\
+166 \ \ \ \ \ \ \ unable to produce pattern image, possible malformed pattern\\
 %%----------------------------------------
 %% These codes are not in unicon/src/runtime/data.r or are different
 %% 160 \ \ \ \ \ \ \ cannot open file\\
@@ -4900,7 +4906,7 @@ unevaluated expression\\
 171 \ \ \ \ \ \ \ UDP socket expected\\
 172 \ \ \ \ \ \ \ signal handler procedure must take one argument\\
 173 \ \ \ \ \ \ \ cannot open directory for writing\\
-174 \ \ \ \ \ \ \ invalid file operation on directory or database\\
+174 \ \ \ \ \ \ \ invalid file operation\\
 175 \ \ \ \ \ \ \ network connection expected\\
 180 \ \ \ \ \ \ \ invalid mutex\\
 181 \ \ \ \ \ \ \ invalid condition variable\\
@@ -4913,6 +4919,7 @@ the same time\\
 is not yet supported\\
 %%----------------------------------------
 190 \ \ \ \ \ \ \ dbm database expected\\
+191 \ \ \ \ \ \ \ cannot open dbm database\\
 201 \ \ \ \ \ \ \ division by zero\\
 202 \ \ \ \ \ \ \ remaindering by zero\\
 203 \ \ \ \ \ \ \ integer overflow\\
@@ -4931,6 +4938,7 @@ length\\
 215 \ \ \ \ \ \ \ attempt to refresh \&main\\
 216 \ \ \ \ \ \ \ external function not found\\
 217 \ \ \ \ \ \ \ unsafe inter-program variable assignment\\
+218 \ \ \ \ \ \ \ invalid file name\\
 301 \ \ \ \ \ \ \ evaluation stack overflow\\
 302 \ \ \ \ \ \ \ memory violation\\
 303 \ \ \ \ \ \ \ inadequate space for evaluation stack\\
@@ -4955,6 +4963,11 @@ length\\
 1046 \ \ \ \ \ \ \ invalid permission string for umask\\
 1047 \ \ \ \ \ \ \ invalid protocol name\\
 1048 \ \ \ \ \ \ \ low-level read or select mixed with buffered read\\
+1049 \ \ \ \ \ \ \ nonexistent service or services database error\\
+1050 \ \ \ \ \ \ \ command not found\\
+1051 \ \ \ \ \ \ \ cannot create temporary file\\
+1052 \ \ \ \ \ \ \ cannot create pipe\\
+1053 \ \ \ \ \ \ \ empty pipe\\
 1100 \ \ \ \ \ \ \ ODBC connection expected\\
 1200 \ \ \ \ \ \ \ system error (see \&errno)\\
 1201 \ \ \ \ \ \ \ malformed URL\\

--- a/src/runtime/data.r
+++ b/src/runtime/data.r
@@ -410,6 +410,8 @@ struct errtab errtab[] = {
 
    1050, "command not found",
    1051, "cannot create temporary file",
+   1052, "cannot create pipe",
+   1053, "empty pipe",
 
 #ifdef ISQL
    1100, "ODBC connection expected",

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -896,13 +896,13 @@ Deliberate Syntax Error
 	    }
 
 	 f = popen(fnamestr, mode);
+         if (NULL == f) {set_errortext(1052); fail;}
 	 if (!strcmp(mode,"r")) {
-	    /* try and read a byte. if we can't treat it as a "bad command" */
+	    /* Try to read a byte. If we can't, treat it as "empty pipe" or "bad command" */
 	    if ((c = getc(f)) == EOF) {
-	       pclose(f);
-	       set_errortext(1050);
-	       fail;
-	       }
+              if (0 == pclose(f)) {set_errortext(1053);} else {set_errortext(1050);}
+              fail;
+            }
 	    else
 	       ungetc(c, f);
 	    }


### PR DESCRIPTION
Handle failure of popen(). Distinguish between a successful command that
produces no output and a non-zero return status from the command.
Document new (and not so new) error numbers in Appendix A.