### PR TITLE
IPL: suppress clang's deprecated-non-prototype warning.

### DIFF
--- a/ipl/cfuncs/Makefile
+++ b/ipl/cfuncs/Makefile
@@ -14,6 +14,12 @@ ICONT = icont
 IFLAGS = -us
 ITRAN = $(ICONT) $(IFLAGS)
 
+# If clang, suppress W-deprecated-non-prototype warnings
+CC_VERSION := $(shell $(CC) --version)
+ifneq '' '$(findstring clang,$(CC_VERSION))'
+  CFLAGS +=  -Wno-deprecated-non-prototype
+endif
+
 # Macs should really use libcfunc.dylib, but libcfunc.so works just as well
 #  (and requires no alterations to other makefiles to accommodate the change to dylib).
 FUNCLIB = libcfunc.so


### PR DESCRIPTION
It was decided to retain the old style function declarations in the IPL. So we suppress the clang warnings about them.