### PR TITLE
Fix Tab overflow and TikZ missing character messages.

### DIFF
--- a/doc/ib/p2-codeGen.tex
+++ b/doc/ib/p2-codeGen.tex
@@ -729,7 +729,7 @@ variable 0, but not the allocation of variable 1. Therefore, variable
     level distance=2cm, sibling distance=3cm
 ]
   \tmpTree{4,9}
-  \stBox{3,1}{4}{5}{F}{F};
+  \stBox{3,1}{4}{5}{F}{F}
   % annotate the nodes
   \TR{f1}{\{0:\F, 1:\F\}};
 
@@ -752,7 +752,7 @@ variable 0, but not the allocation of variable 1. Therefore, variable
     level distance=2cm, sibling distance=3cm
 ]
   \tmpTree{4,9}
-  \stBox{3,1}{4}{3}{F}{F};
+  \stBox{3,1}{4}{3}{F}{F}
   
   % annotate the nodes
   \TR{f1}{\{0:\F, 1:\F\}};
@@ -787,7 +787,7 @@ used in this allocation. This is illustrated in the tree:
     level distance=2cm, sibling distance=3cm
 ]
   \tmpTree{4,9}
-  \stBox{3,1}{4}{3}{1}{2};
+  \stBox{3,1}{4}{3}{1}{2}
 
   % annotate the nodes
   \TR{f1}{\{0:\F, 1:\F, 2:\F\}};
@@ -829,36 +829,36 @@ in node-number order.
   \node(x)[rbx] at (1,7) {\tmpLabel{x}{1}};
   \TR{x}{\{~\}};
   \BR{x}{2};
-  \stBox{0,5}{4}{3}{I}{2};
+  \stBox{0,5}{4}{3}{I}{2}
   \draw[-Latex] ($ (x.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
   \node(f4)[rbx] at (6,7) {\tmpLabel{f4()}{2}};
   \TR{f4}{\{~\}};
   \BR{f4}{3};
-  \stBox{5,5}{4}{3}{I}{I};
+  \stBox{5,5}{4}{3}{I}{I}
   \draw[-Latex] ($ (f4.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
   \node(f3)[rbx] at (11,7) {\tmpLabel{f3()}{3}};
   \TR{f3}{\{3:\F\}};
   \BR{f3}{1};
-  \stBox{10,5}{4}{I}{I}{F};
+  \stBox{10,5}{4}{I}{I}{F}
   \draw[-Latex] ($ (f3.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
   \node(f2)[rbx] at (1,3) {\tmpLabel{f2}{4}};
   \TR{f2}{\{1:5\}};
   \BR{f2}{0};
-  \stBox{0,1}{I}{5}{I}{F};
+  \stBox{0,1}{I}{5}{I}{F}
   \draw[-Latex] ($ (f2.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
   \node(y)[rbx] at (6,3) {\tmpLabel{y}{5}};
   \TR{y}{\{~\}};
   \BR{y}{1};
-  \stBox{5,1}{I}{I}{I}{F};
+  \stBox{5,1}{I}{I}{I}{F}
   \draw[-Latex] ($ (y.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
   \node(f1)[rbx] at (11,3) {\tmpLabel{f1()}{6}};
   \TR{f1}{\{0:\F, 1:\F, 2:\F\}};
-  \stBox{10,1}{F}{F}{F}{F};
+  \stBox{10,1}{F}{F}{F}{F}
   \draw[-Latex] ($ (f1.south west) - (0.3, -0.2)$) -- ++(0,0.8);
 
 \end{tikzpicture}
@@ -870,7 +870,7 @@ status after the deallocation associated with node \textit{4},
 
 \begin{center}
 \begin{tikzpicture}[draw,very thick,font=\small\tt]
-  \stBox{0,1}{I}{5}{I}{F};
+  \stBox{0,1}{I}{5}{I}{F}
 \end{tikzpicture}
 \end{center}
 

--- a/doc/ib/p2-iconcOrg.tex
+++ b/doc/ib/p2-iconcOrg.tex
@@ -45,7 +45,7 @@ to be a local variable.
 \begin{tikzpicture}[draw,very thick,font=\small\tt,>=Latex,arrows=->,
     box/.style={rectangle, minimum width=4cm, thick, minimum height=0.9cm,draw},
     elps/.style={ellipse,ellipse,draw,minimum width=2cm},
-]`
+]
 %  \draw[help lines] (0,0) grid (15,15);
 
 % column headers
@@ -55,7 +55,7 @@ to be a local variable.
   \foreach \x in {3.75, 10.25} {
     \draw[-,dashed, dash pattern=on 0.3cm off 0.3cm, line width=1.4pt]
         (\x,15) -- (\x, -0.5);
-  };
+  }
   
 % draw the boxes and ellipses
   \node(rtdb)[elps] at (1,14)      {rt.db};
@@ -215,7 +215,7 @@ The physical organization of this phase is shown in the following diagram.
 \begin{tikzpicture}[draw,very thick,font=\small\tt,>=Latex,arrows=->,
     box/.style={rectangle, minimum width=4cm, thick, minimum height=1.4cm,draw},
     elps/.style={ellipse,ellipse,draw,minimum width=2cm},
-]`
+]
 %  \draw[help lines] (0,2) grid (15,13);
 
 % column headers
@@ -224,7 +224,7 @@ The physical organization of this phase is shown in the following diagram.
   \foreach \x in {3.5, 10.5} {
     \draw[-,dashed, dash pattern=on 0.3cm off 0.3cm, line width=1.4pt]
         (\x,13) -- (\x, 2);
-  };
+  }
   
 % draw the boxes and ellipses
   \node(symt) at (13.5,11) [elps, align=center]

--- a/doc/ib/p2-liveness.tex
+++ b/doc/ib/p2-liveness.tex
@@ -305,12 +305,12 @@ tree for the example above is:
 % Paint round rectangles
 \node[rr, minimum width=9cm] at ($(v7.west) - (0.5cm,0)$) {};
 \node[rr, minimum width=10.5cm] at ($(v1.west) - (0.5cm,0)$) {};
-\foreach \n in {dot,f,x} {\node[rr, minimum width=1cm] at ($(\n.west) - (0.25cm,0)$) {};};
-\foreach \n in {fail,write} {\node[rr, minimum width=1.5cm] at ($(\n.west) - (0.5cm,0)$) {};};
-\foreach \n in {v2,v4} {\node[rr, minimum width=2.6cm] at ($(\n.west) - (0.2cm,0)$) {};};
+\foreach \n in {dot,f,x} {\node[rr, minimum width=1cm] at ($(\n.west) - (0.25cm,0)$) {};}
+\foreach \n in {fail,write} {\node[rr, minimum width=1.5cm] at ($(\n.west) - (0.5cm,0)$) {};}
+\foreach \n in {v2,v4} {\node[rr, minimum width=2.6cm] at ($(\n.west) - (0.2cm,0)$) {};}
 % Paint labels
-\foreach \n in {v7,v8,v1,v3,v5,v6,v2,v4} {\node at (\n) {\n};};
-\foreach \n in {invoke,write,f,x} {\node at (\n) {\tt\small \n};};
+\foreach \n in {v7,v8,v1,v3,v5,v6,v2,v4} {\node at (\n) {\n};}
+\foreach \n in {invoke,write,f,x} {\node at (\n) {\tt\small \n};}
 \node at (amp) {\tt\small \&};
 \node at (fail) {{\tt\small \&{}fail}};
 \node[anchor=east] at (bslash) {\textbackslash};
@@ -359,7 +359,7 @@ isolation.
 \node(v1){};&&&\node(v3){};&&&\node(v5){};&&&\node(v6){};&&\node(invoke){};\\
 };
 \node[rr, minimum width=10cm] at ($(v1.west) - (0.5cm,0)$) {};
-\foreach \n in {v1,v3,v5,v6} {\node at (\n) {\it \n};};
+\foreach \n in {v1,v3,v5,v6} {\node at (\n) {\it \n};}
 \node[anchor=west] at (invoke) {\tt\small invoke};
 \end{tikzpicture}
 \end{center}
@@ -591,9 +591,9 @@ the postfix tree.
 \draw (ex1) -- (v1) (ex2) -- (v2);
 \foreach \p in {ex1,ex2} {
   \draw [dashed,->] ($(\p) + (0.3cm,0)$) to node[right] {gen} ($(\p) + (0.3cm,1.7cm)$);
-};
+}
 \node[rr, minimum width=9cm] at ($(v1.west) - (0.7cm,0)$) {};
-\foreach \n in {v1,v2} {\node at (\n) {\it \n};};
+\foreach \n in {v1,v2} {\node at (\n) {\it \n};}
 \node (plus) at (pl) {+};
 \node (expr1) [rr,anchor=center] at (ex1) {expr$_1$};
 \node (expr2) [rr,anchor=center] at (ex2) {expr$_2$};

--- a/doc/ib/p2-overview.tex
+++ b/doc/ib/p2-overview.tex
@@ -49,7 +49,7 @@ delimited by braces) represents files, and arrows represent data flow.
 \foreach \n in {csf, rmc, pch, of} {
   \draw[-,decorate,decoration=brace] ($(\n.south west)+(0.15,0)$) -- ($(\n.north west)+(0.15,0)$);
   \draw[-,decorate,decoration=brace] ($(\n.north east)-(0.15,0)$) -- ($(\n.south east)-(0.15,0)$);
-};
+}
 \draw (rttf.east) -- (rtt); \draw (rtt) -- (csf.west);
 \draw (csf.east) -- (cc);   \draw (cc) -- (of.west); \draw (of.east) -- (lmp);
 

--- a/doc/ib/p3-2D3D.tex
+++ b/doc/ib/p3-2D3D.tex
@@ -133,7 +133,7 @@ a large set of resources, including pens, brushes, fonts and bitmaps.
 \begin{figure}[h]
 \begin{tikzpicture}[draw,very thick,font=\small\tt,
     elps/.style={ellipse,ellipse,draw,minimum width=1.5cm, minimum height=1.25cm},
-]`
+]
   %\draw[help lines] (0,0) grid (16,11);
 
 % draw the ellipses above the line (Iconx) solid

--- a/doc/icon.sty
+++ b/doc/icon.sty
@@ -31,7 +31,13 @@
 %\declare@font[1.18]{bigcourier}{m}{n}{pcrr}
 %\makeatother
 %\renewcommand{\"}[0]{{\family{bigcourier}\selectfont\symbol{34}}}
-\makeatletter\countdef\@maxtab=30\makeatother
+%
+% The number of tab stops is given by the difference between \@firsttab and \@maxtab
+% (and the value of \@firsttab varies, depending on how many packages have been loaded before LaTeX).
+% So this assignment doesn't always work because it's assigning an absolute value to \@maxtab.
+%      \makeatletter\countdef\@maxtab=30\makeatother
+% Add another 20 tab stops to \@maxtab
+\makeatletter\count255=\the\@maxtab\advance\count255 by 20 \chardef\@maxtab=\the\count255\makeatother%
 \renewcommand{\"}[0]{{\tt "}}
 \tolerance=1000 \small\normalsize
 %

--- a/doc/utr/icon.sty
+++ b/doc/utr/icon.sty
@@ -31,7 +31,13 @@
 %\declare@font[1.18]{bigcourier}{m}{n}{pcrr}
 %\makeatother
 %\renewcommand{\"}[0]{{\family{bigcourier}\selectfont\symbol{34}}}
-\makeatletter\countdef\@maxtab=30\makeatother
+%
+% The number of tab stops is given by the difference between \@firsttab and \@maxtab
+% (and the value of \@firsttab varies, depending on how many packages have been loaded before LaTeX).
+% So this assignment doesn't always work because it's assigning an absolute value to \@maxtab.
+%      \makeatletter\countdef\@maxtab=30\makeatother
+% Add another 20 tab stops to \@maxtab
+\makeatletter\count255=\the\@maxtab\advance\count255 by 20 \chardef\@maxtab=\the\count255\makeatother%
 \renewcommand{\"}[0]{{\tt "}}
 \tolerance=1000 \small\normalsize
 \newcommand{\iconcode}[1]{{\tt%


### PR DESCRIPTION
I'm not sure whether to wait for the results (if any) of people building the IB on various platforms to see if the "Tab Overflow" fix works for them. But, since the IB is not part of the regular Unicon build, on balance I think it's better to commit it now and fix any problems that arise as and when they surface.  There is more information in the separate commit messages.