### PR TITLE
add default vscode configs and extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "jafar.unicon-syntax",
+        "jafar.unicon-debugger",
+        "jafar.unicon-lsp"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "json.format.keepLines": true,
+  "[json]": {
+    "editor.tabSize": 3
+  },
+  "[shellscript]": {
+    "editor.tabSize": 3,
+    "editor.detectIndentation": true
+  },
+
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,105 @@
+{
+   "version": "2.0.0",
+   "tasks": [
+      {
+         "label": "build Unicon",
+         "command": "make",
+         "options": {
+            "cwd": "${workspaceFolder}"
+         },
+         "args": [ "-j" ],
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         }
+      },
+      {
+         "label": "build iconx",
+         "type": "shell",
+         "command": "make",
+         "options": {
+            "cwd": "${workspaceFolder}/src/runtime"
+         },
+         "args": [ "-j", "iconx" ],
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         }
+      },
+      {
+         "label": "build src",
+         "type": "shell",
+         "command": "make",
+         "options": {
+            "cwd": "${workspaceFolder}/src"
+         },
+         "args": [ "-j" ],
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         }
+      },
+      {
+         "label": "build uni",
+         "command": "make",
+         "options": {
+            "cwd": "${workspaceFolder}/uni"
+         },
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         }
+      },
+      {
+         "label": "Configure Unicon",
+         "command": "configure",
+         "options": {
+            "cwd": "${workspaceFolder}"
+         },
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         }
+      },
+      {
+         "label": "Configure Dev Unicon",
+         "command": "configure",
+         "args": [
+            "--enable-debug",
+            "--enable-devmode"
+         ],
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         },
+         "presentation": {
+            "reveal": "always"
+         }
+      },
+      {
+         "label": "Configure Dev Unicon No iconc",
+         "command": "configure",
+         "args": [
+            "--enable-debug",
+            "--enable-devmode"
+         ],
+         "group": {
+            "kind": "build",
+            "isDefault": true
+         },
+         "presentation": {
+            "reveal": "always"
+         }
+      },
+      {
+         "label": "Run Unicon Tests",
+         "type": "shell",
+         "command": "make Test",
+         "group": "test",
+         "presentation": {
+            "reveal": "always",
+            "panel": "new"
+         }
+      }
+   ]
+}

--- a/.vscode/unicon.code-workspace
+++ b/.vscode/unicon.code-workspace
@@ -1,0 +1,33 @@
+{
+   "folders": [
+      {
+         "path": ".."
+      }
+   ],
+   "settings": {
+      "files.associations": {
+         //"*.r": "c11",
+         // "*.ri": "c11"
+      },
+      "files.exclude": {
+         "**/*.la": true,
+         "**/*.lo": true,
+         "**/*.a": true,
+         "**/*.so": true,
+         "**/*.o": true,
+         "**/*.u": true,
+         "config.status": true,
+         "**/uniclass.*": true
+      },
+      "C_Cpp.default.includePath": [
+         "${default}",
+         "${workspaceFolder}",
+         "${workspaceFolder}/**",
+         "${workspaceFolder}/src/h",
+         "${workspaceFolder}/rt/include"
+      ],
+      "C_Cpp.default.intelliSenseMode": "linux-gcc-x64",
+      "C_Cpp.default.compilerPath": "/usr/bin/gcc",
+      "C_Cpp.default.defines": [ ]
+   }
+}


### PR DESCRIPTION
Add extensions suggestions
Add common build, configure, and tests tasks.

Tasks can be invoked from vscode command menu or via shortcuts.