### PR TITLE
runtime: Make "mono" select a monospaced font.

### DIFF
--- a/src/runtime/rmswin.ri
+++ b/src/runtime/rmswin.ri
@@ -1674,9 +1674,13 @@ HFONT mkfont(char *s, char is_3D)
        * This is a legal Icon font spec.
        * Check first for special "standard" family names.
        */
-      if (!strcmp(family, "mono") || !strcmp(family, "fixed")) {
-	 stdfam = "Lucida Sans"; /* Lucida Console? */
+      if (!strcmp(family, "mono")) {
+	 stdfam = "Lucida Console";
 	 flags |= FONTFLAG_MONO + FONTFLAG_SANS;
+	 }
+      else if ( !strcmp(family, "fixed")) {
+	 stdfam = "Lucida Sans";
+	 flags |= FONTFLAG_PROPORTIONAL + FONTFLAG_SANS;
 	 }
       else if (!strcmp(family, "typewriter")) {
 	 stdfam = "Courier New"; /* was "courier" */

--- a/src/runtime/rxwin.ri
+++ b/src/runtime/rxwin.ri
@@ -5698,9 +5698,13 @@ void mkfont(char *s, char is_3D)
        * This is a legal Icon font spec.
        * Check first for special "standard" family names.
        */
-      if (!strcmp(family, "mono") || !strcmp(family, "fixed")) {
-	 stdfam = "Lucida Sans"; /* Lucida Console? */
+      if (!strcmp(family, "mono")) {
+	 stdfam = "Lucida Console";
 	 flags |= FONTFLAG_MONO + FONTFLAG_SANS;
+	 }
+      else if ( !strcmp(family, "fixed")) {
+	 stdfam = "Lucida Sans";
+	 flags |= FONTFLAG_PROPORTIONAL + FONTFLAG_SANS;
 	 }
       else if (!strcmp(family, "typewriter")) {
 	 stdfam = "Courier New"; /* was "courier" */


### PR DESCRIPTION
Previously, "mono" and "fixed" were treated as the same thing and asked for Lucida Sans, which is a proportionally spaced font. Now, "mono" asks for Lucida Console, which is monospaced, and "fixed" selects Lucida Sans (with the correct flags).