### PR TITLE
Update SHA plugin to handle (i.e fail)  patterns.

### DIFF
--- a/plugins/src/SHA/shalib.icn
+++ b/plugins/src/SHA/shalib.icn
@@ -256,7 +256,7 @@ method _Sha(a[])
                 }
 
             # this list 'borrowed' from ximage.icn
-            "set"|"table"|"window"|"thread"|"co-expression"|"external": fail
+            "set"|"table"|"window"|"thread"|"co-expression"|"external"|"pattern": fail
 
             # If it's none of the above, assume it's a record
             default: every xx := key(x) do _Sha(x[xx], More) | fail


### PR DESCRIPTION
The SHA code detects record types by using a "none of the above" approach. So it needs to explicitly fail patterns to avoid them being treated as records.