### PR TITLE
tests: fix a few posix issues. Skip test if feature isn't supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ uni/udb/udb
 uni/udb/udap/udap
 uni/udb/udap/dapcom
 uni/unicon/unicon
+uni/unicon/nocc.icn
+uni/unicon/nocchelper
 uni/unidep/unidep
 uni/unidoc/.lastbuild
 uni/unidoc/unidoc

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,9 @@
          "options": {
             "cwd": "${workspaceFolder}"
          },
-         "args": [ "-j" ],
+         "args": [
+            "-j"
+         ],
          "group": {
             "kind": "build",
             "isDefault": true
@@ -20,7 +22,10 @@
          "options": {
             "cwd": "${workspaceFolder}/src/runtime"
          },
-         "args": [ "-j", "iconx" ],
+         "args": [
+            "-j",
+            "iconx"
+         ],
          "group": {
             "kind": "build",
             "isDefault": true
@@ -33,7 +38,9 @@
          "options": {
             "cwd": "${workspaceFolder}/src"
          },
-         "args": [ "-j" ],
+         "args": [
+            "-j"
+         ],
          "group": {
             "kind": "build",
             "isDefault": true
@@ -81,7 +88,8 @@
          "command": "configure",
          "args": [
             "--enable-debug",
-            "--enable-devmode"
+            "--enable-devmode",
+            "--disable-iconc"
          ],
          "group": {
             "kind": "build",

--- a/tests/Makefile.test
+++ b/tests/Makefile.test
@@ -29,7 +29,7 @@ $(IGNORE):
 	else ./$@ > local/$@.out 2>&1; fi || true
 	-@echo "Expect/ignore these differences in $@:"
 	-@diff stand/$@.std local/$@.out; \
-	@if [ $$? -eq 0 ] ; then echo "OK"; \
+	if [ $$? -eq 0 ] ; then echo "OK"; \
 	else echo "[Test $@] Ignored"; fi || true
 	-@rm $@$(EXE)
 
@@ -63,8 +63,11 @@ endif
 	diff --suppress-common-lines -wy stand/$@.wstd local/$@.out > $@.diff; fi \
 	else diff -wq stand/$@.std local/$@.out >/dev/null; \
 	if [ $$? -eq 0 ] ; then echo "OK"; \
+	else \
+	if grep -qi "This Program Requires" local/$@.out; then cat local/$@.out; \
 	else echo "Failed"; \
 	diff --suppress-common-lines -wy stand/$@.std local/$@.out > $@.diff; fi \
+	fi; \
 	fi || true
 	-@rm $@$(EXE)
 

--- a/tests/general/ssl.icn
+++ b/tests/general/ssl.icn
@@ -64,9 +64,9 @@ class Server(addrport, mode, opt, rounds)
            rounds := 4
            opt := [addrport, "nae", key, cert, ca]
            }
-        "TLS1.1 Min": {
+        "TLS1.2 Min": {
            rounds := 3;
-           opt := [addrport, "nae", key, cert, ca, "minProto=TLS1.1"]
+           opt := [addrport, "nae", key, cert, ca, "minProto=TLS1.2"]
            }
 
         "Client Auth": {
@@ -187,6 +187,8 @@ procedure main(args)
 
    if not (&features == "secure sockets layer encryption") then
       stop("This program requires secure sockets layer encryption.")
+   if not (&features == "concurrent threads") then
+      stop("This program requires concurrent threads.")
 
    interactive := args[1]
 
@@ -196,8 +198,8 @@ procedure main(args)
    ssltest("Encrypted sockets", "TLS",
            [["No TLS", "Fail"], ["TLS No CA", "Fail"], ["TLS No Verify", "Pass"], ["TLS With CA", "Pass"]])
 
-   ssltest("TLS versions", "TLS1.1 Min",
-           [["TLS1.0", "Fail"], ["TLS1.1", "Pass"], ["TLS1.2", "Pass"]])
+   ssltest("TLS versions", "TLS1.2 Min",
+           [["TLS1.0", "Fail"], ["TLS1.1", "Fail"], ["TLS1.2", "Pass"]])
 
    ssltest("Client authentication", "Client Auth",
            [["TLS No Cert", "Fail"], ["Client Auth", "Pass"]])

--- a/tests/posix/getserv.icn
+++ b/tests/posix/getserv.icn
@@ -3,16 +3,15 @@ $include "posix.icn"
 
 procedure main()
 
-   s := getserv("daytime") | stop("Couldn't get service \"daytime\"")
+   s := getserv("ntp") | stop("Couldn't get service \"daytime\"")
    sdump(s)
-   port := 22
+   port := s.port
    s := getserv(port) | stop("Couldn't get service for port ", port)
    sdump(s)
 
 end
 
 procedure sdump(s)
-   writes(s.name, "\t\t", s.port, "/", s.proto)
-   writes("\t\t#", s.aliases)
-   write()
+   writes(left(s.name, 10), left(s.port || "/" || s.proto, 10))
+   write("[", s.aliases, "]")
 end

--- a/tests/posix/stand/getserv.std
+++ b/tests/posix/stand/getserv.std
@@ -1,2 +1,2 @@
-daytime		13/tcp		#
-ssh		22/tcp		#
+ntp       123/udp   []
+ntp       123/udp   []

--- a/tests/posix/udp.icn
+++ b/tests/posix/udp.icn
@@ -1,9 +1,9 @@
 $include "posix.icn"
 
 procedure main() 
-
+   port:=":1072"
    if fork() == 0 then {
-      f := open(":1072", "nua") 
+      f := open(port, "nua")
  
       if r := receive(f) then { 
           # Process the request in r.msg - in the case of the time 
@@ -14,7 +14,10 @@ procedure main()
    }
 
    delay(100)
-   f := open(":1072", "nu") |
+   if (&features == "MacOS") then
+      port := "localhost" || port
+
+   f := open(port, "nu") |
       stop("Open failed: ", sys_errstr(&errno))
 
    write(f, "")

--- a/tests/posix/uxsocket.icn
+++ b/tests/posix/uxsocket.icn
@@ -2,12 +2,12 @@
 $include "posix.icn"
 
 procedure main()
-
+   sock := "revsock" || (?900 + 100)
    if fork() ~== 0 then {
       # parent
       delay(1000)
-      f := open("revsock", "n") | stop("Couldn't connect: ",
-				       sys_errstr(&errno))
+      f := open(sock, "n") |
+         stop("Couldn't connect: ",  sys_errstr(&errno))
 
       write(f, "hello, world!")
       write(read(f))
@@ -18,15 +18,18 @@ procedure main()
    }
 
    # child
-   if f := open("revsock", "na") then {
+   if f := open(sock, "na") then {
       if fork() = 0 then {
-	 handle(f)
-	 close(f)
-	 exit(0)
+         handle(f)
+         close(f)
+         exit(0)
       }
       close(f)
-
-      system("rm revsock")
+      if (&features == "MacOS") then
+         # workaround a bug on MacOS where the name is one character shorter
+         system("rm " || sock[1:-1])
+      else
+         system("rm " || sock)
    }
    (&errno = 0) | stop("Couldn't accept: ", sys_errstr(&errno))
 end

--- a/tests/thread/sharelist.icn
+++ b/tests/thread/sharelist.icn
@@ -5,7 +5,7 @@
 global L, m
 procedure main()
    if not (&features == "concurrent threads") then
-       stop("requires concurrent threads")
+      stop("This program requires concurrent threads.")
    n := 4
    L := mutex( [ ] )
    m := 100000

--- a/tests/thread/sum.icn
+++ b/tests/thread/sum.icn
@@ -1,5 +1,9 @@
 global gsum, usermode
 procedure main(argv)
+
+   if not (&features == "concurrent threads") then
+      stop("This program requires concurrent threads.")
+
    gsum:=0
    thrd := []
 

--- a/tests/unicon/FxPtTest.icn
+++ b/tests/unicon/FxPtTest.icn
@@ -9,7 +9,7 @@
 
 procedure main(args)
    if not(&features == "large integers") then
-      stop("large integers not supported")
+      stop("This program requires large integers.")
 
    runTests(args)
 end

--- a/tests/unicon/FxPtTest_OVLD.icn
+++ b/tests/unicon/FxPtTest_OVLD.icn
@@ -8,11 +8,11 @@
 # --------------------------------------------------------------------------------
 
 procedure main(args)
-   if not(&features == "large integers") then
-      stop("large integers not supported")
-   
    if not (&features == "operator overloading") then
-       stop("operator overloading not supported")
+       stop("This program requires operator overloading.")
+
+   if not(&features == "large integers") then
+      stop("This program requires large integers.")
 
    runTests(args)
 end

--- a/tests/unicon/Makefile
+++ b/tests/unicon/Makefile
@@ -1,17 +1,10 @@
 
 include ../Makedefs
 
-ifneq ("$(wildcard $(UC))","")
 TARGETS=$(patsubst %.icn,%,$(wildcard *.icn))
 
 SKIP= tester FxPtTests\
       audio dbi list_test nlm q rec test testnlm clin_err hello mintest ovld q2 sel to
-else
-skip:
-	@echo "Unicon compiler not found"
-
-TARGETS=skip
-endif
 
 Test: DoTest
 


### PR DESCRIPTION
If the test standard output contains the text "This program requires", the test is considered skipped and the output is reported as is. Ex:
 
```
[Testing utf8]... OK
[Testing utf8_ovld]... This program requires operator overloading.
[Testing var]... OK
```