### PR TITLE
Document the fourth parameter of spawn() in the language reference

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -3332,14 +3332,14 @@ come before those that do have an \texttt{i}'th field.
 \bigskip\hrule\vspace{0.1cm}
 \index{spawn}
 \noindent
-{\bf spawn(CE, i, i) : thread } \hfill {\bf launch asynchronous thread}
+{\bf spawn(CE, i, i, i) : thread } \hfill {\bf launch asynchronous thread}
 
 \noindent
 \index{spawn()}\texttt{spawn(ce)} launches co-expression \texttt{ce} as an
 asynchronous thread that will execute concurrently with the current
-co-expression. The two optional integers specify the memory in bytes
-allocated for the thread's block and string regions. The defaults are 10\%
-of the main thread heap size.
+co-expression. The three optional integers specify the memory in bytes
+allocated for the thread's block and string regions and stack size.
+The defaults are 10\% of the corresponding sizes for the main thread.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{sql}


### PR DESCRIPTION
Also clarify that the defaults are based on the corresponding sizes for the main thread (rather than all being based on heap size).