### PR TITLE
Fix ivib to cope with changes in commit 7d4093ae.

### DIFF
--- a/uni/ide/ivib/main.icn
+++ b/uni/ide/ivib/main.icn
@@ -286,6 +286,7 @@ class Main : CommonDialog(
    method custom_show(a)
       local s, f, c
       self.args := a
+      self.set_abs_coords(0,0)
       show()
       dispatcher.add(self)
       if *self.args > 0  then {


### PR DESCRIPTION
7d4093ae changed the compute_absolutes() method in the Dialog class. A side effect of this change is that the coordinates of ivib's main dialog were no longer set to (0,0) before the dialog is displayed by custom_show(), which led to extra space in the dialog window (and an ivib crash under some circumstances).

The smallest, and probably safest, fix is to set the coordinates explicitly in the custom_show() method.