### PR TITLE
Remove direct access methods from the SecureHash plugin.

### DIFF
--- a/plugins/src/SHA/shalib.icn
+++ b/plugins/src/SHA/shalib.icn
@@ -20,6 +20,7 @@
 #     June 2019
 #
 #     March 2021         Added Raw output and direct access methods
+#     February 2023      Remove direct access methods
 ################################################################################
 #
 # The SecureHash plugin has two public methods, Sha and Restart.
@@ -76,7 +77,7 @@
 # of the number, not a hash of the underlying bits. This is different to RFC6234
 # but probably more useful for Unicon programs.
 #
-# Sha is tolerent of null parameters and empty strings. The effect is to add
+# Sha is tolerant of null parameters and empty strings. The effect is to add
 # nothing to the hash.
 #
 # The SecureHash class is not thread-safe. Using a shared SecureHash object in
@@ -303,43 +304,6 @@ end
 # is used until a subsequent restart.
 method Restart(sf)
     return _Restart(sf)
-end
-
-# ----------------------------------------
-#                RFC6234 Interface methods
-# These are provided to cater for a situation where use of the Sha method is
-# intermingled with direct access to the underlying routines. If the goal is to
-# provide a different API then it is probably better to use the access procedures
-# (below) rather than these methods.
-# Note the (very slightly) different capitalisation compared to the procedures.
-method Sha_Reset(a[])
-   static Csha_Reset; initial Csha_Reset := loadfunc(LIB,"sha_Reset")
-   return Csha_Reset !a
-end
-
-method Sha_Input(a[])
-   static Csha_Input; initial Csha_Input := loadfunc(LIB,"sha_Input")
-   return Csha_Input !a
-end
-
-method Sha_Result(a[])
-   static Csha_Result; initial Csha_Result := loadfunc(LIB,"sha_Result")
-   return Csha_Result !a
-end
-
-method Sha_RawResult(a[])
-   static Csha_RawResult; initial Csha_RawResult := loadfunc(LIB,"sha_RawResult")
-   return Csha_RawResult !a
-end
-
-method Sha_FinalBits(a[])
-   static Csha_FinalBits; initial Csha_FinalBits := loadfunc(LIB,"sha_FinalBits")
-   return Csha_FinalBits !a
-end
-
-method Sha_ShaFunction(a[])
-   static Csha_ShaFunction; initial Csha_ShaFunction := loadfunc(LIB,"sha_ShaFunction")
-   return Csha_ShaFunction !a
 end
 
 # ----------------------------------------


### PR DESCRIPTION
They don't add any value and can be replaced with other calls. e.g.
   s.Sha_Input(x, ...)   ->    s.Sha(x, ..., More)
   s.Sha_Result()        ->    s.Sha()
   s.Sha_RawResult()     ->    s.Sha(Raw)
   s.Sha_ShaFunction()   ->    s.shaF
   s.Sha_ShaFunction(x)  ->    s.Reset(x)
etc.
Leaving them in would mean adding extra test code and documentation, so
it's better to remove them.