### PR TITLE
Fix call to open() on a database.

### DIFF
--- a/uni/lib/database.icn
+++ b/uni/lib/database.icn
@@ -32,7 +32,7 @@ class Database : Object (dsn, db_table, db, dbu, blockDepth)
                password)   # Password for that user.
       static real_open
       initial real_open := ::proc("open")
-      return \accessDb(real_open(dsn,"o",db_table,user,password))
+      return \accessDb(real_open(db_table,"o",user,password))
    end
 
    #<p>


### PR DESCRIPTION
To be honest, I don't understand how the original version ever worked as the arguments to open() aren't correct according to the documentation.  Yet it used to work but now doesn't.  This new version fixes that.