### PR TITLE
Apply preprocessor bugfix to uni/parser preprocessor.

### DIFF
--- a/uni/parser/preproce.icn
+++ b/uni/parser/preproce.icn
@@ -168,7 +168,7 @@ procedure preproc_new(fname,predefined_syms)
       preproc_include_set := set([fname])
       preproc_filename := preproc_include_name := fname
       }
-   preproc_sym_table := \predefined_syms |table()
+   preproc_sym_table := copy(\predefined_syms) |table()
    preproc_if_stack := []
    preproc_file_stack := []
    preproc_if_state := &null


### PR DESCRIPTION
Commit 509fea20 fixed a bug in the uni/unicon preprocessor. The fix should also  have been applied to the uni/parser preprocessor.