### PR TITLE
Remove CRAY configuration.

### DIFF
--- a/doc/ib/appH.tex
+++ b/doc/ib/appH.tex
@@ -77,8 +77,8 @@ ConcurrentCOMPILER & U & build iconc with (preliminary) concurrency support \\
 ConsoleWindow & U & emulate a console window (graphics, mainly Windows) \\
 const & U & disable the const keyword when necessary \\
 COpts & IU & C compiler command line options that iconc uses \\
-CRAY & IU & build on Cray (gdbm, should delete) \\
-CRAY\_STACK & U & legacy CRAY stack linkage structs (delete) \\
+{\gr CRAY} & {\gr IU} & {\gr build on Cray (gdbm, should delete)} \\
+{\gr CRAY\_STACK} & {\gr U } & {\gr legacy CRAY stack linkage structs (delete)} \\
 CStateSize & IU & size of the C state (saved registers) for co-expressions \\
 CSuffix & all & extension used for C source files \\
 CUsage & IU & iconc usage string \\

--- a/src/h/config.h
+++ b/src/h/config.h
@@ -1017,3 +1017,12 @@ Deliberate Syntax Error
 			   sizeof(word) - 1) / sizeof(word))
 
 #endif					/* UNICON_CONFIG_H */
+
+/*
+ * Ensure configurations that are no longer supported cannot be built by accident.
+ * The date gives a clue to the last commit where the configuration was supported.
+ */
+
+#if defined(CRAY) || defined (CRAY_STACK)
+#error The CRAY configuration option is no longer supported (since 7 Mar 2024)
+#endif					/* CRAY */

--- a/src/h/lexdef.h
+++ b/src/h/lexdef.h
@@ -26,11 +26,7 @@ struct toktab {
    int  t_flags;		/* flags for semicolon insertion */
    };
 
-#ifdef CRAY
-   extern struct toktab toktab[35];	/* compiler bug workaround */
-#else					/* CRAY */
-   extern struct toktab toktab[];	/* token table */
-#endif					/* CRAY */
+extern struct toktab toktab[];	/* token table */
 
 extern struct toktab *restab[];	/* reserved word index */
 

--- a/src/icont/lcode.c
+++ b/src/icont/lcode.c
@@ -494,12 +494,7 @@ static void setfile()
       fnmtbl = (struct ipc_fname *) trealloc(fnmtbl, &fnmfree,
          &fnmsize, sizeof(struct ipc_fname), 1, "file name table");
 
-#ifdef CRAY
-   fnmfree->ipc_saved = pc/8;
-#else					/* CRAY */
    fnmfree->ipc_saved = pc;
-#endif					/* CRAY */
-
    fnmfree->fname = getrest();
    fnmfree++;
    newline();
@@ -553,12 +548,7 @@ char *name;
       labels[lab] = WordSize - pc;	/* add to front of reference chain */
       }
    else					/* output relative offset */
-
-#ifdef CRAY
-      outword((labels[lab] - (pc + WordSize))/8);
-#else					/* CRAY */
-      outword(labels[lab] - (pc + WordSize));
-#endif					/* CRAY */
+     outword(labels[lab] - (pc + WordSize));
    }
 
 static void lemitn(op, n, name)
@@ -585,12 +575,7 @@ word loc;
 char *name;
    {
    misalign();
-
-#ifdef CRAY
-   loc = (loc - pc - 16)/8;
-#else					/* CRAY */
    loc -= pc + ((IntBits/ByteBits) + WordSize);
-#endif					/* CRAY */
 
 #ifdef DeBugLinker
    if (Dflag) {
@@ -1848,12 +1833,7 @@ int lab;
    if (p > 0)
       quit("multiply defined label in ucode");
    while (p < 0) {		/* follow reference chain */
-
-#ifdef CRAY
-      r = (pc - (WordSize - p))/8;	/* compute relative offset */
-#else					/* CRAY */
       r = pc - (WordSize - p);	/* compute relative offset */
-#endif					/* CRAY */
       q = codep - (pc + p);	/* point to word with address */
       cp = (char *) &p;		/* address of integer p       */
       cr = (char *) &r;		/* address of integer r       */

--- a/src/icont/link.c
+++ b/src/icont/link.c
@@ -49,17 +49,10 @@ void	setexe	(char *fname);
 #endif					/* MVS */
 
 #if UNIX
-   #ifdef CRAY
-      #define word word_fubar
+   #ifndef XWindows
       #include <sys/types.h>
-      #include <sys/stat.h>
-      #undef word
-   #else				/* CRAY */
-      #ifndef XWindows
-         #include <sys/types.h>
-      #endif				/* XWindows */
-      #include <sys/stat.h>
-   #endif				/* CRAY */
+   #endif				/* XWindows */
+   #include <sys/stat.h>
 #endif					/* UNIX */
 
 /*

--- a/src/runtime/interp.r
+++ b/src/runtime/interp.r
@@ -827,11 +827,7 @@ L_areal:
 	       }
 	    else
 #endif					/* MultiProgram */
-#ifdef CRAY
-	       opnd = (word)(strcons + GetWord);
-#else					/* CRAY */
-	       opnd = (word)strcons + GetWord;
-#endif					/* CRAY */
+          opnd = (word)strcons + GetWord;
 
 #ifdef Concurrent
 	    PutInstr(Op_Astr, opnd, 2);

--- a/src/runtime/rmemmgt.r
+++ b/src/runtime/rmemmgt.r
@@ -4,10 +4,6 @@
  *   garbage collection, dump routines
  */
 
-#ifdef CRAY
-#include <malloc.h>
-#endif					/* CRAY */
-
 /*
  * Prototypes
  */
@@ -894,12 +890,7 @@ dptr dp;
    char *newqual;
    CURTSTATE();
 
-#ifdef CRAY
-   if (strbase <= StrLoc(*dp) && StrLoc(*dp) < (strfree + 1)) {
-#else					/* CRAY */
    if (InRange(strbase,StrLoc(*dp),strfree + 1)) { 
-#endif					/* CRAY */
-
       /*
        * The string is in the string space.  Add it to the string qualifier
        *  list, but before adding it, expand the string qualifier list if


### PR DESCRIPTION
The standard configuration scripts could still select it, but the CRAY specific code has been removed and compilation errors will occur.