### PR TITLE
Extend unicon's -K option (keep files) to rtt, icont and iconc.

### DIFF
--- a/src/iconc/cmain.c
+++ b/src/iconc/cmain.c
@@ -123,6 +123,7 @@ char **argv;
    char *hfile = NULL;			/* name of C file - include */
    char *ofile = NULL;			/* name of executable result */
    char *efile = NULL;			/* stderr file */
+   int keeptmp = 0;			/* Do not remove cfile and hfile */
 
    char *db_name = "rt.db";		/* data base name */
    char *incl_file = "rt.h";		/* header file name */
@@ -191,8 +192,9 @@ char **argv;
          }
          if (opts[n][0] != '-') {
            break;               /* stop at first non option */
-         } else { /* See if we have -help or -version */
-           if (0 == strncmp("-help", opts[n], 5)) {
+         } else { /* See if we have -help --help or -version */
+           if ((0 == strncmp("-help", opts[n], 5)) ||
+               (0 == strncmp("--help", opts[n], 6))) {
              printf("Usage: %s [-cEgmstTuU] [-help] [-version] [-C comp]\n", progname);
              printf("       [-e efile] [-f[adelns]] [-n[acest]] [-o ofile]\n");
              printf("       [-p opt] [-r path] [-v i] [-w[bf]] file ... [-x args]\n");
@@ -217,6 +219,7 @@ char **argv;
              printf("     -nt       :   disable type inference\n");
              printf("   -p opt      : pass opt through to C compiler (or linker)\n");
              printf("   -r path     : path is the location of the runtime system\n");
+             printf("   -K          : keep temporary files\n");
              printf("   -s          : work silently\n");
              printf("   -t          : turn on tracing\n");
              printf("   -T          : type trace only\n");
@@ -242,7 +245,7 @@ char **argv;
    /*
     * Process options.
     */
-   while ((c = getopt(argc,argv,"A:C:EL:S:TU:ce:f:gmn:o:p:r:stuv:w:x")) != EOF)
+   while ((c = getopt(argc,argv,"A:C:EL:S:KTU:ce:f:gmn:o:p:r:stuv:w:x")) != EOF)
       switch (c) {
          case 'A': /* here come the perifiles... */
             ca_init(optarg, argc, argv);
@@ -260,6 +263,9 @@ char **argv;
             break;
          case 'S': /* Ignore: interpreter only */
             break;
+         case 'K':
+           keeptmp = 1;
+           break;
          case 'T':
             just_type_trace = 1;
             break;
@@ -612,10 +618,12 @@ Deliberate Syntax Error
        * Finish by removing C files.
        */
       fprintf(stderr,"Succeeded\n");
-      rmfile(cfile);
-      rmfile(hfile);
-      rmfile(makename(buf,TargetDir,cfile,ObjSuffix));
+      if (0 == keeptmp) {
+        rmfile(cfile);
+        rmfile(hfile);
+        rmfile(makename(buf,TargetDir,cfile,ObjSuffix));
       }
+   }
 #ifdef IconcLogAllocations
    alc_stats();
 #endif					/* IconcLogAllocations */

--- a/src/icont/tmain.c
+++ b/src/icont/tmain.c
@@ -278,6 +278,7 @@ void iconx(int argc, char** argv){
    int main(int argc, char **argv)
    {
    int nolink = 0;			/* suppress linking? */
+   int keeptmp = 0;			/* suppress removal of temporary files */
    int errors = 0;			/* translator and linker errors */
    char **tfiles, **tptr;		/* list of files to translate */
    char **lfiles, **lptr;		/* list of files to link */
@@ -314,8 +315,8 @@ void iconx(int argc, char** argv){
    /*
     * Process options. NOTE: Keep Usage definition in sync with getopt() call.
     */
-   #define Usage "[-cBstuEG] [-f s] [-l logfile] [-o ofile] [-v i]"	/* omit -e from doc */
-   while ((c = getopt(argc,argv, "cBe:f:l:o:O:stuGv:ELZ")) != EOF)
+   #define Usage "[-cBstuEGK] [-f s] [-l logfile] [-o ofile] [-v i]"	/* omit -e from doc */
+   while ((c = getopt(argc,argv, "cBe:f:l:o:O:stuGv:ELKZ")) != EOF)
       switch (c) {
 	 case 'B':
 	    bundleiconx = 1;
@@ -392,6 +393,9 @@ void iconx(int argc, char** argv){
 #endif					/* ConsoleWindow */
          case 'r':			/* Ignore: compiler only */
             break;
+         case 'K':
+           keeptmp = 1;			/* -K: Keep temporary files */
+           break;
          case 's':			/* -s: suppress informative messages */
             silent = 1;
             verbose = 0;
@@ -704,8 +708,10 @@ void iconx(int argc, char** argv){
     *  Execute the linked program if so requested and if there were no errors.
     */
 
-   for (rptr = rfiles; *rptr; rptr++)	/* delete intermediate files */
-      remove(*rptr);
+   if (0 == keeptmp) {
+     for (rptr = rfiles; *rptr; rptr++)	/* delete intermediate files */
+       remove(*rptr);
+   }
    if (errors > 0) {			/* exit if linker errors seen */
       char errbuf[32];
       remove(ofile);

--- a/src/rtt/rttmain.c
+++ b/src/rtt/rttmain.c
@@ -71,15 +71,15 @@ char *rt_path = "../src/h/rt.h";
  * End of operating-system specific code.
  */
 
-static char *ostr = "AECPD:I:U:O:d:cir:st:x";
+static char *ostr = "AKECPD:I:U:O:d:cir:st:x";
 
 #if EBCDIC
 static char *options =
-   "<-A> <-E> <-C> <-P> <-c> <-O copts> <-s> <-Dname<=<text>>> <-Uname> <-Ipath> <-dfile>\n    \
+   "<-A> <-E> <-C> <-P> <-K> <-c> <-O copts> <-s> <-Dname<=<text>>> <-Uname> <-Ipath> <-dfile>\n    \
 <-rpath> <-tname> <-x> <files>";
 #else                                   /* EBCDIC */
 static char *options =
-   "[-A] [-E] [-C] [-P] [-c] [-O copts] [-s] [-Dname[=[text]]] [-Uname] [-Ipath] [-dfile]\n    \
+   "[-A] [-E] [-C] [-P] [-K] [-c] [-O copts] [-s] [-Dname[=[text]]] [-Uname] [-Ipath] [-dfile]\n    \
 [-rpath] [-tname] [-x] [files]";
 #endif                                  /* EBCDIC */
 
@@ -239,6 +239,7 @@ char **argv;
    int nopts;
    char buf[MaxFileName];		/* file name construction buffer */
    struct fileparts *fp;
+   int keeptmp = 0;
 
    /*
     * See if the location of include files has been patched into the
@@ -286,6 +287,9 @@ char **argv;
             pp_only = 1;
             if (whsp_image == NoSpelling)
                whsp_image = NoComment;
+            break;
+     case 'K':              /* Do not remove files */
+            keeptmp = 1;
             break;
 	 case 'C':  /* retain spelling of white space, only effective with -E */
             whsp_image = FullImage;
@@ -468,7 +472,8 @@ char **argv;
 
    /*
     * If -c was used, go ahead and invoke a C compiler on curlst_string.
-    * If the compile did not report an error, remove the .c files afterwards.
+    * If the compile did not report an error, remove the .c files afterwards
+    * unless the keeptmp option is present.
     * Note that the remove command is at present hardwired to "rm"; for
     * greater portability (e.g. Windows) perhaps it should be rewritten to
     * a loop of C library remove() calls.
@@ -481,10 +486,12 @@ char **argv;
       sprintf(ccomp_line, "%s -c %s%s", CComp, ccomp_opts, curlst_string);
       if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
       if (system(ccomp_line)) return EXIT_FAILURE;
-      sprintf(ccomp_line, "%s%s", "rm", curlst_string);
-      if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
-      if (system(ccomp_line)) return EXIT_FAILURE;
+      if (0 == keeptmp) { 
+        sprintf(ccomp_line, "%s%s", "rm", curlst_string);
+        if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
+        if (system(ccomp_line)) return EXIT_FAILURE;
       }
+   }
 
    return EXIT_SUCCESS;
    }

--- a/uni/unicon/unicon.icn
+++ b/uni/unicon/unicon.icn
@@ -30,6 +30,7 @@
 # LISTS  : links = names of external icon code to link to
 #          imports = names of external classes to import
 #
+
 global parsingErrors, returnErrorsFlag, dbg, fset
 
 global fin,flog,flogname,fLine,alpha,alphadot,white,nonwhite,nonalpha
@@ -235,7 +236,7 @@ procedure iconc_importref_resolve(ref)
    initial {
       sep := PATHCHAR
       ipaths := ipaths_get()
-      }
+   }
 
    # write("iconc_importref_resolve(" || ref || ")...")
    rslt := []
@@ -369,7 +370,7 @@ end
 procedure unicon_usage(continue_flag)
    local f, msg
    if \continue_flag then f := iwrite else f := istop
-   msg := "Usage: unicon [-cBCstuEGyZMhK] [-Dsym=val] [-f[adelns]...] [-o ofile]\n   _
+   msg := "Usage: unicon [-cBCstuEGyZMhRK] [-Dsym=val] [-f[adelns]...] [-o ofile]\n   _
 	    [-nofs] [-help] [-version] [-features] [-v i] file... [-x args]"
    f(msg)
 end
@@ -398,7 +399,7 @@ procedure unicon_help()
    "   -x args     : execute immediately",
    "   -y          : parse (syntax check) only, do not compile",
    "   -Z          : compress icode",
-   "   -K           : keep tmpfiles",
+   "   -K          : keep tmpfiles",
    "   -h          : display this information"
    ] )
    istop()
@@ -547,6 +548,9 @@ procedure unicon(argv)
                   silent := 1
                   icontopt ||:= "-s "
                   ilinkopt ||:= "-s "
+                  }
+               "-K"      : {
+                  icontopt ||:= "-K "
                   }
                "-log"  : {
                   if (i=1) | (argv[i-1] ~=== "-log") then {


### PR DESCRIPTION
This should make the task of interpreting the diagnostics from gitHub's codeQL scanner (which works on the temporary files) a bit easier.