### PR TITLE
add $$= syntax

### DIFF
--- a/src/iyacc/reader.c
+++ b/src/iyacc/reader.c
@@ -76,6 +76,14 @@ void get_line(void)
     {
 	line[i]  =  c;
 	if (c == '\n') { cptr = line; return; }
+
+	if(iflag && (i>=2) &&
+	   (line[i-2]=='$') && (line[i-1]=='$') && (line[i] == '=')) {
+	   /* add a colon to make $$= into $$:= on Icon/Unicon */
+           line[i] = ':';
+	   ungetc(c, f);
+	   }
+
 	if (++i >= linesize)
 	{
 	    linesize += LINESIZE;


### PR DESCRIPTION
Tweak iyacc to interpret "$$=" as "$$:=" under Icon/Unicon, allowing the same .y file to work for both Unicon and Java, for example.