### PR TITLE
Complex class: Workaround Unicon -C problems.

### DIFF
--- a/uni/lib/complex.icn
+++ b/uni/lib/complex.icn
@@ -7,8 +7,6 @@
 
 package math
 
-import lang
-
 #<p>
 #  A complex number representation that supports overloading the
 #  basic numeric operators ("<tt>+</tt>","<tt>-</tt>",
@@ -21,7 +19,7 @@ import lang
 #  the <tt>--enable-ovld</tt> flag.  However, this class provides
 #  methods that can be invoked directly, as in: <tt>Complex(3,1).add(4)</tt></b>
 #</p>
-class Complex:Object(r:0,i:0)
+class Complex(r,i)
 
     #<p>Add a scalar or Complex to this complex number.
     #   Fails if right operator cannot be converted to Complex.
@@ -132,4 +130,7 @@ class Complex:Object(r:0,i:0)
        return Complex(::numeric(x),0)
     end
 
+    initially (pr,pi)
+       r := \pr | 0
+       i := \pi | 0
 end


### PR DESCRIPTION
The present optimising compiler has problems with the complex class. The workaround(s) are to remove the Object superclass and to provide an initially section to set the default values.
These changes can be reverted when the problems are solved.