### PR TITLE
Clarify the behaviour of ready() in the Language Reference.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -3091,10 +3091,10 @@ very large files.
 
 \noindent
 \index{ready(f,i)}\texttt{ready(f,i)} reads up to \texttt{i} characters
-from file \texttt{f}. It returns immediately with available data and
+from file \texttt{f}. If \texttt{i} is positive it returns immediately with available data or
 fails if no data is available. If \texttt{i} is 0, \texttt{ready()}
-returns all available input. It is not currently implemented for window
-values.
+returns all available input or an empty string if no data is available.
+It is not currently implemented for window values.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{real}


### PR DESCRIPTION
It's possible to read the present description as specifying that ready() always fails if there is no input available. This clarifies that failure can only occur if the second parameter is not zero.