### PR TITLE
Remove MACINTOSH configuration.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -4769,7 +4769,6 @@ platforms. These symbols include:
 
 \_V9\ \ \ \ \ \ \ \ \ \ Version 9\\
 \_CMS\ \ \ \ \ \ \ \ \ \ CMS\\
-\_MACINTOSH\ \ \ \ \ \ Macintosh\\
 \_MSDOS\_386\ \ \ \ \ \ MS-DOS/386\\
 \_MS\_WINDOWS\_NT\ \ \ \ MS Windows NT\\
 \_MSDOS\ \ \ \ \ \ \ \ MS-DOS\\

--- a/doc/ib/appH.tex
+++ b/doc/ib/appH.tex
@@ -273,7 +273,7 @@ LoopThreshold & U & number of tended var initializations iconc will unroll \\
 M\_PI & IU & constant value of Pi \\
 MacGraph & U & build graphics using (legacy pre OSX) Mac graphics (should delete)  \\
 MACGRAPH\_H & IU & macgraph.h has been included \\
-MACINTOSH & all & build on legacy Mac platform (delete?)  \\
+{\gr MACINTOSH} & {\gr all} & {\gr build on legacy Mac platform (delete?)}  \\
 MacOS & U & build on modern UNIX-based Mac platform \\
 max & all & compute maximum of x and y \\
 MaxAbrSize & all & maximum allocated block region size \\

--- a/src/common/dconsole.c
+++ b/src/common/dconsole.c
@@ -1045,9 +1045,7 @@ int i;
       pollevent();
       }
 
-#if !MACINTOSH
-   #undef exit
-#endif					/* MACINTOSH */
+#undef exit
    exit(i);
 }
 

--- a/src/common/filepart.c
+++ b/src/common/filepart.c
@@ -30,11 +30,6 @@ static char *tryfile	(char *buf, char *dir, char *name, char *extn);
    #define FileSep '/'
 #endif					/* MSDOS */
 
-#if MACINTOSH
-   #define Prefix ":"
-   #define FileSep ':'
-#endif					/* MACINTOSH */
-
 #if MVS
    #define Prefix ""
    #define FileSep '('

--- a/src/h/config.h
+++ b/src/h/config.h
@@ -210,10 +210,6 @@
    #define PORT 0
 #endif					/* PORT */
 
-#ifndef MACINTOSH
-   #define MACINTOSH 0
-#endif					/* MACINTOSH */
-
 #ifndef MSDOS
    #define MSDOS 0
 #endif					/* MSDOS */
@@ -1026,3 +1022,7 @@ Deliberate Syntax Error
 #if defined(CRAY) || defined (CRAY_STACK)
 #error The CRAY configuration option is no longer supported (since 7 Mar 2024)
 #endif					/* CRAY */
+
+#if defined(MACINTOSH)
+#error The MACINTOSH configuration option is no longer supported (since 7 Mar 2024)
+#endif					/* MACINTOSH */

--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -22,10 +22,6 @@
    Feature(1, "_CMS", "CMS")
 #endif					/* VM */
 
-#if MACINTOSH
-   Feature(1, "_MACINTOSH", "Macintosh")
-#endif					/* MACINTOSH */
-
 #ifdef MacOS
    Feature(1, "_MACOS", "MacOS")
 #endif					/* MacOS */

--- a/src/h/rmacros.h
+++ b/src/h/rmacros.h
@@ -824,9 +824,9 @@
       Deliberate Syntax Error
    #endif				/* PORT */
    
-   #if MACINTOSH || MVS || UNIX || VM || VMS
+   #if MVS || UNIX || VM || VMS
       #define PushAVal(x) PushVal(x)
-   #endif				/* MACINTOSH ... */
+   #endif				/* MVS ... VMS */
    
    #if MSDOS
          #define PushAVal(x)  {sp++; \

--- a/src/h/sys.h
+++ b/src/h/sys.h
@@ -36,18 +36,6 @@
    Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH
-   #ifdef MacGraph
-      #include <console.h>
-      #include <AppleEvents.h>
-      #include <GestaltEqu.h>
-      #include <fp.h>
-      #include <QDOffscreen.h>
-      #include <Palettes.h>
-      #include <Quickdraw.h>
-   #endif				/* MacGraph */
-#endif					/* MACINTOSH */
-
 #ifdef ISQL
   #undef Type
   #undef Precision

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -32,7 +32,7 @@ Deliberate Syntax Error
 #endif
 #endif
 
-#if UNIX || MACINTOSH || MVS || VM
+#if UNIX || MVS || VM
 #define ExeFlag "-o"
 #define LinkLibs " -lm"
 #endif						/* UNIX ... */
@@ -79,7 +79,7 @@ char *libname;
 Deliberate Syntax Error
 #endif						/* PORT */
 
-#if UNIX || MACINTOSH || MSDOS || MVS || VM
+#if UNIX || MSDOS || MVS || VM
    l->libname = libname;
    l->nm_sz = strlen(libname);
 #endif						/* UNIX ... */
@@ -123,7 +123,7 @@ rmv_ccomp_opts(opts)
    char * q;
    char * rslt;
 
-#if PORT || MACINTOSH || MSDOS || MVS || VM || VMS
+#if PORT || MSDOS || MVS || VM || VMS
    /* something may be needed */
    fprintf(stderr, "warning: option \"-nO\" unsupported on this platform.\n");
    return opts;
@@ -214,7 +214,7 @@ char *exename;
  *  time as the number of libraries grew, it became a maintenance problem.
  */
 
-#if PORT || MACINTOSH || MVS || VM
+#if PORT || MVS || VM
    /* something may be needed */
 Deliberate Syntax Error
 #endif						/* PORT || ... */

--- a/src/iconc/cmain.c
+++ b/src/iconc/cmain.c
@@ -467,11 +467,11 @@ Deliberate Syntax Error
          addlib(argv[optind]);		/* assume linker option */
 #endif					/* UNIX ... */
 
-#if MACINTOSH || MSDOS || MVS || VM || VMS
+#if MSDOS || MVS || VM || VMS
       /*
        * Linker options on command line not supported.
        */
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS || ... */
 
 /*
  * End of operating-system specific code.
@@ -511,12 +511,12 @@ Deliberate Syntax Error
             addlib(argv[optind]);
 #endif					/* UNIX ... */
 
-#if MACINTOSH || MSDOS || MVS || VM || VMS
+#if MSDOS || MVS || VM || VMS
             /*
              * Pass no files to the linker.
              */
             quitf("bad argument %s",argv[optind]);
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS || ... */
 
 /*
  * End of operating-system specific code.
@@ -703,10 +703,6 @@ char *ofile, *efile, **args;
    /* something is needed */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-      fprintf(stderr,"-x not supported\n"); fflush(stderr);
-#endif					/* MACINTOSH */
 
 #if MSDOS
 #if MICROSOFT || TURBO

--- a/src/icont/link.c
+++ b/src/icont/link.c
@@ -33,9 +33,9 @@ void	setexe	(char *fname);
    Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || VM || VMS
+#if VM || VMS
    /* nothing to do */
-#endif					/* MACINTOSH || ... */
+#endif					/* VM || VMS */
 
 #if MSDOS
    extern char pathToIconDOS[];
@@ -199,9 +199,9 @@ char *outname;
    Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MVS || UNIX || VM || VMS
+#if MVS || UNIX || VM || VMS
    /* nothing to do */
-#endif					/* MACINTOSH || ... */
+#endif					/* MVS || ... */
 
 #if MSDOS
    #if MICROSOFT || TURBO

--- a/src/icont/tmain.c
+++ b/src/icont/tmain.c
@@ -805,11 +805,6 @@ char *ofile, *efile, **args;
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH
-      fprintf(stderr,"-x not supported\n");
-      fflush(stderr);
-#endif					/* MACINTOSH */
-
 #if MSDOS
       /* No special handling is needed for an .exe files, since iconx
        * recognizes it from the extension andfrom internal .exe data.

--- a/src/preproc/files.c
+++ b/src/preproc/files.c
@@ -18,13 +18,6 @@ Deliberate Syntax Error
 Deliberate Syntax Error
 #endif					/* VM || MVS */
 
-#if MACINTOSH
-char *FileNameMacToUnix(char *fn);
-char *FileNameUnixToMac(char *fn);
-char *FileNameMacConvert(char *(*func)(char *),char *fn);
-#define IsRelPath(fname) (fname[0] != '/')
-#endif					/* MACINTOSH */
-
 #if MSDOS
 #if MICROSOFT
    /* nothing is needed */
@@ -79,10 +72,6 @@ Deliberate Syntax Error
    /* something may be needed */
 Deliberate Syntax Error
 #endif					/* VM || MVS */
-
-#if MACINTOSH
-   fname = FileNameMacConvert(FileNameMacToUnix,fname);
-#endif					/* MACINTOSH */
 
 #if MSDOS
    char *s;
@@ -170,25 +159,11 @@ int system;
                      if (*s == '/')
                         end_prfx = s;
                   if (end_prfx != NULL) 
-#if MACINTOSH
-		     /*
-		      * For Mac-style names, don't include the file
-		      * separator character in the prefix.
-		      */
-                     for (s = cs->fname; s < end_prfx; ++s)
-#else					/* MACINTOSH */
-                     for (s = cs->fname; s <= end_prfx; ++s)
-#endif					/* MACINTOSH */
-                        AppChar(*sbuf, *s);
+                  for (s = cs->fname; s <= end_prfx; ++s)
+                     AppChar(*sbuf, *s);
                   for (s = fname; *s != '\0'; ++s)
                      AppChar(*sbuf, *s);
                   path = str_install(sbuf);
-#if MACINTOSH
-		  /*
-		   * Convert UNIX-style path to Mac-style.
-		   */
-		  path = FileNameMacConvert(FileNameUnixToMac,path);
-#endif					/* MACINTOSH */
                   f = fopen(path, "r");
                   }
                }
@@ -207,12 +182,6 @@ int system;
          for (s = fname; *s != '\0'; ++s)
             AppChar(*sbuf, *s);
          path = str_install(sbuf);
-#if MACINTOSH
-	 /*
-	  * Convert UNIX-style path to Mac-style.
-	  */
-	 path = FileNameMacConvert(FileNameUnixToMac,path);
-#endif					/* MACINTOSH */
          f = fopen(path, "r");
          ++prefix;
          }
@@ -300,10 +269,10 @@ Deliberate Syntax Error
       }
 #endif					/* VMS */
 
-#if VM || MVS || MACINTOSH
+#if VM || MVS
    /* probably needs something */
 Deliberate Syntax Error
-#endif					/* VM || MVS || ... */
+#endif					/* VM || MVS */
 
 #if MSDOS
 
@@ -458,9 +427,9 @@ Deliberate Syntax Error
 
 #endif					/* MSDOS */
 
-#if UNIX || VMS || MACINTOSH
+#if UNIX || VMS
    /* nothing is needed */
-#endif					/* UNIX || VMS || MACINTOSH */
+#endif					/* UNIX || VMS */
 
 /*
  * End of operating-system specific code.
@@ -491,10 +460,6 @@ Deliberate Syntax Error
    /* something might be needed */
 Deliberate Syntax Error
 #endif					/* VM || MVS */
-
-#if MACINTOSH
-   s1 = FileNameMacConvert(FileNameMacToUnix,s);
-#endif					/* MACINTOSH */
 
 #if MSDOS
          /*
@@ -589,9 +554,9 @@ Deliberate Syntax Error
 
 #endif					/* MSDOS */
 
-#if UNIX || MACINTOSH
+#if UNIX
    incl_search[n_paths - 1] = sysdir;
-#endif					/* UNIX || MACINTOSH */
+#endif					/* UNIX */
 
 /*
  * End of operating-system specific code.

--- a/src/preproc/pinit.c
+++ b/src/preproc/pinit.c
@@ -16,10 +16,6 @@
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH
-   /* nothing is needed */
-#endif					/* MACINTOSH */
-
 #if MSDOS
 #if MICROSOFT
    /* nothing is needed */
@@ -97,10 +93,6 @@ char **opt_args;
    /* something may be needed */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-   /* nothing is needed */
-#endif					/* MACINTOSH */
 
 #if MSDOS
 #if MICROSOFT
@@ -371,10 +363,6 @@ Deliberate Syntax Error
    /* something may be needed */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-   /* nothing is needed */
-#endif					/* MACINTOSH */
 
 #if MSDOS
 #if MICROSOFT

--- a/src/preproc/pmain.c
+++ b/src/preproc/pmain.c
@@ -16,14 +16,6 @@ static char *options =
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH
-static char *ostr = "CPD:I:U:o:";
-static char *options = 
-   "[-C] [-P] [-Dname[=[text]]] [-Uname] [-Ipath] [-ofile] [files]";
-   /* may need more options */
-Deliberate Syntax Error
-#endif					/* MACINTOSH */
-
 #if MSDOS
 #if MICROSOFT
    /* this really isn't right for anything but Microsoft */
@@ -118,11 +110,6 @@ char **argv;
    /* may need something */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-   /* may need something */
-Deliberate Syntax Error
-#endif					/* MACINTOSH */
 
 #if MSDOS
 #if MICROSOFT

--- a/src/rtt/rttmain.c
+++ b/src/rtt/rttmain.c
@@ -2,10 +2,6 @@
 
 /*#include "../h/filepat.h"		?* added for filepat change */
 
-#if MACINTOSH
-#include <console.h>
-#endif					/* MACINTOSH */
-
 /*
  * prototypes for static functions.
  */
@@ -41,11 +37,6 @@ char *src_file_nm;
    /* something is needed */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-char *grttin_path = "::h:grttin.h";
-char *rt_path = "::h:rt.h";
-#endif					/* MACINTOSH */
 
 #if MSDOS
 char *grttin_path = "..\\src\\h\\grttin.h";
@@ -265,10 +256,6 @@ char **argv;
    whsp_image = NoSpelling;
    line_cntrl = 1;
 
-#if MACINTOSH
-   argc = ccommand(&argv);
-#endif					/* MACINTOSH */
-
    /*
     * opt_lst and opt_args are the options and corresponding arguments
     *  that are passed along to the preprocessor initialization routine.
@@ -341,10 +328,6 @@ char **argv;
          default:
             show_usage();
          }
-
-#if MACINTOSH
-   iconx_flg = 1;     /* Produce interpreter code */
-#endif					/* MACINTOSH */
 
 #ifdef Rttx
    if (!iconx_flg) {

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -332,9 +332,9 @@ function{0,1} open(fname, spec)
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MSDOS || MVS || VM
+#if MSDOS || MVS || VM
    /* nothing is needed */
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS || ... */
 
 #ifdef PosixFns
       int is_udp_or_listener = 0;	/* UDP = 1, listener = 2 */
@@ -638,14 +638,6 @@ Deliberate Syntax Error
       if ((status & (Fs_Read|Fs_Write)) == (Fs_Read|Fs_Write))
 	 mode[1] = '+';
 #endif					/* UNIX || VMS */
-
-#if MACINTOSH
-      if ((status & (Fs_Read|Fs_Write)) == (Fs_Read|Fs_Write)) {
-         mode[1] = '+';
-         if ((status & Fs_Untrans) != 0) mode[2] = 'b';
-         }
-      else if ((status & Fs_Untrans) != 0) mode[1] = 'b';
-#endif					/* MACINTOSH */
 
 #if MSDOS
       if ((status & (Fs_Read|Fs_Write)) == (Fs_Read|Fs_Write)) {
@@ -3185,9 +3177,9 @@ function{0,1} chdir(s)
 #if PORT
    Deliberate Syntax Error
 #endif                                  /* PORT */
-#if MACINTOSH || MVS || VM
+#if MVS || VM
       runerr(121);
-#endif                                  /* MACINTOSH ... */
+#endif                                  /* MVS || VM */
 #if MSDOS || UNIX || VMS || NT
 
       char path[PATH_MAX];

--- a/src/runtime/init.r
+++ b/src/runtime/init.r
@@ -29,9 +29,9 @@ FILE		*pathOpen       (char *fname, char *mode);
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MVS || VM || UNIX || VMS
+#if MVS || VM || UNIX || VMS
    /* nothing needed */
-#endif					/* MACINTOSH ... */
+#endif					/* MVS ... VMS */
 
 /*
  * End of operating-system specific code.
@@ -1142,7 +1142,7 @@ btinit:
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || UNIX || VMS
+#if UNIX || VMS
    if (noerrbuf)
       setbuf(stderr, NULL);
    else {
@@ -1153,7 +1153,7 @@ Deliberate Syntax Error
 	 fatalerr(305, NULL);
       setbuf(stderr, buf);
       }
-#endif					/* MACINTOSH ... */
+#endif					/* UNIX || VMS */
 
 #if MSDOS
    if (noerrbuf)
@@ -1260,9 +1260,9 @@ void envset()
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MSDOS || MVS || UNIX || VM || VMS
+#if MSDOS || MVS || UNIX || VM || VMS
    /* nothing to do */
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS || ... */
 
 /*
  * End of operating-system specific code.
@@ -1279,10 +1279,6 @@ Deliberate Syntax Error
    /* can't handle */
 Deliberate Syntax Error
 #endif					/* PORT */
-
-#if MACINTOSH
-   /* can't handle */
-#endif					/* MACINTOSH */
 
 #if MSDOS
 #if TURBO

--- a/src/runtime/interp.r
+++ b/src/runtime/interp.r
@@ -35,9 +35,9 @@ static void vanq_proc (struct ef_marker *efp_v, struct gf_marker *gfp_v);
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MSDOS || MVS || UNIX || VM || VMS
+#if MSDOS || MVS || UNIX || VM || VMS
    /* nothing needed */
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS|| ... */
 
 /*
  * End of operating-system specific code.
@@ -355,9 +355,9 @@ deliberate syntax error
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MVS || UNIX || VM || VMS
+#if MVS || UNIX || VM || VMS
 #define PushAVal(x) PushVal(x)
-#endif					/* MACINTOSH || ... */
+#endif					/* MSDOS || ... */
 
 #if MSDOS
 #define PushAVal(x) {rsp++; \
@@ -2439,9 +2439,9 @@ interp_macro(interp,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 Deliberate Syntax Error
 #endif					/* PORT */
 
-#if MACINTOSH || MVS || VM || VMS
+#if MVS || VM || VMS
    /* not included */
-#endif					/* MACINTOSH || ... */
+#endif					/* MVS || ... */
 
 #if DEBUG_INTERP
 void stkdump(op)

--- a/src/runtime/rmisc.r
+++ b/src/runtime/rmisc.r
@@ -2974,10 +2974,6 @@ Deliberate Syntax Error
    return (isascii(c) && isprint(c));
 #endif					/* MSDOS ... */
 
-#if MACINTOSH
-   return isprint(c);
-#endif					/* MACINTOSH */
-
 #if MVS || VM
    return isprint(c);
 #endif                                  /* MVS || VM */

--- a/src/runtime/rsys.r
+++ b/src/runtime/rsys.r
@@ -536,14 +536,6 @@ int n;
 #endif					/* NT */
 #endif					/* MSDOS */
 
-#if MACINTOSH
-   void MacDelay(int n);
-   DEC_NARTHREADS;
-   MacDelay(n);
-   INC_NARTHREADS_CONTROLLED;
-   return Succeeded;
-#endif					/* MACINTOSH */
-
 #if PORT || MVS || VM
    return Failed;
 #endif					/* PORT || ... */

--- a/tests/general/prepro.icn
+++ b/tests/general/prepro.icn
@@ -50,9 +50,7 @@ $endif
 
    # test that predefined symbols agree with &features
    # (if defined, first argument is 1, else it's null)
-   precheck(_ACORN,		"Acorn Archimedes")
    precheck(_CMS,		"CMS")
-   precheck(_MACINTOSH,		"Macintosh")
    precheck(_MACOS,		"MacOS")
    precheck(_MSDOS_386,		"MS-DOS/386")
    precheck(_MSDOS,		"MS-DOS")

--- a/uni/parser/preproce.icn
+++ b/uni/parser/preproce.icn
@@ -41,7 +41,6 @@ procedure predefs()
 	t[case s of {
 # _CMS # gone
 	    "CMS": "_CMS"
-	    "Macintosh":"_MACINTOSH"
 	    "MacOS":"_MACOS"
 	    "MS Windows NT":"_MS_WINDOWS_NT"
 	    "MS-DOS":"_MSDOS"

--- a/uni/unicon/preproce.icn
+++ b/uni/unicon/preproce.icn
@@ -41,7 +41,6 @@ procedure predefs()
 	t[case s of {
 # _CMS # gone
 	    "CMS": "_CMS"
-	    "Macintosh":"_MACINTOSH"
 	    "MacOS":"_MACOS"
 	    "MS Windows NT":"_MS_WINDOWS_NT"
 	    "MS-DOS":"_MSDOS"


### PR DESCRIPTION
The standard configuration scripts could still select it, but the MACINTOSH specific code has been removed and compilation errors will occur.