### PR TITLE
Correct the use of find_method in the plugin api method.

### DIFF
--- a/plugins/src/SHA/shalib.icn
+++ b/plugins/src/SHA/shalib.icn
@@ -119,9 +119,9 @@ class SecureHash : uso::USO (
 # ----------------------------------------
 method api()
    return [
-           lang::find_method("Sha"),
-           lang::find_method("Restart"),
-           lang::find_method("test")
+           lang::find_method(self,"Sha"),
+           lang::find_method(self,"Restart"),
+           lang::find_method(self,"test")
            ]
 end
 

--- a/plugins/src/bitman/bitman.icn
+++ b/plugins/src/bitman/bitman.icn
@@ -136,16 +136,16 @@ class Bitman : uso::USO()
    # ----------------------------------------
    method api()
       return [
-              lang::find_method("bor"),
-              lang::find_method("bxor"),
-              lang::find_method("band"),
-              lang::find_method("bcom"),
-              lang::find_method("bshift"),
-              lang::find_method("ushift"),
-              lang::find_method("bit"),
-              lang::find_method("bits"),
-              lang::find_method("brot"),
-              lang::find_method("test")
+              lang::find_method(self,"bor"),
+              lang::find_method(self,"bxor"),
+              lang::find_method(self,"band"),
+              lang::find_method(self,"bcom"),
+              lang::find_method(self,"bshift"),
+              lang::find_method(self,"ushift"),
+              lang::find_method(self,"bit"),
+              lang::find_method(self,"bits"),
+              lang::find_method(self,"brot"),
+              lang::find_method(self,"test")
               ]
    end
 

--- a/plugins/src/sqlite/sqlite.icn
+++ b/plugins/src/sqlite/sqlite.icn
@@ -454,18 +454,18 @@ class SQLite : uso::USO (db, transactions, mtx, waitSecs, cachedErr)
    # ----------------------------------------
    method api()
       return [
-              lang::find_method("BEGIN"),
-              lang::find_method("END"),
-              lang::find_method("ROLLBACK"),
-              lang::find_method("Close"),
-              lang::find_method("ErrMsg"),
-              lang::find_method("Exec"),
-              lang::find_method("SQL_Row"),
-              lang::find_method("SQL_As_List"),
-              lang::find_method("SQL_As_Table"),
-              lang::find_method("SQL_As_Set"),
-              lang::find_method("Rows"),
-              lang::find_method("isTable")
+              lang::find_method(self,"BEGIN"),
+              lang::find_method(self,"END"),
+              lang::find_method(self,"ROLLBACK"),
+              lang::find_method(self,"Close"),
+              lang::find_method(self,"ErrMsg"),
+              lang::find_method(self,"Exec"),
+              lang::find_method(self,"SQL_Row"),
+              lang::find_method(self,"SQL_As_List"),
+              lang::find_method(self,"SQL_As_Table"),
+              lang::find_method(self,"SQL_As_Set"),
+              lang::find_method(self,"Rows"),
+              lang::find_method(self,"isTable")
               ]
    end
 


### PR DESCRIPTION
The first parameter of find_method() must be an object, which was missing in the SHA, Bitman and SQLite plugins.