### PR TITLE
Fix documentation of &clock and &dateline.

### DIFF
--- a/doc/book/diffs.tex
+++ b/doc/book/diffs.tex
@@ -6,13 +6,19 @@ Unicon. Since the language has myriad additions covered by the whole book,
 the emphasis of this page is on {\em incompatibilities\/} that might
 require changes to existing Icon programs.
 
-\section{Extensions to Functions and Operators}
+\section{Extensions to Functions, Operators and Keywords}
 
 Unicon broadens the meaning of certain pre-existing functions where it
 is consistent and unambiguous to do so. These extensions revolve
 primarily around the list type. For example,
 \index{insert()}\texttt{insert()} allows insertion into the middle of a
 list, \texttt{reverse()} reverses a list, and so forth.
+
+The keywords \texttt{\&clock}\index{\&clock} and
+\texttt{\&dateline}\index{\&dateline}
+have been extended to generate timezone information. The extensions
+may alter the behavour of Icon programs that use these keywords in a
+context where failure is possible.
 
 \section{Objects}
 

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -317,11 +317,11 @@ the ASCII characters.
 
 \bigskip\hrule\vspace{0.1cm}
 \noindent
-{\bf \&clock : string } \hfill {\bf time of day}
+{\bf \&clock : string* } \hfill {\bf time of day}
 
 \noindent
-\texttt{\&clock} produces a string consisting of the current
-\index{time of day \&clock}time of day in hh:mm:ss format.
+\texttt{\&clock} generates two strings, consisting of the current
+\index{time of day \&clock}time of day (in hh:mm:ss format) and the time zone.
 See also keyword \texttt{\&now}.
 
 \bigskip\hrule\vspace{0.1cm}
@@ -368,11 +368,11 @@ co-expression that is currently executing.
 
 \bigskip\hrule\vspace{0.1cm}
 \noindent
-{\bf \&dateline : string } \hfill {\bf time stamp}
+{\bf \&dateline : string* } \hfill {\bf time stamp}
 
 \noindent
-\index{time stamp}\texttt{\&dateline} produces a human-readable time
-stamp that includes the day of the week, the date, and the current
+\index{time stamp}\texttt{\&dateline} generates two strings, consisting of a human-readable time
+stamp and the time zone. The time stamp includes the day of the week, the date, and the current
 time, down to the minute.
 
 \bigskip\hrule\vspace{0.1cm}


### PR DESCRIPTION
These keywords are generators.  Add the incompatibility (with Icon) to appendix E of the Unicon book.