### PR TITLE
Fix utr20.

### DIFF
--- a/doc/utr/utr20.tex
+++ b/doc/utr/utr20.tex
@@ -44,7 +44,7 @@ non-operator JSON token.
  possible first characters  & JSON token \\
  \hline
  \{                         & object \\
- \verb [                    & array \\
+ \verb"["                   & array \\
  -0123456789                & number \\
  $\prime\prime$             & string \\
  t                          & true \\


### PR DESCRIPTION
On some platforms (Debian Bullseye with TeX-live 2022) an error is generated on line 47 "! LaTeX Error: \verb ended by end of line." Others -- MacOS 12 with TeXShop (TeX-Live 2020) -- work without error.