### PR TITLE
src: fix clang and Windows warnings and enable werror on both

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: windows-latest,  name: 'Windows 64-bit',  opt: '' }
+        -  { os: windows-latest,  name: 'Windows 64-bit',  opt: '--enable-werror' }
         #-  { os: windows-latest,  name: 'Windows 32-bit', opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
 
     defaults:
@@ -183,7 +183,7 @@ jobs:
       matrix:
         cfg:
         #-  { os: ubuntu-latest, name: 'Ubuntu 32-bit',  opt: '--host=i686-pc-linux-gnu' }
-        -  { os: ubuntu-latest, name: 'Clang',          opt: 'CC=clang CXX=clang++' }
+        -  { os: ubuntu-latest, name: 'Clang',          opt: 'CC=clang CXX=clang++ --enable-werror' }
         -  { os: ubuntu-latest, name: 'No Graphics',    opt: '--disable-graphics --enable-werror' }
         -  { os: ubuntu-latest, name: 'No 3D Graphics', opt: '--disable-graphics3d --enable-werror' }
         -  { os: ubuntu-latest, name: 'No Concurrency', opt: '--disable-concurrency --enable-werror' }

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -102,7 +102,7 @@ dlrgint.$(O): ../h/auto.h ../h/rproto.h ../h/rexterns.h ../h/rmacros.h ../h/rstr
 xwindow.$(O): ../h/auto.h ../h/graphics.h ../h/xwin.h
 
 rswitch.$(O): FORCE
-	$(SLNT) $(CC) $(CPPFLAGS) $(CFLAGS) -c rswitch.[cs]
+	$(SLNT) $(CC) $(CPPFLAGS) $(CFLAGS) -Wno-unused-command-line-argument -c rswitch.[cs]
 FORCE:
 
 distclean clean:

--- a/src/common/dconsole.c
+++ b/src/common/dconsole.c
@@ -157,10 +157,11 @@ unsigned char allchars[256] = {
  * fatalerr - disable error conversion and call run-time error routine.
  */
 void fatalerr(int n, dptr v)
-   {
+{
    IntVal(kywd_err) = 0;
    err_msg(n, v);
-   }
+   c_exit(0); /* unreachable; but makes the compiler happy happy */
+}
 
 struct b_list *alclist_0(uword size, uword nslots)
    {

--- a/src/runtime/keyword.r
+++ b/src/runtime/keyword.r
@@ -52,12 +52,9 @@ keyword{4} allocated
 end
 
 #if NT
-#if HAVE_TIMEZONE
+/* redefine deprected functions to fix warnings on Windows*/
 #define timezone _timezone
-#endif
-#if HAVE_TZNAME
 #define tzname _tzname
-#endif
 #endif
 
 "&clock - a string consisting of the current time of day"


### PR DESCRIPTION
silence a clang warning when compiling rswitch.s
fix Windows warnings
