### PR TITLE
Improve accuracy of is_prime procedure

### DIFF
--- a/uni/lib/fastprime.icn
+++ b/uni/lib/fastprime.icn
@@ -43,14 +43,14 @@ procedure is_prime(n, precision)
     (d := n-1, s := 0)
     while d%2 = 0 do (d /:= 2, s +:= 1)
     # Returns exact according to http://primes.utm.edu/prove/prove2_3.html
-    if n < 1373653 then return  primetest(n, known_primes[1:2], d, s)
-    if n < 25326001 then return primetest(n, known_primes[1:3], d, s)
+    if n < 1373653 then return  primetest(n, known_primes[1:3], d, s)
+    if n < 25326001 then return primetest(n, known_primes[1:4], d, s)
     if n < 118670087467 then
-        if n ~= 3215031751 then return primetest(n, known_primes[1:4], d, s)
+        if n ~= 3215031751 then return primetest(n, known_primes[1:5], d, s)
         else fail
-    if n < 2152302898747 then return primetest(n, known_primes[1:5], d, s)
-    if n < 3474749660383 then return primetest(n, known_primes[1:6], d, s)
-    if n < 341550071728321 then return primetest(n, known_primes[1:7], d, s)
+    if n < 2152302898747 then return primetest(n, known_primes[1:6], d, s)
+    if n < 3474749660383 then return primetest(n, known_primes[1:7], d, s)
+    if n < 341550071728321 then return primetest(n, known_primes[1:8], d, s)
     # otherwise
     return primetest(n, known_primes[1:precision], d, s)
 end


### PR DESCRIPTION
The previous version allowed a few composites to be identified as primes.  This version increases the desired precision to address this issue.
Signed-off-by: Steve Wampler <sbw@tapestry.tucson.az.us>
