### PR TITLE
Correct f6620ef5 (Remove a development diagnostic from the Unicon com…

### DIFF
--- a/uni/unicon/unigram.y
+++ b/uni/unicon/unigram.y
@@ -846,7 +846,7 @@ neregex3:  IDENT
                     $2.s := " " || $2.s
                     }
                  }
-                 else { /* write("[ followed by ", type($2), " so not checking for space") */}
+                 # else write("[ followed by ", type($2), " so not checking for space")
               }
         | LBRACK CARET brackchars RBRACK { $$ := node("notany", $1, $2, $3, $4) }
         | BACKSLASH neregex { $$ := node("escape", $1, $2) }


### PR DESCRIPTION
…piler).

The original fix assumed the output language from unigram.y was C, so it used the C comment syntax to remove code. The actual output language is Unicon, so the Unicon comment syntax must be used.