### PR TITLE
runtime: initialize a window pbuffer only if the window is GL2D

### DIFF
--- a/src/runtime/rxwin.ri
+++ b/src/runtime/rxwin.ri
@@ -1590,18 +1590,20 @@ int wmap(wbp w)
 
    /*
     * Get PBuffer for offscreen rendering (OpenGL rendering only)
+    * TODO: migrate to use  framebuffer objects instead,
+    * PBuffers are deprecated in OpenGL 3.0 and not available on MacOS
     */
-   {
-   int pbufattrs[] = {GLX_PBUFFER_WIDTH, DisplayWidth(stddpy, wd->screen),
-                      GLX_PBUFFER_HEIGHT, DisplayHeight(stddpy, wd->screen),
-                      GLX_PRESERVED_CONTENTS, True,
-                      None};
-   ws->pbuf = glXCreatePbuffer(stddpy, wd->configs[0],pbufattrs);
-   if (ws->pbuf == (GLXPixmap)NULL) {
-      /* consider freeing window binding/resources */
-      set_errortext(144);
-      return Failed;
-      }
+   if (wc->rendermode == UGL2D) {
+     int pbufattrs[] = {GLX_PBUFFER_WIDTH, DisplayWidth(stddpy, wd->screen),
+			GLX_PBUFFER_HEIGHT, DisplayHeight(stddpy, wd->screen),
+			GLX_PRESERVED_CONTENTS, True,
+			None};
+     ws->pbuf = glXCreatePbuffer(stddpy, wd->configs[0],pbufattrs);
+     if (ws->pbuf == (GLXPixmap)NULL) {
+       /* consider freeing window binding/resources */
+       set_errortext(144);
+       return Failed;
+     }
    }
 
    /*


### PR DESCRIPTION
PBuffer seems to be deprecated. glXCreatePbuffer fails on MacOS. So the GL 2D implementation still needs a fix, but this patch allows 3D graphics to work again at least.
