### PR TITLE
Remove definition of MaxLevel.

### DIFF
--- a/doc/ib/appH.tex
+++ b/doc/ib/appH.tex
@@ -287,7 +287,7 @@ MaxHeader & IU & bytes offset at which the icode header will be found \\
 MaxHLoad & all & average hash table bucket length that triggers expansion \\
 MAXHOSTNAMELEN & U & maximum host name length (change to use
 	HOST\_NAME\_MAX from <limits.h>) \\
-MaxLevel & IU & Maximum levels (fragment, delete) \\
+{\gr MaxLevel} & {\gr IU} & {\gr Maximum levels (fragment, delete)} \\
 MaxListSlots & all & Maximum number of list slots per block, if any \\
 MaxLong & all & largest long integer \\
 MaxNegInt & all & string representation of smallest negative number \\

--- a/src/runtime/imain.r
+++ b/src/runtime/imain.r
@@ -541,12 +541,6 @@ void icon_setup(int argc, char **argv, int *ip)
    free(tmp);
    }
 
-#ifdef MaxLevel
-   maxilevel = 0;
-   maxplevel = 0;
-   maxsp = 0;
-#endif                                  /* MaxLevel */
-
 /*
  * Handle command line options.
 */


### PR DESCRIPTION
It isn't used anywhere. It's either a vestige of something that has been removed or it's the start of something that was never completed.