### PR TITLE
ci: win 2025 images no longer include inno setup, stick with 2022

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: windows-latest,  name: 'Windows_64-bit',  opt: '--disable-iconc' }
+        -  { os: windows-2022,  name: 'Windows_64-bit',  opt: '--disable-iconc' }
         #-  { os: windows-latest,  name: 'Windows_32-bit', opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
 
     defaults:


### PR DESCRIPTION
Windows 2025 github images don't include InnoSetup. For now, stick with 2022 image. 