### PR TITLE
Fix _CONCURRENT

### DIFF
--- a/src/iconc/ctrans.c
+++ b/src/iconc/ctrans.c
@@ -10,6 +10,7 @@
 #include "ccode.h"
 #include "cproto.h"
 #include "ca.h"
+#include "../h/auto.h"
 
 /*
  * Prototypes.
@@ -214,7 +215,9 @@ char *filename;
       ppdef("_LARGE_INTEGERS", (char *)NULL);
    ppdef("_MULTITASKING", (char *)NULL);	/* never defined in compiler */
    ppdef("_EVENT_MONITOR", (char *)NULL);
+#ifdef NoConcurrentCOMPILER
    ppdef("_CONCURRENT", (char *)NULL);
+#endif
    ppdef("_OVLD", (char *)NULL);
    ppdef("_MEMORY_MONITOR", (char *)NULL);
    ppdef("_VISUALIZATION", (char *)NULL);

--- a/src/runtime/keyword.r
+++ b/src/runtime/keyword.r
@@ -138,7 +138,7 @@ keyword{1} current
       return coexpr
       }
    inline {
-#if 1 /* proposed !ConcurrentCOMPILER */
+#if !ConcurrentCOMPILER
       /* should be separate &current for each thread */
       CURTSTATE();
 #endif					/* !ConcurrentCOMPILER */

--- a/uni/parser/preproce.icn
+++ b/uni/parser/preproce.icn
@@ -58,6 +58,7 @@ procedure predefs()
 	    "co-expressions":"_CO_EXPRESSIONS"
 	    "native coswitch":"_NATIVECOSWITCH"
 	    "concurrent threads":"_CONCURRENT"
+            "concurrent threads, compiler subset":"_CONCURRENT"
 	    "console window":"_CONSOLE_WINDOW"
 	    "dynamic loading":"_DYNAMIC_LOADING"
 # "" environment variables
@@ -103,8 +104,8 @@ $endif
 #      t["_COMPILED"] := "1"  # see test preproc.icn
 #       ^ requires &features to have "compiled" when a prog is compiled
       # at present, iconc implies various features will be absent...
-      every delete(t, "_CONCURRENT" | "_EVENT_MONITOR" |
-		      "_MULTITASKING"| "_OVLD")
+      every delete(t, "_EVENT_MONITOR" | "_MULTITASKING"| "_OVLD")
+      if NoConcurrentCOMPILER() then delete(t,"_CONCURRENT")
       if not member(fset,"l") then  delete(t,"_LARGE_INTEGERS") # no -fl
       }
     return t

--- a/uni/unicon/Makefile
+++ b/uni/unicon/Makefile
@@ -3,10 +3,10 @@ include $(BASE)/Makedefs.uni
 
 export PATH:=$(BIN):$(PATH)
 
-U= unicon.u unigram.u unilex.u tree.u preproce.u idol.u unix.u tokens.u yyerror.u main.u cfy.u ca.u
+U= unicon.u unigram.u unilex.u tree.u preproce.u idol.u unix.u tokens.u yyerror.u main.u cfy.u ca.u nocc.u
 
 # Don't delete unigram.u and idol.u, needed for bootstrapping
-UDEL= unicon.u unilex.u tree.u preproce.u unix.u tokens.u yyerror.u main.u cfy.u ca.u
+UDEL= unicon.u unilex.u tree.u preproce.u unix.u tokens.u yyerror.u main.u cfy.u ca.u nocc.u
 
 UCFILES= unicon.icn unigram.icn unilex.icn tree.icn preproce.icn idol.u unix.icn tokens.icn yyerror.icn main.icn cfy.icn ca.icn
 
@@ -15,12 +15,12 @@ UCFILES= unicon.icn unigram.icn unilex.icn tree.icn preproce.icn idol.u unix.icn
 LIBFILES= ../lib/unilex.u ../lib/tree.u
 
 all: unicon $(WUNICONTARGET)
-unicon $(UNICONEXE): $(U) $(LIBFILES)
+unicon $(UNICONEXE): nocc.icn $(U) $(LIBFILES)
 	$(ICONT) $(U)
 	$(CP) unicon$(EXE) $(BIN)
 
 # A windows-specific build option
-wunicon $(WUNICONEXE): $(U)
+wunicon $(WUNICONEXE): nocc.icn $(U)
 	$(ICONT) -G -o wunicon$(EXE) $(U)
 	$(CP) wunicon$(EXE) $(BIN)
 
@@ -28,6 +28,17 @@ wunicon $(WUNICONEXE): $(U)
 
 unicon.u : unicon.icn
 	$(ICONT) $(UFLAGS) -c unicon
+
+nocc.u : nocc.icn nocchelper$(EXE)
+	$(ICONT) $(UFLAGS) -c nocc
+
+nocc.icn : nocchelper$(EXE)
+	./nocchelper$(EXE) > nocc.icn
+
+nocchelper$(EXE) : nocchelper.c
+# The explicit action helps Windows make do the right thing.
+# Use gcc explicitly because Makedefs.uni does not have a definition of $(CC).
+	gcc $^ -o $@
 
 ../lib/unilex.u: unilex.u
 	$(CP) unilex.u ../lib
@@ -97,4 +108,4 @@ unix.u: unix.icn
 #
 
 clean Clean:
-	$(RM) unicon$(EXE) wunicon$(EXE) uniclass.dir uniclass.pag uniclass.db $(UDEL)
+	$(RM) unicon$(EXE) wunicon$(EXE) uniclass.dir uniclass.pag uniclass.db $(UDEL) nocchelper$(EXE) nocc.icn

--- a/uni/unicon/nocchelper.c
+++ b/uni/unicon/nocchelper.c
@@ -1,0 +1,15 @@
+/* Write a unicon procedure that reflects whether NoConcurrentCOMPILER has been defined */
+#include <stdio.h>
+#include "../../src/h/auto.h"
+
+int main(void)
+{
+  puts("procedure NoConcurrentCOMPILER()");
+#ifdef NoConcurrentCOMPILER
+  puts("   return   # NoConcurrentCOMPILER is defined in auto.h");
+#else
+  puts("   fail     # NoConcurrentCOMPILER is not defined in auto.h");
+#endif
+  puts("end");
+  return 0;    /* Success */
+}

--- a/uni/unicon/preproce.icn
+++ b/uni/unicon/preproce.icn
@@ -58,6 +58,7 @@ procedure predefs()
 	    "co-expressions":"_CO_EXPRESSIONS"
 	    "native coswitch":"_NATIVECOSWITCH"
 	    "concurrent threads":"_CONCURRENT"
+            "concurrent threads, compiler subset":"_CONCURRENT"
 	    "console window":"_CONSOLE_WINDOW"
 	    "dynamic loading":"_DYNAMIC_LOADING"
 # "" environment variables
@@ -103,8 +104,8 @@ $endif
 #      t["_COMPILED"] := "1"  # see test preproc.icn
 #       ^ requires &features to have "compiled" when a prog is compiled
       # at present, iconc implies various features will be absent...
-      every delete(t, "_CONCURRENT" | "_EVENT_MONITOR" |
-		      "_MULTITASKING"| "_OVLD")
+      every delete(t, "_EVENT_MONITOR" | "_MULTITASKING"| "_OVLD")
+      if NoConcurrentCOMPILER() then delete(t,"_CONCURRENT")
       if not member(fset,"l") then  delete(t,"_LARGE_INTEGERS") # no -fl
       }
     return t


### PR DESCRIPTION
Allow `_CONCURRENT` to be a built in Unicon preprocessor definition with `iconc` or `unicon -C` if the system has been configured with `--enable-iconcurrency`.