### PR TITLE
Fix possible buffer overflow in rmsg.r

### DIFF
--- a/src/runtime/rmsg.r
+++ b/src/runtime/rmsg.r
@@ -545,7 +545,7 @@ void Msmtp(struct MFile* mf, dptr attr, int nattr)
 
    /* Parse attributes into the header */
    header[0] = '\0';
-   hleft = sizeof(header);
+   hleft = sizeof(header) - 1;
    for (i=0; i<nattr; i++) {
       if (!cnv:C_string(attr[i], s)) {
          abort();


### PR DESCRIPTION
The  Mhttp and Msmtp routines both use Maddtoheader() which uses strncat to fill up the buffer and append a trailing zero char after each append. Mhttp initialises hleft to sizeof(header) - 1, which leaves space for a terminating zero char, even if the header becomes full. Msmtp initialises hleft to sizeof(header), which means a buffer overflow is possible.