### PR TITLE
config: improve debug options/reporting, strip, musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure
-      run: ./configure CFLAGS=-fno-pie LDFLAGS=-no-pie --disable-iconc
+      run: ./configure --disable-iconc
       shell: alpine.sh {0}
 
     - name: Make

--- a/Makedefs.in
+++ b/Makedefs.in
@@ -40,9 +40,6 @@ LIBTP=libtp
 # Do we want to build iconc? If so, set to Iconc
 ICONCTARGET=@ICONCTARGET@
 
-# with strip
-DASHX=@DASHX@
-
 # If graphics is enabled
 GRAPHICS= @GRAPHICS@
 XL= @XL@
@@ -76,6 +73,8 @@ AR = ar
 MAKEINFO = makeinfo
 TEXI2DVI = texi2dvi
 RANLIB = ranlib
+
+STRIP=@STRIP@
 
 UNICONX=@UNICONX@
 UNICONWX=@UNICONWX@

--- a/configure
+++ b/configure
@@ -627,8 +627,8 @@ GL_LDFLAGS
 GL_CFLAGS
 JV_LDFLAGS
 PLUGINS
+STRIP
 DASHG
-DASHX
 DASHS
 SLNT
 CMNT
@@ -2977,28 +2977,39 @@ unicon_osrel=$OSREL
 case $host_os in
      *linux*)
         unicon_os="linux"
-
-	# if dist/version are not set, try to guess them
-	if test x$unicon_osdist = x ; then
-	   if test -f /etc/os-release ; then
-	      . /etc/os-release
-	      unicon_osdist=$NAME
-	      unicon_osrel=$VERSION_ID
-	   elif type lsb_release >/dev/null 2>&1; then
-	      unicon_osdist=$(lsb_release -si)
-	      unicon_osrel=$(lsb_release -sr)
-	   elif test -f /etc/lsb-release ; then
-	      . /etc/lsb-release
-	      unicon_osdist=$DISTRIB_ID
-	      unicon_osrel=$DISTRIB_RELEASE
-	   elif test -f /etc/debian_version ; then
-	      unicon_osdist=Debian
-	      unicon_osrel=$(cat /etc/debian_version)
-	   fi
-	fi
+        # if dist/version are not set, try to guess them
+        if test x$unicon_osdist = x ; then
+            if test -f /etc/os-release ; then
+               . /etc/os-release
+               unicon_osdist=$NAME
+               unicon_osrel=$VERSION_ID
+            elif type lsb_release >/dev/null 2>&1; then
+               unicon_osdist=$(lsb_release -si)
+               unicon_osrel=$(lsb_release -sr)
+            elif test -f /etc/lsb-release ; then
+               . /etc/lsb-release
+               unicon_osdist=$DISTRIB_ID
+               unicon_osrel=$DISTRIB_RELEASE
+            elif test -f /etc/debian_version ; then
+               unicon_osdist=Debian
+               unicon_osrel=$(cat /etc/debian_version)
+            fi
+        fi
 
 
 $as_echo "#define UNIX 1" >>confdefs.h
+
+
+        case $host_os in
+           *musl*)
+
+$as_echo "#define __MUSL__ 1" >>confdefs.h
+
+            MUSLFLG="-D__MUSL__"
+            CFLAGS="-fno-pie $CFLAGS"
+            LDFLAGS=" -no-pie $LDFLAGS"
+            ;;
+         esac
 
         ;;
      *solaris*)
@@ -3020,7 +3031,7 @@ $as_echo "#define UNIX 1" >>confdefs.h
 
         ;;
      *bsd*)
-       # freebsd for now
+        # freebsd for now
         unicon_os="freebsd"
 
 $as_echo "#define UNIX 1" >>confdefs.h
@@ -3200,6 +3211,7 @@ else
   thin=no
 fi
 
+
 # Check whether --enable-debug was given.
 if test "${enable_debug+set}" = set; then :
   enableval=$enable_debug; debug=yes
@@ -3223,10 +3235,11 @@ fi
 
 # Check whether --enable-devmode was given.
 if test "${enable_devmode+set}" = set; then :
-  enableval=$enable_devmode; devmode=yes
+  enableval=$enable_devmode; devmode=$enableval
 else
   devmode=no
 fi
+
 
 # Check whether --enable-werror was given.
 if test "${enable_werror+set}" = set; then :
@@ -3241,6 +3254,7 @@ if test "${enable_warnings+set}" = set; then :
 else
   warn=no
 fi
+
 
 # Check whether --enable-uniconx was given.
 if test "${enable_uniconx+set}" = set; then :
@@ -4741,24 +4755,30 @@ else
   UNICONWT=wicont
 fi
 
-if test x"$devmode" = x"yes" ; then
+if test x"$devmode" = x"yes" || test x"$devmode" = x"all"; then
   debug=yes
   warn=yes
 
 $as_echo "#define DEVELOPMODE 1" >>confdefs.h
 
+  if test x"$devmode" = x"all"; then
+   debugheap=yes
+   verifyheap=yes
+  fi
 fi
 
 if test x"$debugheap" = x"yes" ; then
 
 $as_echo "#define DebugHeap 1" >>confdefs.h
 
+  debugheapreport="DebugHeap"
 fi
 
 if test x"$verifyheap" = x"yes" ; then
 
 $as_echo "#define VerifyHeap 1" >>confdefs.h
 
+    verifyheapreport="VerifyHeap"
 fi
 
 if test x"$udbtools" = x"yes" ; then
@@ -7022,7 +7042,7 @@ esac
 
 OBJ=o
 CFUNCTARGET="cfun"
-CFDYN="-fPIC "
+CFDYN="-fPIC $MUSLFLG "
 LDDYN="-shared "
 SO=so
 # OS specific flags go here
@@ -7042,7 +7062,6 @@ case $unicon_host in
         ;;
      *macos*)
        LDDYN="-Xlinker -undefined -Xlinker dynamic_lookup -shared "
-       DASHX=-x
        RLIBS="-ldl "
 	;;
      *windows*)
@@ -7080,9 +7099,14 @@ if test "x$iconc" = "xyes" || test "x$iconc" = "xon" ; then
        ICONCTARGET=Iconc
 fi
 
-
 if test "x$orig_cflags" != "x" ; then
   CFLAGS="$CFLAGS $orig_cflags"
+fi
+
+if test x"$debug" = x"yes" ; then
+  STRIP="@\#strip"
+else
+  STRIP=strip
 fi
 
 
@@ -17122,9 +17146,11 @@ LDFLAGS  :$LDFLAGS
 LIBS     : $LIBS
 CXX      :  $CXX  (Required only with FTGL and VOIP)
 CXXFLAGS : $CXXFLAGS
-prefix	 :  $prefix
+CFDYN    : $CFDYN
+LDDYN    : $LDDYN
+prefix   :  $prefix
 Verbose  :  $verbosebuild
-Debug    :  $debug
+Debug    :  $debug $debugheapreport $verifyheapreport
 Warnings :  $warn
 Werror   :  $werror
 Devmode  :  $devmode

--- a/configure.ac
+++ b/configure.ac
@@ -47,52 +47,61 @@ unicon_osrel=$OSREL
 case $host_os in
      *linux*)
         unicon_os="linux"
+        # if dist/version are not set, try to guess them
+        if test x$unicon_osdist = x ; then
+            if test -f /etc/os-release ; then
+               . /etc/os-release
+               unicon_osdist=$NAME
+               unicon_osrel=$VERSION_ID
+            elif type lsb_release >/dev/null 2>&1; then
+               unicon_osdist=$(lsb_release -si)
+               unicon_osrel=$(lsb_release -sr)
+            elif test -f /etc/lsb-release ; then
+               . /etc/lsb-release
+               unicon_osdist=$DISTRIB_ID
+               unicon_osrel=$DISTRIB_RELEASE
+            elif test -f /etc/debian_version ; then
+               unicon_osdist=Debian
+               unicon_osrel=$(cat /etc/debian_version)
+            fi
+        fi
 
-	# if dist/version are not set, try to guess them
-	if test x$unicon_osdist = x ; then
-	   if test -f /etc/os-release ; then
-	      . /etc/os-release
-	      unicon_osdist=$NAME
-	      unicon_osrel=$VERSION_ID
-	   elif type lsb_release >/dev/null 2>&1; then
-	      unicon_osdist=$(lsb_release -si)
-	      unicon_osrel=$(lsb_release -sr)
-	   elif test -f /etc/lsb-release ; then
-	      . /etc/lsb-release
-	      unicon_osdist=$DISTRIB_ID
-	      unicon_osrel=$DISTRIB_RELEASE
-	   elif test -f /etc/debian_version ; then
-	      unicon_osdist=Debian
-	      unicon_osrel=$(cat /etc/debian_version)
-	   fi
-	fi
+        AC_DEFINE([UNIX], [1], [Unix platform])
 
-	AC_DEFINE([UNIX], [1], [Unix platform])
+        case $host_os in
+           *musl*)
+            AC_DEFINE([__MUSL__], [1], [MUSL C Library])
+            MUSLFLG="-D__MUSL__"
+            CFLAGS="-fno-pie $CFLAGS"
+            LDFLAGS=" -no-pie $LDFLAGS"
+            ;;
+         esac
+
         ;;
      *solaris*)
         unicon_os="solaris"
-	AC_DEFINE([UNIX], [1], [Unix platform])
-	AC_DEFINE([SOLARIS], [1], [Solaris OS])
-	AC_DEFINE([SUN], [1], [Sun platform])
+        AC_DEFINE([UNIX], [1], [Unix platform])
+        AC_DEFINE([SOLARIS], [1], [Solaris OS])
+        AC_DEFINE([SUN], [1], [Sun platform])
         ;;
      *aix*)
         unicon_os="aix"
-	AC_DEFINE([UNIX], [1], [Unix platform])
+        AC_DEFINE([UNIX], [1], [Unix platform])
         ;;
      *bsd*)
-       # freebsd for now
+        # freebsd for now
         unicon_os="freebsd"
-	AC_DEFINE([UNIX], [1], [Unix platform])
-	AC_DEFINE([FreeBSD], [1], [FreeBSD OS])
+        AC_DEFINE([UNIX], [1], [Unix platform])
+        AC_DEFINE([FreeBSD], [1], [FreeBSD OS])
         ;;
      *darwin*)
         unicon_os="macos"
-	AC_DEFINE([UNIX], [1], [Unix platform])
-	AC_DEFINE([MacOS], [1], [Mac OS])
+        AC_DEFINE([UNIX], [1], [Unix platform])
+        AC_DEFINE([MacOS], [1], [Mac OS])
         ;;
      *cygwin* | *mingw* | *msys*)
         unicon_os="windows"
-	AC_DEFINE([Windows], [1], [Windows platform])
+        AC_DEFINE([Windows], [1], [Windows platform])
         ;;
 esac
 
@@ -170,6 +179,7 @@ AC_ARG_ENABLE([htmldoc],
 AC_ARG_ENABLE([thin],
 	[AS_HELP_STRING([--enable-thin], [Do a minimalist build disabling non critical features])],
 			[thin=yes], [thin=no])
+
 AC_ARG_ENABLE([debug],
 	[AS_HELP_STRING([--enable-debug], [Add debugging symbols])],
 			[debug=yes], [debug=no])
@@ -181,13 +191,15 @@ AC_ARG_ENABLE([verifyheap],
 			[verifyheap=yes], [verifyheap=no])
 AC_ARG_ENABLE([devmode],
 	[AS_HELP_STRING([--enable-devmode], [Developer mode: turn on warnings and debugging options])],
-			[devmode=yes], [devmode=no])
+			[devmode=$enableval], [devmode=no])
+
 AC_ARG_ENABLE([werror],
 	[AS_HELP_STRING([--enable-werror], [Change compiler warnings to errors])],
 			[werror=yes], [werror=no])
 AC_ARG_ENABLE([warnings],
 	[AS_HELP_STRING([--enable-warnings], [Turn on most types of compiler warnings])],
 			[warn=yes], [warn=no])
+
 AC_ARG_ENABLE([uniconx],
 	[AS_HELP_STRING([--enable-uniconx], [Change executable names to co-exist with Icon])],
 			[uniconx=yes], [uniconx=no])
@@ -248,18 +260,24 @@ else
   UNICONWT=wicont
 fi
 
-if test x"$devmode" = x"yes" ; then
+if test x"$devmode" = x"yes" || test x"$devmode" = x"all"; then
   debug=yes
   warn=yes
   AC_DEFINE([DEVELOPMODE], [1], [Developer Mode])
+  if test x"$devmode" = x"all"; then
+   debugheap=yes
+   verifyheap=yes
+  fi
 fi
 
 if test x"$debugheap" = x"yes" ; then
   AC_DEFINE([DebugHeap], [1], [Debug Heap])
+  debugheapreport="DebugHeap"
 fi
 
 if test x"$verifyheap" = x"yes" ; then
   AC_DEFINE([VerifyHeap], [1], [Verify Heap])
+    verifyheapreport="VerifyHeap"
 fi
 
 if test x"$udbtools" = x"yes" ; then
@@ -354,7 +372,7 @@ esac
 
 OBJ=o
 CFUNCTARGET="cfun"
-CFDYN="-fPIC "
+CFDYN="-fPIC $MUSLFLG "
 LDDYN="-shared "
 SO=so
 # OS specific flags go here
@@ -374,7 +392,6 @@ case $unicon_host in
         ;;
      *macos*)
        LDDYN="-Xlinker -undefined -Xlinker dynamic_lookup -shared "
-       DASHX=-x
        RLIBS="-ldl "
 	;;
      *windows*)
@@ -412,9 +429,14 @@ if test "x$iconc" = "xyes" || test "x$iconc" = "xon" ; then
        ICONCTARGET=Iconc
 fi
 
-
 if test "x$orig_cflags" != "x" ; then
   CFLAGS="$CFLAGS $orig_cflags"
+fi
+
+if test x"$debug" = x"yes" ; then
+  STRIP="@\#strip"
+else
+  STRIP=strip
 fi
 
 AC_SUBST(UNICONX)
@@ -673,8 +695,8 @@ fi
   AC_SUBST(CMNT)
   AC_SUBST(SLNT)
   AC_SUBST(DASHS)
-  AC_SUBST(DASHX)
   AC_SUBST(DASHG)
+  AC_SUBST(STRIP)
 
 if test -f src/asm/$unicon_host-rswitch.s; then
     echo "Native coswitch detected"
@@ -1050,9 +1072,11 @@ LDFLAGS  :$LDFLAGS
 LIBS     : $LIBS
 CXX      :  $CXX  (Required only with FTGL and VOIP)
 CXXFLAGS : $CXXFLAGS
-prefix	 :  $prefix
+CFDYN    : $CFDYN
+LDDYN    : $LDDYN
+prefix   :  $prefix
 Verbose  :  $verbosebuild
-Debug    :  $debug
+Debug    :  $debug $debugheapreport $verifyheapreport
 Warnings :  $warn
 Werror   :  $werror
 Devmode  :  $devmode

--- a/ipl/cfuncs/fpoll.c
+++ b/ipl/cfuncs/fpoll.c
@@ -63,8 +63,6 @@ int fpoll(int argc, descriptor *argv)	/*: await data from file */
    /* there's no legal way to do this in C; we cheat */
    /* cheating leads to portability issues, skip this on MUSL/ALPINE */
 
-#define __MUSL__
-
 #ifdef __MUSL__
       /*FIXME: this is always defined */
       /* insert your implementation here */

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -27,7 +27,7 @@ TMPdoincl.exe:     doincl.$(O)
 patchstr$(EXE): patchstr.$(O)
 		$(CC) $(CPPFLAGS) $(LDFLAGS) -o patchstr patchstr.$(O)
 		$(CP) patchstr$(EXE) ../../bin/
-		strip ../../bin/patchstr$(EXE)
+		$(STRIP) ../../bin/patchstr$(EXE)
 
 # iconx needs NTConsole to be defined/set,
 # make this a dependency for iconx to set it

--- a/src/h/auto.in
+++ b/src/h/auto.in
@@ -464,9 +464,9 @@
 /* If using the C implementation of alloca, define if you know the
    direction of stack growth for your system; otherwise it will be
    automatically deduced at runtime.
-        STACK_DIRECTION > 0 => grows toward higher addresses
-        STACK_DIRECTION < 0 => grows toward lower addresses
-        STACK_DIRECTION = 0 => direction of growth unknown */
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
 #undef STACK_DIRECTION
 
 /* Define to 1 if you have the ANSI C header files. */
@@ -539,6 +539,9 @@
 
 /* Define to 1 if you need to in order for `stat' and other things to work. */
 #undef _POSIX_SOURCE
+
+/* MUSL C Library */
+#undef __MUSL__
 
 /* bindir */
 #undef config_bindir

--- a/src/iconc/Makefile
+++ b/src/iconc/Makefile
@@ -20,7 +20,7 @@ all:		$(UNICONC)
 $(UNICONC):		$(OBJS) ../../rt/lib/libucommon.a
 		$(CC) $(LDFLAGS) -o $(UNICONC)  $(OBJS) -lucommon
 		$(CP) $(UNICONC)$(EXE) ../../bin
-		strip ../../bin/$(UNICONC)$(EXE)
+		$(STRIP) ../../bin/$(UNICONC)$(EXE)
 
 $(OBJS):	../h/config.h ../h/cpuconf.h ../h/cstructs.h ../h/define.h\
 		../h/proto.h ../h/mproto.h ../h/typedefs.h ../h/gsupport.h \

--- a/src/icont/Makefile
+++ b/src/icont/Makefile
@@ -24,8 +24,8 @@ all:		$(UNICONT)
 
 $(UNICONT) $(ICONTEXE):		 $(NTCONDEP) $(OBJS) ../../rt/lib/libucommon.a
 		$(CC) $(CFLAGS) $(LDFLAGS) -o $(UNICONT) $(OBJS) -lucommon $(LIBS)
-		cp $(PGMS) ../../bin
-		strip ../../bin/$(PGMS)
+		$(CP) $(PGMS) ../../bin
+		$(STRIP) ../../bin/$(PGMS)
 
 $(UNICONWT) $(WICONTEXE): WNTCON $(OBJS) ../../rt/lib/libucommon.a common
 	$(CC) -Wl,--subsystem,windows $(LDFLAGS) -o $(UNICONWT) -mwindows $(OBJS) $(WOBJS)  -lucommon -lwuconsole -lwinmm $(LIBS) $(WGLIBS)

--- a/src/iyacc/Makefile
+++ b/src/iyacc/Makefile
@@ -47,8 +47,8 @@ all:		$(PROGRAM)
 $(PROGRAM):     $(OBJS) $(LIBS)
 		@echo -n "Loading $(PROGRAM) ... "
 		@$(LINKER) $(LDFLAGS) -o $(PROGRAM) $(OBJS) $(LIBS)
-		@cp $(PROGRAM) ../../bin/
-		strip ../../bin/$(PROGRAM)
+		@$(CP) $(PROGRAM) ../../bin/
+		$(STRIP) ../../bin/$(PROGRAM)
 		@cd test; $(MAKE)
 		@echo "done"
 

--- a/src/preproc/Makefile
+++ b/src/preproc/Makefile
@@ -16,7 +16,7 @@ DOT_H = preproc.h pproto.h ptoken.h ../h/define.h ../h/config.h\
 pp: pmain.o $(OBJS) ../../rt/lib/libucommon.a
 	$(CC) $(CFLAGS) $(LDFLAGS) -o pp pmain.o $(OBJS) -lucommon
 	$(CP) pp ../../bin
-	-strip ../../bin/pp
+	$(STRIP) ../../bin/pp
 
 %.o: %.c
 	$(CMNT)@echo "   [PREPROC] $<"

--- a/src/rtt/Makefile
+++ b/src/rtt/Makefile
@@ -24,7 +24,7 @@ all:	urtt$(EXE)
 urtt$(EXE):	$(OBJ)
 	$(CC) $(LDFLAGS) -o urtt $(OBJ) -lucommon
 	$(CP) urtt$(EXE) ../../bin/
-	strip ../../bin/urtt$(EXE)
+	$(STRIP) ../../bin/urtt$(EXE)
 
 library:	$(OBJ)
 		$(RM) -r rtt.a

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -65,13 +65,13 @@ interp_all: update_rev
 $(UNICONX) $(ICONXEXE): $(NTCONDEP) $(OBJS) ../../rt/lib/libucommon.a ../../rt/lib/libuconsole.a ../../rt/lib/libgdbm.a ../../rt/lib/libtp.a
 	$(CC) $(LDFLAGS) $(WSUBSYS) $(WSTKLDFLAG) $(RLINK) -o $(UNICONX)  $(OBJS) $(XLIBS) $(RLIBS) $(XL) $(LIBSTDCPP) $(WGLIBS) -luconsole
 	cp $(UNICONX)$(EXE) ../../bin
-	strip $(DASHX) ../../bin/$(UNICONX)$(EXE);
+	$(STRIP) ../../bin/$(UNICONX)$(EXE);
 
 # on windows, always add WNTCON dependency to set NTCONSOLE accordingly
 $(UNICONWX) $(WICONEXE): WNTCON $(OBJS) ../../rt/lib/libucommon.a ../../rt/lib/libwuconsole.a ../../rt/lib/libgdbm.a ../../rt/lib/libtp.a
 	$(CC) $(LDFLAGS) -Wl,--subsystem,windows $(WSTKLDFLAG) $(RLINK) -o $(UNICONWX)  $(OBJS) $(XLIBS) $(RLIBS) $(XL) $(LIBSTDCPP) $(WGLIBS) -lwuconsole
 	cp $(UNICONWX)$(EXE) ../../bin
-	strip $(DASHX) ../../bin/$(UNICONWX)$(EXE);
+	$(STRIP) ../../bin/$(UNICONWX)$(EXE);
 
 # prepare the icon for the executables
 icon.$(O):


### PR DESCRIPTION
* `--enable-devmode=all` now enables DebugHeap and DebugVerify
* DebugHeap/Verify are reported as part of the config summary
*  Report `CFDYN` and `LDDYN` in config summary
* Don't strip in debug mode
* Detect MUSL C library
* MUSL needs `no-pie`