### PR TITLE
Fix build failure on macOS with Apple's arm processor.

### DIFF
--- a/src/xpm/lib/xpm.h
+++ b/src/xpm/lib/xpm.h
@@ -57,7 +57,10 @@
 #define XpmRevision 11
 #define XpmIncludeVersion ((XpmFormat * 100 + XpmVersion) * 100 + XpmRevision)
 
+/* Check we aren't running macOS on Apple's processors */
+#if !(defined(__APPLE__) && defined(__arm64))
 #define _POSIX_C_SOURCE 200809L
+#endif /* macOS on Apple silicon */
 
 #ifdef FOR_MSW
 # define SYSV                   /* uses memcpy string.h etc. */


### PR DESCRIPTION
If _POSIX_C_SOURCE is defined, it suppresses the inclusion of machine/_types.h which causes wait.h to fail because
__DARWIN_BYTE_ORDER and __DARWIN_LITTLE_ENDIAN and __DARWIN_BIG_ENDIAN are all undefined.