### PR TITLE
Link to New Sublime Unicon Package

### DIFF
--- a/config/editor/README
+++ b/config/editor/README
@@ -33,8 +33,21 @@ the end of the "Advanced Features" section of the manual.  Use C-h i
 to access the manual.
 
 
-Sublime Text
-------------
+Sublime Text 4
+--------------
+
+https://packagecontrol.io/packages/Unicon
+
+To install the "Unicon" package via Sublime Text native package manager:
+
+1. Open the Command Palette by pressing CTRL+SHIFT+P (Win, Linux)
+   or CMD+SHIFT+P (Mac).
+2. In the Command Palette type "Package Control: Install Package"
+3. When the packages list shows up, type "Unicon".
+
+
+Sublime Text 3
+--------------
 
 To get syntax highlighting in Sublime Text copy unicon.sublime-syntax to
 ~/.config/sublime-text-3/Packages/User/


### PR DESCRIPTION
Edit `config/editor/REAMDE` to mention the new Unicon package for Sublime Text 4:

- Rename existing "Sublime Text" section to "Sublime Text 3".
- Add new "Sublime Text 4" section with a link to the the   package page and installation instructions.