### PR TITLE
Rename DEVMODE to DEVELOPMODE.

### DIFF
--- a/configure
+++ b/configure
@@ -4739,7 +4739,7 @@ if test x"$devmode" = x"yes" ; then
   debug=yes
   warn=yes
 
-$as_echo "#define DEVMODE 1" >>confdefs.h
+$as_echo "#define DEVELOPMODE 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ fi
 if test x"$devmode" = x"yes" ; then
   debug=yes
   warn=yes
-  AC_DEFINE([DEVMODE], [1], [Developer Mode])
+  AC_DEFINE([DEVELOPMODE], [1], [Developer Mode])
 fi
 
 if test x"$debugheap" = x"yes" ; then

--- a/doc/ib/appD.tex
+++ b/doc/ib/appD.tex
@@ -1324,12 +1324,12 @@ a value, a core dump is produced if an Icon program terminates as a result of
 \texttt{ICONCORE} when making modifications to Icon. For an extended debugging
 session, it may be convenient to set \texttt{dodump} in \textfn{runtime/init.r} to 1.
 
-\subsection{Extra help in \texttt{DEVMODE} (Unicon)}
-When Unicon is built with \texttt{DEVMODE} enabled there are some extra
+\subsection{Extra help in \texttt{DEVELOPMODE} (Unicon)}
+When Unicon is built with \texttt{DEVELOPMODE} enabled there are some extra
 facilities that are provided to help with debugging.
 \subsubsection{Breakpoints in the Unicon program}
 It is difficult (when debugging the runtime system) to arrange for a breakpoint
-to occur at a particular location in the Unicon program. In \texttt{DEVMODE}
+to occur at a particular location in the Unicon program. In \texttt{DEVELOPMODE}
 there is a new standard function, which is callable from Unicon, named
 \texttt{dbgbreak}. Writing something like the code fragment below will
 cause a debugger breakpoint at the desired moment -- provided the debugger is
@@ -1341,7 +1341,9 @@ instructed to place a break point at the function called \texttt{Zdbgbrk}.
 \end{iconcode}
 Note that use of \texttt{dbgbrk} should always be protected by
 \texttt{\$ifdef \_DEVMODE} because the function is only defined when
-\texttt{DEVMODE} is enabled.
+\texttt{DEVELOPMODE} is enabled. \texttt{DEVELOPMODE} used to be called \texttt{DEVMODE}
+but it was renamed because it clashed with the use of the same identifier in the Windows
+UCRT runtime library.
 \subsubsection{Identifying the current Unicon line}
 The position in the Unicon program can always be established by looking into the
 runtime system with the debugger. A couple of functions make this process

--- a/src/h/auto.in
+++ b/src/h/auto.in
@@ -18,7 +18,7 @@
 #undef C_ALLOCA
 
 /* Developer Mode */
-#undef DEVMODE
+#undef DEVELOPMODE
 
 /* Debug Heap */
 #undef DebugHeap

--- a/src/h/fdefs.h
+++ b/src/h/fdefs.h
@@ -31,9 +31,9 @@ FncDefV(constructor)
 FncDef(copy,1)
 FncDef(cos,1)
 FncDef(cset,1)
-#if defined(DEVMODE)
+#if defined(DEVELOPMODE)
 FncDef(dbgbrk,0)
-#endif                     /* DEVMODE */
+#endif                     /* DEVELOPMODE */
 FncDef(delay,1)
 FncDefV(delete)
 FncDefV(detab)

--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -195,6 +195,15 @@
    Feature(1, "_OVLD", "operator overloading")
 #endif					/* OVLD */
 
-#ifdef DEVMODE
+#ifdef DEVELOPMODE
+   /*
+    * DEVELOPMODE used to be called DEVMODE and caused (amongst other things)
+    * the preprocessor to define _DEVMODE as a predefined symbol.
+    * Unfortunately, DEVMODE is used by the Windows UCRT run time and the clash of
+    * symbols causes a build failure when Unicon is configured with --enable-devmode
+    * So, in the Unicon run time system, DEVMODE has been renamed to DEVELOPMODE.
+    * The name of the preprocessor defined symbol and the configure option
+    * are unchanged to avoid breaking existing usage.
+    */
    Feature(1, "_DEVMODE", "developer mode")
-#endif					/* DEVMODE */
+#endif					/* DEVELOPMODE */

--- a/src/h/rexterns.h
+++ b/src/h/rexterns.h
@@ -427,8 +427,8 @@ extern void vrfyLog(const char *fmt, ...);
 extern void vrfy_Live_Table(struct b_table *b);
 #endif                  /* VerifyHeap */
 
-#ifdef DEVMODE
+#ifdef DEVELOPMODE
 extern void dbgUFL();
 extern void dbgUtrace();
 extern int dbgbrkpoint();
-#endif                  /* DEVMODE */
+#endif                  /* DEVELOPMODE */

--- a/src/runtime/rdebug.r
+++ b/src/runtime/rdebug.r
@@ -1228,7 +1228,7 @@ void heaperr(char *msg, union block *p, int t)
 #endif					/* DebugHeap */
 
 
-#ifdef DEVMODE
+#ifdef DEVELOPMODE
 /*----------------------------------------------------------------------
  * This is a home for code that is only intended to be present when
  * the --enable-devmode option has been supplied to configure.
@@ -1279,4 +1279,4 @@ body {
 }
 end
 
-#endif                  /* DEVMODE */
+#endif                  /* DEVELOPMODE */


### PR DESCRIPTION
DEVMODE clashes with a type name inside the Windows UCRT library and causes a build failure if --enable-devmode is given as an option to configure. The --enable-devmode and the _DEVMODE preprocessor defined symbol have not been renamed to avoid breaking existing usage.