### PR TITLE
Correct typos in the language reference section of the book.

### DIFF
--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -5580,8 +5580,8 @@ column an operator is placed in, is not significant).
                            & \e1\$\etxt{id1}.\etxt{id2}(\e2 \etc)\\
 {}[:~\e{}~:]    &\\
 \mcc{< \etxt{regexp} >}{(regular expressions have different precedence rules)}
-@<              & @>\\
-@<{}<           & @>{}>\\
+<@              & @>\\
+<{}<@           & @>{}>\\
 \separator
 not \e{}        &     {\textbar} \e{}\\
 ! \e{}          &     * \e{}\\
@@ -5590,8 +5590,8 @@ not \e{}        &     {\textbar} \e{}\\
 . \e{}          &     ++ \e{}\\
 ? \e{}          &     \verb/~/ \e{}\\
 \verb/^/ \e{}   &     {\tt @} \e{}\\
-@> \e()         &     @>{}> \e{}\\
-@< \e{}         &     @<{}< \e{}\\
+@> \e{}         &     @>{}> \e{}\\
+<@ \e{}         &     <{}<@ \e{}\\
 || \e{}         &     ||| \e{}\\
 -{}- \e{}       &     ** \e{}\\
 = \e{}          &     \verb/~/= \e{}\\
@@ -5602,10 +5602,10 @@ not \e{}        &     {\textbar} \e{}\\
 \e1 {\textbackslash} \e2 &\\
 \e1 {\tt @} \e2 &     \e1 ! \e2\\
 \e1  @> \e2     &    \e1 @>{}> \e2\\
-\e1  @< \e2     &    \e1 @<{}< \e2\\
+\e1  <@ \e2     &    \e1 <{}<@ \e2\\
 \separator
 \e{} @>         &     \e{} @>{}>\\
-\e{} @<         &     \e{} @<{}<\\
+\e{} <@         &     \e{} <{}<@\\
 \separator
 % [DonW] /verb cannot be used in the arg of another command, at least,
 % not without a lot of jiggery-pokery, so this is the best we can do


### PR DESCRIPTION
Correct the name of the receive operators (from @< and @<< to <@ and <<@). Remove a spurious pair of parentheses.