### PR TITLE
Fix build errors on Windows when using --disable-graphics

### DIFF
--- a/src/common/dconsole.c
+++ b/src/common/dconsole.c
@@ -305,38 +305,6 @@ c_exit(1);
 }
 
 /*
- * qsearch(key,base,nel,width,compar) - binary search
- *
- *  A binary search routine with arguments similar to qsort(3).
- *  Returns a pointer to the item matching "key", or NULL if none.
- *  Based on Bentley, CACM 28,7 (July, 1985), p. 676.
- */
-
-char * qsearch (key, base, nel, width, compar)
-char * key;
-char * base;
-int nel, width;
-int (*compar)();
-{
-    int l, u, m, r;
-    char * a;
-
-    l = 0;
-    u = nel - 1;
-    while (l <= u) {
-        m = (l + u) / 2;
-        a = (char *) ((char *) base + width * m);
-        r = compar (a, key);
-        if (r < 0)
-            l = m + 1;
-        else if (r > 0)
-            u = m - 1;
-        else
-            return a;
-    }
-    return 0;
-}
-/*
  * c_get - convenient C-level access to the get function
  *  returns 0 on failure, otherwise fills in res
  */
@@ -1075,6 +1043,39 @@ int strncasecmp(char *s1, char *s2, int n)
 
 #endif                                  /* NTGCC */
 #endif                                  /* ConsoleWindow */
+
+/*
+ * qsearch(key,base,nel,width,compar) - binary search
+ *
+ *  A binary search routine with arguments similar to qsort(3).
+ *  Returns a pointer to the item matching "key", or NULL if none.
+ *  Based on Bentley, CACM 28,7 (July, 1985), p. 676.
+ */
+
+char * qsearch (key, base, nel, width, compar)
+char * key;
+char * base;
+int nel, width;
+int (*compar)();
+{
+    int l, u, m, r;
+    char * a;
+
+    l = 0;
+    u = nel - 1;
+    while (l <= u) {
+        m = (l + u) / 2;
+        a = (char *) ((char *) base + width * m);
+        r = compar (a, key);
+        if (r < 0)
+            l = m + 1;
+        else if (r > 0)
+            u = m - 1;
+        else
+            return a;
+    }
+    return 0;
+}
 
 int
 getenv_r(const char *name, char *buf, size_t len)

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -2054,6 +2054,7 @@ function{0,1} seek(f,o)
 end
 
 #ifdef PosixFns
+
 "system() - create a new process, optionally mapping its stdin/stdout/stderr."
 
 function{0,1} system(argv, d_stdin, d_stdout, d_stderr, mode)

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -2508,8 +2508,6 @@ function{0,1} select(files[nargs])
          BlkLoc(d) = (union block *) lp;
          tv.tv_sec = tv.tv_usec = 0;
          }
-#endif                                  /* Graphics */
-
 #if defined(PseudoPty) && defined(MSWindows)
       else if ((lps->size > 0) && ((lp = findactivepty(lps)) != NULL)) {
          d.dword = D_List;
@@ -2517,6 +2515,7 @@ function{0,1} select(files[nargs])
          tv.tv_sec = tv.tv_usec = 0;
          }
 #endif                                  /* PseudoPty && MSWindows */
+#endif                                  /* Graphics */
 
       if (n) {
         DEC_NARTHREADS;
@@ -2543,7 +2542,6 @@ function{0,1} select(files[nargs])
             d.dword = D_List;
             BlkLoc(d) = (union block *) lp;
             }
-#endif                                  /* Graphics */
 #if defined(PseudoPty) && defined(MSWindows)
          /*
           * if our select() could have taken any time, try ptys again
@@ -2553,6 +2551,7 @@ function{0,1} select(files[nargs])
             BlkLoc(d) = (union block *) lp;
             }
 #endif                                  /* PseudoPty */
+#endif                                  /* Graphics */
          }
       else if (ptv && (ptv->tv_sec || ptv->tv_usec)) {
          idelay(ptv->tv_sec * 1000 + ptv->tv_usec / 1000);

--- a/src/runtime/init.r
+++ b/src/runtime/init.r
@@ -1600,8 +1600,10 @@ void c_exit(int i)
 #endif
 
 #ifdef MSWindows
+#ifdef Graphics
    PostQuitMessage(0);
    while (wstates != NULL) pollevent();
+#endif                                  /* Graphics  */
 #endif                                  /* MSWindows */
 
 #if NT

--- a/src/runtime/rmswin.ri
+++ b/src/runtime/rmswin.ri
@@ -215,61 +215,6 @@ char *lookcmdname(char *buf, char *s)
   return buf;
 }
 
-int mswinsystem(char *s)
-{
-   int i, rv, j, background = 0;
-   char *s2, **argv, cmd[256], prefixed[384];
-   int argc;
-
-   if (s == NULL) return -1;
-   for(i=0; ((s[i] == ' ') || (s[i] == '\t')) ;i++) ;
-   if (s[i] == '\0') return -1;
-
-   s2 = strdup(s + i);
-   if (s2 == NULL) return -1;
-
-   for(j=strlen(s2)-1; j > 0 && (s2[j] == ' ' || s2[j] == '\t'); j--)
-      s2[j] = '\0';
-
-   /*
-    * if it is a "background task", launch using WinExec.
-    */
-   if ((j>0) && (s2[j] == '&')) {
-      s2[j] = '\0';
-      while (s2[--j] == ' ') s2[j] = '\0';
-
-      i = WinExec(s2, SW_SHOW);
-      if ( i >= 32 ) return 0;
-      return -1;
-      }
-
-   if (strchr(s, '>')) {
-      if (getenv_r("SystemRoot", prefixed, 384)) strcat(prefixed, "\\System32\\");
-      else prefixed[0] = '\0';
-      strcat(prefixed, "cmd /C "); strcat(prefixed, s);
-      s = prefixed;
-      }
-
-
-   /*
-    * launch using spawnvp
-    * and wait for _P_WAIT.  _P_WAIT's semantics do not seem to actually
-    * work some of the time; the program is launched but we don't wait for it.
-    * CmdParamToArgv() is called so as leave quoted arguments quoted, but
-    * spawnvp's command name argument (redundant with argv[0]) must not
-    * be quoted.
-    */
-      argc = CmdParamToArgv(s, &argv, 0);
-      if (argv[0][0] == '\"') strcpy(cmd, argv[0]+1);
-        else strcpy(cmd, argv[0]);
-      if (cmd[strlen(cmd)-1] == '\"') cmd[strlen(cmd)-1] = '\0';
-
-      rv = _spawnvp(_P_WAIT, cmd, (const char* const*) argv);
-      for(i=0; i<argc; i++) free(argv[i]);
-      free(argv);
-      return rv;
-}
-
 /*
  * wopen
  * If it returns NULL, per fsys.r, wopen() should set err_idx to one of:

--- a/src/runtime/rsys.r
+++ b/src/runtime/rsys.r
@@ -2100,3 +2100,60 @@ getenv_r(const char *name, char *buf, size_t len)
 }
 
 #endif                                  /* HAVE_LIBPTHREAD */
+
+#ifdef MSWindows
+int mswinsystem(char *s)
+{
+   int i, rv, j, background = 0;
+   char *s2, **argv, cmd[256], prefixed[384];
+   int argc;
+
+   if (s == NULL) return -1;
+   for(i=0; ((s[i] == ' ') || (s[i] == '\t')) ;i++) ;
+   if (s[i] == '\0') return -1;
+
+   s2 = strdup(s + i);
+   if (s2 == NULL) return -1;
+
+   for(j=strlen(s2)-1; j > 0 && (s2[j] == ' ' || s2[j] == '\t'); j--)
+      s2[j] = '\0';
+
+   /*
+    * if it is a "background task", launch using WinExec.
+    */
+   if ((j>0) && (s2[j] == '&')) {
+      s2[j] = '\0';
+      while (s2[--j] == ' ') s2[j] = '\0';
+
+      i = WinExec(s2, SW_SHOW);
+      if ( i >= 32 ) return 0;
+      return -1;
+      }
+
+   if (strchr(s, '>')) {
+      if (getenv_r("SystemRoot", prefixed, 384)) strcat(prefixed, "\\System32\\");
+      else prefixed[0] = '\0';
+      strcat(prefixed, "cmd /C "); strcat(prefixed, s);
+      s = prefixed;
+      }
+
+
+   /*
+    * launch using spawnvp
+    * and wait for _P_WAIT.  _P_WAIT's semantics do not seem to actually
+    * work some of the time; the program is launched but we don't wait for it.
+    * CmdParamToArgv() is called so as leave quoted arguments quoted, but
+    * spawnvp's command name argument (redundant with argv[0]) must not
+    * be quoted.
+    */
+      argc = CmdParamToArgv(s, &argv, 0);
+      if (argv[0][0] == '\"') strcpy(cmd, argv[0]+1);
+        else strcpy(cmd, argv[0]);
+      if (cmd[strlen(cmd)-1] == '\"') cmd[strlen(cmd)-1] = '\0';
+
+      rv = _spawnvp(_P_WAIT, cmd, (const char* const*) argv);
+      for(i=0; i<argc; i++) free(argv[i]);
+      free(argv);
+      return rv;
+}
+#endif                                  /* MSWindows */


### PR DESCRIPTION
The fix consists mostly of moving routines that are not graphics oriented to places that included them even if Graphics is not defined.