### PR TITLE
Remove spaces/tabs before EOL in Unicon files.

### DIFF
--- a/uni/3d/animationkeys.icn
+++ b/uni/3d/animationkeys.icn
@@ -32,11 +32,11 @@ class AnimationKeys(
       lst_translation := []
       lst_matrix := []
    end
-   
+
    method is_name(bname)
       if boneName==bname then return self
    end
-   
+
    method matrix_empty()
       if *lst_matrix=0 then return
    end
@@ -85,8 +85,8 @@ class AnimationKeys(
       return lst_scaling[i]
    end
 
-   
-   method addAnimationKey(key_type, theKey)   
+
+   method addAnimationKey(key_type, theKey)
       case key_type of{
          "rotate"    : put(lst_rotation, theKey)
          "scale"     : put(lst_scaling, theKey)

--- a/uni/3d/basicanimationobject3d.icn
+++ b/uni/3d/basicanimationobject3d.icn
@@ -13,29 +13,29 @@ $include "graphics3dh.icn"
 #
 class BasicAnimationObject3D : BasicObject3D (
 
-      velocity,         # Vector3 , directional           
+      velocity,         # Vector3 , directional
       rot_speed,        # Vector3
-      
-      speed_inc,         #  
+
+      speed_inc,         #
       max_speed,
-      
+
       strength,
-      health           
+      health
    )
-           
+
    method animate_move()
       loc.add(velocity)
 # ??
       Txyz := Translate(loc.x, loc.y, loc.z)
    end
-   
+
    method animate_rotate()
       orientation_angles.add(rot_speed)
       Rx.angle := rot_speed.x
       Ry.angle := rot_speed.y
       Rz.angle := rot_speed.z
    end
-   
+
    method animate()
       animate_move()
       animate_rotate()
@@ -51,17 +51,17 @@ class BasicAnimationObject3D : BasicObject3D (
    method set_velocity (v)
       velocity.set(v)
    end
-   
+
    method set_velocityxyz (x, y, z)
       velocity.setxyz (x, y, z)
    end
-   
+
    method add_velocity(v)
       velocity.add(v)
    end
-   
+
    method adjust_with_frame_rate()
-   
+
    end
 
    initially ( myname )
@@ -74,6 +74,6 @@ class BasicAnimationObject3D : BasicObject3D (
       # objects during collision, that is why strength is 0.
       # Also, a very small value for health guarantees that the object
       # will die in the first collision.
-      /health := .0000000001    # new born, barely alive! 
-      /strength := 0            # and has no strength!      
+      /health := .0000000001    # new born, barely alive!
+      /strength := 0            # and has no strength!
 end

--- a/uni/3d/face.icn
+++ b/uni/3d/face.icn
@@ -30,7 +30,7 @@ class Face (
    method set_material_id(i)
       materialIndex :=  i
    end
-   
+
    method get_material_id()
       return \materialIndex
    end

--- a/uni/3d/s3dparse.icn
+++ b/uni/3d/s3dparse.icn
@@ -51,7 +51,7 @@ end
 
 
 method load(filename, m3d)
-   local fin, s, face, mesh, new_frames, frame, tri, s3dpart, i, frm, j, 
+   local fin, s, face, mesh, new_frames, frame, tri, s3dpart, i, frm, j,
          tex_fname, tex_fname2, newMaterial, p
 
    fin := open(filename) | stop("can't open ", filename)
@@ -66,7 +66,7 @@ method load(filename, m3d)
       S3Dparse()
       }
 
-   new_frames := [] 
+   new_frames := []
       every s3dpart := !partRecs do
          {
 
@@ -84,7 +84,7 @@ method load(filename, m3d)
             every tex_fname := !textureRecs do
             {
                if tex_fname[-1] == "\r" then tex_fname := tex_fname[1:-1]
-               if map(tex_fname[-4:0]) ~== ".gif" then 
+               if map(tex_fname[-4:0]) ~== ".gif" then
                      tex_fname := map(tex_fname[1:-4])||".gif"
 
                if not exists(tex_fname) then{
@@ -100,7 +100,7 @@ method load(filename, m3d)
                newMaterial := Material()
                newMaterial.textureFileName := tex_fname
                put (mesh.lsTexture, tex_fname)
-               
+
                put (mesh.lst_material, newMaterial)
             }
 
@@ -111,10 +111,10 @@ method load(filename, m3d)
 
 
             j:=(frm-1)*s3dpart.vertexCount
-            
+
             every i:= (s3dpart.firstVertexIndex+1 ) to ( s3dpart.firstVertexIndex + s3dpart.vertexCount) do{
-               #  if i%100 = 0 then write( "  x=",vertexRecs[i+j].x, 
-               #                            "  y=",vertexRecs[i+j].y, 
+               #  if i%100 = 0 then write( "  x=",vertexRecs[i+j].x,
+               #                            "  y=",vertexRecs[i+j].y,
                #                            "  z=",vertexRecs[i+j].z)
                 put( mesh.lst_vertex, Vector3( vertexRecs[i+j].x, vertexRecs[i+j].y, vertexRecs[i+j].z ))
              }
@@ -122,7 +122,7 @@ method load(filename, m3d)
             every i := s3dpart.firstTriIndex+1 to ( s3dpart.firstTriIndex + s3dpart.triCount) do {
                  face := Face()
                  tri := triangleRecs[i]
-                 put( face.lst_vertex_index, (tri.vi1+1) ) 
+                 put( face.lst_vertex_index, (tri.vi1+1) )
                  put( face.lst_vertex_index, (tri.vi2+1) )
                  put( face.lst_vertex_index, (tri.vi3+1) )
 

--- a/uni/3d/util3d.icn
+++ b/uni/3d/util3d.icn
@@ -70,7 +70,7 @@ procedure matrixTranspose(c)
    a[13]:=:a[ 4]
    a[14]:=:a[ 8]
    a[15]:=:a[12]
-   
+
    return a
 end
 
@@ -125,7 +125,7 @@ end
 procedure matrixMulVector(a, v)
    local newv, L, Lnew, row, col, k
    newv := Vector3()
-   
+
    newv.x := a[1]*v.x + a[5]*v.y + a[ 9]*v.z + a[13]
    newv.y := a[2]*v.x + a[6]*v.y + a[10]*v.z + a[14]
    newv.z := a[3]*v.x + a[7]*v.y + a[11]*v.z + a[15]
@@ -151,7 +151,7 @@ procedure matrixRotate(angle, axis)
    local sint, cost, c
    sint := sin(angle)
    cost := cos(angle)
-   
+
    case axis of{
    "x" :{
       c := [ 1,    0,    0, 0,
@@ -175,6 +175,6 @@ procedure matrixRotate(angle, axis)
             ]
          }
       } # case
-         
+
   return c
 end

--- a/uni/3d/viewer/subwin3d.icn
+++ b/uni/3d/viewer/subwin3d.icn
@@ -55,7 +55,7 @@ class Dispatcher3D : Dispatcher(subwins)
    method add_subwin(sw)
       insert(subwins, sw)
    end
-   
+
    method message_loop(r)
       if /r then {
          while *dispatcher.dialogs > 0 do
@@ -65,13 +65,13 @@ class Dispatcher3D : Dispatcher(subwins)
             do_event() | do_validate() | do_ticker() | world.handle_event() | delay(10)
       }
    end
-   
+
    initially
-   
+
       self.Dispatcher.initially()
       subwins := set()
    #tickers := set()
-   
+
 
 end
 
@@ -82,13 +82,13 @@ global subwins3d
 class Subwindow3D : Component (xbtn_x, xbtn_y)
    method resize()
      compute_absolutes()
-     self.invalidate()  
+     self.invalidate()
      WAttrib(cwin, "pos="||x||","||y)
      WAttrib(cwin, "size="||w||","||h)
    end
    method display()
-   
-      
+
+
     Refresh(cwin)
    end
    method init()
@@ -105,7 +105,7 @@ class Subwindow3D : Component (xbtn_x, xbtn_y)
                self.attribs))
 
       /subwins3d := set()
-      insert(subwins3d, self.cwin)      
+      insert(subwins3d, self.cwin)
 
       set_accepts_focus()
       dispatcher.add_subwin(self.cwin)

--- a/uni/gprogs/qmazer.icn
+++ b/uni/gprogs/qmazer.icn
@@ -20,7 +20,7 @@ global fullPath, visited
 
 import util
 link printf
- 
+
 $define CELL   20                                   # cell size in pixels
 $define BORDER 30                                   # border size in pixels
 
@@ -46,12 +46,12 @@ procedure main(A)
     mw := Args().getOpt("cols") | 88              # Maze width (columns)
     delayms := Args().getOpt("delay")             # Delay between mice creations
     fullPath := []                                # Points in best path
- 
+
     mz := DisplayMaze(GenerateMaze(mh,mw))   # Build and show maze
- 
+
     QMouse(mz.maze,findStart(mz.maze),&null,0)   # Start first quantum mouse
     waitForCompletion() # block until all quantum mice have finished
- 
+
     # Mark the best path into the maze and display it.
     if showPath(mz.maze) then DisplayMazeSolution(mz)
     else {   # Give the person time to examine the failed maze search...
@@ -80,7 +80,7 @@ record Position(r,c)
 # Must match values used in maze generation!
 $define FINISH 64 # exit
 $define START  32 # entrance
-$define PATH  128 
+$define PATH  128
 $define SEEN   16 # bread crumbs for generator
 $define NORTH   8 # sides ...
 $define EAST    4
@@ -202,9 +202,9 @@ end
 procedure waitForCompletion()
    critical qMiceEmpty: while *qMice > 0 do wait(qMiceEmpty)
 end
- 
+
 procedure GenerateMaze(r,c)     # Non-recursive depth first maze generation
-local maze,h,w,rd 
+local maze,h,w,rd
    /h := integer(1 < r) | runerr(r,205)      # valid size 2x2 or better
    /w := integer(1 < c) | runerr(r,205)
    # The maze is a 2-D array implemented as a list of lists, where each cell
@@ -218,17 +218,17 @@ local maze,h,w,rd
    start  := [?h,?w,?4-1,START]              # random [r,c] start & finish
    finish := [?h,?w,(start[3]+2)%4,FINISH]   # w/ opposite side exponent
    every x := start | finish do {
-      case x[3] := 2 ^ x[3] of {             # get side from exponent and 
+      case x[3] := 2 ^ x[3] of {             # get side from exponent and
          NORTH : x[1] := 1                   # project r,c to selected edge
          EAST  : x[2] := w
-         SOUTH : x[1] := h         
+         SOUTH : x[1] := h
          WEST  : x[2] := 1
-         }   
+         }
       maze[x[1],x[2]] +:= x[3] + x[4]        # transcribe s/f to maze
       }
    maze[start[1],start[2]] +:= SEEN
    push(visited := [], Position(start[1],start[2]))
-   rd := [NORTH, EAST, SOUTH, WEST]          # initial list of directions     
+   rd := [NORTH, EAST, SOUTH, WEST]          # initial list of directions
    while *visited > 0 do {
       p := pop(visited)
       r := p.r
@@ -273,27 +273,27 @@ procedure chkPos(maze,r,c,p,wall)
       return Position(r,c)
       }
 end
- 
+
 record mazeinfo(window,maze,filename)               # keepers
- 
+
 procedure DisplayMaze(maze)                         #: show it off
     if CELL < 8 then runerr(205,CELL)                   # too small
- 
+
     wh := (ch := (mh := *maze  ) * CELL) + 2 * BORDER   # win, cell, maze height
     ww := (cw := (mw := *maze[1]) * CELL) + 2 * BORDER  # win, cell, maze width
- 
+
     wparms := [ sprintf("Maze %dx%d",*maze,*maze[1]),   # window parameters
-                "g","bg=white","canvas=hidden",      
+                "g","bg=white","canvas=hidden",
                 sprintf("size=%d,%d",ww,wh),
                 sprintf("dx=%d",BORDER),
                 sprintf("dy=%d",BORDER)]
- 
+
     &window := open!wparms | stop("Unable to open Window")
- 
+
     Fg("black")                                         # Draw full grid
     every DrawLine(x := 0 to cw by CELL,0,x,ch+1)       # . verticals
     every DrawLine(0,y := 0 to ch by CELL,cw+1,y)       # . horizontals
- 
+
     Fg("white")                                         # Set to erase lines
     every y := CELL*((r := 1 to mh)-1) & x := CELL*((c := 1 to mw)-1) do {
        WAttrib("dx="||x+BORDER,"dy="||y+BORDER)         # position @ cell r,c
@@ -301,8 +301,8 @@ procedure DisplayMaze(maze)                         #: show it off
        if iand(maze[r,c],EAST)  ~= EMPTY then DrawLine(CELL,2,CELL,CELL-1)
        if iand(maze[r,c],SOUTH) ~= EMPTY then DrawLine(2,CELL,CELL-1,CELL)
        if iand(maze[r,c],WEST)  ~= EMPTY then DrawLine(0,2,0,CELL-1)
-       }   
- 
+       }
+
     WAttrib(&window,"canvas=normal")
     WAttrib("dx="||(dxy:=BORDER+CELL/2),"dy="||dxy)
     colorCell(start[1],start[2], "red", 3)
@@ -310,7 +310,7 @@ procedure DisplayMaze(maze)                         #: show it off
     until Event() == &lpress
     return mazeinfo(&window,maze,sprintf("maze-%dx%d-%d.gif",r,c,&now))
 end
- 
+
 procedure DisplayMazeSolution(mz)                  #: draw marked PATH
     &window := mz.window
     maze := mz.maze

--- a/uni/gui/border.icn
+++ b/uni/gui/border.icn
@@ -28,7 +28,7 @@ $include "guih.icn"
 # @ self.add(b)
 #
 class Border : Panel(
-   internal_alignment, 
+   internal_alignment,
    title_obj,
    y1,
    h1
@@ -68,7 +68,7 @@ class Border : Panel(
             "c" : EraseRectangle(W, self.x + self.w / 2 - title_obj.w / 2 - BORDER_TEXT_SPACING, y1, title_obj.w + 2 * BORDER_TEXT_SPACING, 2 * BORDER_WIDTH)
             "l" : EraseRectangle(W, self.x + DEFAULT_TEXT_X_SURROUND, y1, title_obj.w + 2 * BORDER_TEXT_SPACING, 2 * BORDER_WIDTH)
             "r" : EraseRectangle(W, self.x + self.w - title_obj.w - DEFAULT_TEXT_X_SURROUND - 2 * BORDER_TEXT_SPACING, y1, title_obj.w + 2 * BORDER_TEXT_SPACING, 2 * BORDER_WIDTH)
-         }         
+         }
       }
 
       every (!self.children).display(buffer_flag)

--- a/uni/gui/button.icn
+++ b/uni/gui/button.icn
@@ -19,7 +19,7 @@ $include "guih.icn"
 # A {Button} produces a BUTTON_PRESS_EVENT when the button is
 # depressed, and code BUTTON_RELEASE_EVENT when it is released,
 # as well as an ACTION_EVENT.
-# 
+#
 # By default, when a button holds the keyboard focus a dashed
 # line appears just within the button.  Then, when return is
 # pressed an ACTION_EVENT is generated.  The method
@@ -32,16 +32,16 @@ $include "guih.icn"
 # events is set in the parent dialog (see above).
 #
 class Button : Toggle : Component(
-   is_down,                 #               
-   is_held,                 #               
-   is_checked_flag,         #                       
+   is_down,                 #
+   is_held,                 #
+   is_checked_flag,         #
    label,
-   img_up,                  #              
-   img_down,                #                
-   img_w,                   #             
-   img_h,                   #             
+   img_up,                  #
+   img_down,                #
+   img_w,                   #
+   img_h,                   #
    parent_check_box_group,  #
-   parent_button_group,     #                           
+   parent_button_group,     #
    repeat_delay,
    no_keyboard_flag,        #
    toggles_flag
@@ -61,7 +61,7 @@ class Button : Toggle : Component(
       self.no_keyboard_flag := 1
       self.accepts_focus_flag := &null
    end
-   
+
    #
    # Clear the no keyboard behaviour (the default)
    #
@@ -105,7 +105,7 @@ class Button : Toggle : Component(
    method handle_drag(e)
       if \self.is_held then {
          #
-         # Button held down; toggle on/off as it goes over the button 
+         # Button held down; toggle on/off as it goes over the button
          #
          if self.in_region() then {
             if /self.is_down then {
@@ -163,7 +163,7 @@ class Button : Toggle : Component(
          handle_drag(e)
       } else if e === (&lrelease | &rrelease | &mrelease) then {
          handle_release(e)
-      } else 
+      } else
          handle_default(e)
    end
 
@@ -227,7 +227,7 @@ class Button : Toggle : Component(
    # between two states, as indicated by the is_checked
    # flag.
    #
-   # Instances of Checkbox have this flag on by default, but 
+   # Instances of Checkbox have this flag on by default, but
    # TextButton and IconButton do not.  When the flag is on,
    # the latter classes indicate their checked status by
    # showing the button as being "down".

--- a/uni/gui/buttongroup.icn
+++ b/uni/gui/buttongroup.icn
@@ -18,7 +18,7 @@ $include "guih.icn"
 # onto another before being released, the other Button will go
 # "down".  This is the common behaviour for buttons in a bar
 # along the top of an application.
-# 
+#
 # NB - A Button must be added to the {ButtonGroup} and the
 # {Dialog} too.
 # @example
@@ -29,7 +29,7 @@ $include "guih.icn"
 # @ bg.add(b)
 #
 class ButtonGroup : Object(
-   buttons                  #               
+   buttons                  #
    )
 
    #

--- a/uni/gui/checkbox.icn
+++ b/uni/gui/checkbox.icn
@@ -47,7 +47,7 @@ class CheckBox : Button(tx, tw)
       #
       # We give extra border space; this looks better with the focus rectangle.
       #
-      /self.w_spec := TextWidth(self.cwin, self.label) + 
+      /self.w_spec := TextWidth(self.cwin, self.label) +
          self.img_w + DEFAULT_TEXT_X_SURROUND + HIGHLIGHT_TEXT_SPACING
 
       self.Component.resize()
@@ -55,7 +55,7 @@ class CheckBox : Button(tx, tw)
       self.tx := self.x + self.img_w + DEFAULT_TEXT_X_SURROUND
       self.tw := self.w - self.img_w - DEFAULT_TEXT_X_SURROUND - HIGHLIGHT_TEXT_SPACING
    end
-      
+
    method display(buffer_flag)
       local cw, i
 
@@ -72,7 +72,7 @@ class CheckBox : Button(tx, tw)
       left_string(self.cbwin, self.tx, self.y + self.h / 2, self.label, self.accel)
 
       if /self.no_keyboard_flag & \self.has_focus then {
-         DashedRectangle(self.cbwin, self.tx - HIGHLIGHT_TEXT_SPACING, self.y, 
+         DashedRectangle(self.cbwin, self.tx - HIGHLIGHT_TEXT_SPACING, self.y,
                          self.tw + 2 * HIGHLIGHT_TEXT_SPACING, self.h)
       }
 

--- a/uni/gui/checkboxgroup.icn
+++ b/uni/gui/checkboxgroup.icn
@@ -26,7 +26,7 @@ $include "guih.icn"
 # and the dialog box too; a {CheckBoxGroup} is not a {Container}.
 #
 class CheckBoxGroup : Object(
-   checkboxes,              #                  
+   checkboxes,              #
    which_one                #
    )
 

--- a/uni/gui/checkboxmenuitem.icn
+++ b/uni/gui/checkboxmenuitem.icn
@@ -18,8 +18,8 @@ $include "guih.icn"
 # structure to give "radio buttons" within menus.
 #
 class CheckBoxMenuItem : Toggle : MenuComponent(
-   img_up,                  #              
-   img_down                 #                
+   img_up,                  #
+   img_down                 #
    )
 
    #
@@ -60,7 +60,7 @@ class CheckBoxMenuItem : Toggle : MenuComponent(
    method synch_left_img()
       if \self.is_checked_flag then
          set_img_left(self.img_down)
-      else 
+      else
          set_img_left(self.img_up)
    end
 
@@ -68,7 +68,7 @@ class CheckBoxMenuItem : Toggle : MenuComponent(
       if \self.parent_check_box_group then
          self.parent_check_box_group.set_which_one(self)
       else
-         self.toggle_is_checked()      
+         self.toggle_is_checked()
       self.MenuComponent.succeed(e)
    end
 

--- a/uni/gui/circulate.icn
+++ b/uni/gui/circulate.icn
@@ -16,7 +16,7 @@ class CirculateLabel:Label()
       if \self.has_focus then {
          if e === Key_Up then
             parent.go_up(e)
-         else if e === Key_Down then 
+         else if e === Key_Down then
             parent.go_down(e)
       }
    end
@@ -139,7 +139,7 @@ class Circulate : Component(selection, selection_list, b, l)
          return l
    end
 
-   initially(a[]) 
+   initially(a[])
       self.Component.initially()
       self.l := CirculateLabel()
       self.l.clear_draw_border()

--- a/uni/gui/dispatcher.icn
+++ b/uni/gui/dispatcher.icn
@@ -20,7 +20,7 @@ $include "guih.icn"
 #
 class Dispatcher : Object(
    dialogs,
-   tickers, 
+   tickers,
    idle_sleep,
    idle_sleep_min,
    idle_sleep_max
@@ -38,7 +38,7 @@ class Dispatcher : Object(
    # @p
    method compute_idle_sleep()
       local n
-      if *tickers = 0 then 
+      if *tickers = 0 then
          idle_sleep := idle_sleep_max
       else {
          #
@@ -85,7 +85,7 @@ class Dispatcher : Object(
 
    #
    # Add a ticker, or reset its time to a new value.
-   # 
+   #
    # @p
    method start_ticker(t, n, d, c)
       insert(tickers, t)
@@ -102,7 +102,7 @@ class Dispatcher : Object(
    #
    # Change a ticker's tick rate, to take effect after its
    # next tick.
-   # 
+   #
    # @p
    method retime_ticker(t, n)
       if \t.ticker_rate then {
@@ -154,7 +154,7 @@ class Dispatcher : Object(
                while *Pending(d.win) > 0 do {
                   #
                   # Discard the event and beep in the window.
-                  # 
+                  #
                   e := ::Event(d.win)
                   if not(e === (-12 | &lrelease | &rrelease | &mrelease | &ldrag | &rdrag | &mdrag)) then
                      Alert(d.win)
@@ -230,7 +230,7 @@ class Dispatcher : Object(
    method find_dialog(class_name)
       local d
       every d := !dialogs do {
-         if /d.is_blocked_flag & 
+         if /d.is_blocked_flag &
             (/class_name | lang::is_instance(d, class_name)) then
              suspend d
       }

--- a/uni/gui/displayscrollarea.icn
+++ b/uni/gui/displayscrollarea.icn
@@ -19,7 +19,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_page_up(e)
       local i
       if i := (\self.vsb).get_value() then {
-         self.vsb.set_value(i - self.vsb.page_size) 
+         self.vsb.set_value(i - self.vsb.page_size)
          self.refresh()
       }
    end
@@ -27,7 +27,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_page_down(e)
       local i
       if i := (\self.vsb).get_value() then {
-         self.vsb.set_value(i + self.vsb.page_size) 
+         self.vsb.set_value(i + self.vsb.page_size)
          self.refresh()
       }
    end
@@ -35,7 +35,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_up(e)
       local i
       if i := (\self.vsb).get_value() then {
-         self.vsb.set_value(i - self.vsb.increment_size) 
+         self.vsb.set_value(i - self.vsb.increment_size)
          self.refresh()
       }
    end
@@ -43,7 +43,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_down(e)
       local i
       if i := (\self.vsb).get_value() then {
-         self.vsb.set_value(i + self.vsb.increment_size) 
+         self.vsb.set_value(i + self.vsb.increment_size)
          self.refresh()
       }
    end
@@ -51,7 +51,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_left(e)
       local i
       if i := (\self.hsb).get_value() then {
-         self.hsb.set_value(i - self.hsb.increment_size) 
+         self.hsb.set_value(i - self.hsb.increment_size)
          self.refresh()
       }
    end
@@ -59,7 +59,7 @@ class DisplayScrollArea : LineBasedScrollArea()
    method handle_key_right(e)
       local i
       if i := (\self.hsb).get_value() then {
-         self.hsb.set_value(i + self.hsb.increment_size) 
+         self.hsb.set_value(i + self.hsb.increment_size)
          self.refresh()
       }
    end

--- a/uni/gui/dropdown.icn
+++ b/uni/gui/dropdown.icn
@@ -11,7 +11,7 @@ link graphics
 
 $include "guih.icn"
 
-class DropDownTextList : TextList(drag_flag) 
+class DropDownTextList : TextList(drag_flag)
    #
    # Determine an appropriate size for the drop-down list.
    #
@@ -25,7 +25,7 @@ class DropDownTextList : TextList(drag_flag)
       #
       mw := get_subject_width()
 
-      # 
+      #
       # Set the width needed, ensuring within min/max dimensions requested
       #
       self.w_spec := mw + 2 * get_view_x_padding()
@@ -61,10 +61,10 @@ end
 # This class is just a superclass of {List} and {EditList}.
 #
 class DropDown : Component(
-   b,                           
-   selection,               #                 
-   selection_list,          #                      
-   tl,                      #          
+   b,
+   selection,               #
+   selection_list,          #
+   tl,                      #
    temp_win                 #
    )
 
@@ -94,7 +94,7 @@ class DropDown : Component(
    end
 
    #
-   # Convenient method to get the string currently selected. 
+   # Convenient method to get the string currently selected.
    #
    method get_string_selection()
       return self.selection_list[self.selection]
@@ -131,7 +131,7 @@ class DropDown : Component(
       #
       tmp := tl.get_selections()[1]
       self.close_textlist()
-      self.unique_end(1)  
+      self.unique_end(1)
       go_to(\tmp, ev)
    end
 
@@ -201,7 +201,7 @@ class DropDown : Component(
       #
       if \self.tl then {
          self.close_textlist()
-         self.unique_end()  
+         self.unique_end()
       }
       self.Component.finally()
    end
@@ -210,11 +210,11 @@ class DropDown : Component(
       if \tl then {
          b.handle_event(e)
          (\tl).handle_event(e)
-         if \tl & ((e === "\e") | 
+         if \tl & ((e === "\e") |
                    ((e === (&lpress | &rpress | &mpress)) & not(tl.in_region()))) then {
             #
             # Mouse click outside textlist.  Close.
-            # 
+            #
             self.close_textlist()
             self.unique_end()
          }

--- a/uni/gui/editlist.icn
+++ b/uni/gui/editlist.icn
@@ -20,7 +20,7 @@ class EditListTextField:TextField()
       if \self.has_focus then {
          if e === Key_Up then
             parent.go_up(e)
-         else if e === Key_Down then 
+         else if e === Key_Down then
             parent.go_down(e)
       }
       self.TextField.handle_event(e)
@@ -39,7 +39,7 @@ end
 # as though they were from this component itself.
 #
 class EditList : DropDown(
-   tf,                      #          
+   tf,                      #
    no_default               #
    )
 
@@ -94,7 +94,7 @@ class EditList : DropDown(
       #
       if \self.tl then {
          self.close_textlist()
-         self.unique_end()  
+         self.unique_end()
       }
 
       /self.h_spec := WAttrib(self.cwin, "fheight") + 2 * DEFAULT_TEXT_Y_SURROUND
@@ -121,7 +121,7 @@ class EditList : DropDown(
 
    method display(buffer_flag)
       #
-      # Draw text element 
+      # Draw text element
       #
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
       DrawSunkenRectangle(self.cbwin, self.x, self.y, self.w, self.h)

--- a/uni/gui/editspin.icn
+++ b/uni/gui/editspin.icn
@@ -16,7 +16,7 @@ class SpinTextField:TextField()
       if \self.has_focus then {
          if e === Key_Up then
             parent.go_up(e)
-         else if e === Key_Down then 
+         else if e === Key_Down then
             parent.go_down(e)
       }
       self.TextField.handle_event(e)
@@ -59,7 +59,7 @@ class EditSpin : Spin(tf)
 
    method display(buffer_flag)
       #
-      # Draw text element 
+      # Draw text element
       #
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
       DrawSunkenRectangle(self.cbwin, self.x, self.y, self.w, self.h)

--- a/uni/gui/filedialog.icn
+++ b/uni/gui/filedialog.icn
@@ -20,7 +20,7 @@ $endif
 #
 #
 # File dialog class.  This class provides a standard file dialog.
-# 
+#
 # @example
 # @ d := FileDialog()
 # @ d.show()
@@ -29,13 +29,13 @@ $endif
 class FileDialog : Dialog(
    init_dir,                # Initial directory name
    init_file,               # Initial file name
-   res,                     # Resulting file path          
+   res,                     # Resulting file path
    dir,                     # TextField directory
    file,                    # TextField filename
-   dlist,                   # TextList of directories            
-   flist,                   # TextList of files            
-   okay,                    #            
-   cancel                   #              
+   dlist,                   # TextList of directories
+   flist,                   # TextList of files
+   okay,                    #
+   cancel                   #
    )
 
    #
@@ -68,7 +68,7 @@ class FileDialog : Dialog(
 
    #
    # Set the initial file/directory from a whole path.
-   # 
+   #
    method set_path(s)
       self.init_dir := directory_name(s)
       self.init_file := file_name(s)
@@ -82,9 +82,9 @@ class FileDialog : Dialog(
    method set_result()
       local path_to_file
       path_to_file := file.get_contents()
-      self.res := if ((\path_to_file)[1] == PATHCHAR) then 
+      self.res := if ((\path_to_file)[1] == PATHCHAR) then
                      path_to_file
-                  else 
+                  else
                      self.get_std_dir() || path_to_file
    end
 
@@ -124,7 +124,7 @@ class FileDialog : Dialog(
       #
       # Go to parent directory (unless at root directory)
       #
-      if value == (".." || PATHCHAR) then {    
+      if value == (".." || PATHCHAR) then {
          if s ~== PATHCHAR then {
             s[-1] := ""
             while s[-1] ~== PATHCHAR do s[-1] := ""
@@ -171,7 +171,7 @@ class FileDialog : Dialog(
    method init_dialog()
       self.set_focus(file)
    end
-   
+
    method component_setup()
       local l
 
@@ -248,7 +248,7 @@ $else
    if (*s > 1) & (s[-1] == PATHCHAR)
 $endif
    then s[-1] := ""
- 
+
    p := open(s) | {
        write(&errout, "get_directory_list: can't open ", image(s))
        fail
@@ -269,7 +269,7 @@ $endif
    close(p)
    return [sort(dir_list), sort(file_list)]
 end
- 
+
 #
 # Return the directory name of the file name s, including the trailing /
 #
@@ -278,7 +278,7 @@ procedure directory_name(s)
    every i := find(PATHCHAR, s)
    return s[1:\i + 1] | ""
 end
- 
+
 #
 # Return the file name of s
 #

--- a/uni/gui/font_dlg.icn
+++ b/uni/gui/font_dlg.icn
@@ -20,10 +20,10 @@ class fdialog : Dialog(cur_font,
    label_3, font, fn, fsz, fst, fontcolor, myanswer
    )
    method component_setup()
-      local type, size, style                  
+      local type, size, style
       if \cur_font then {
          cur_font ? {
-            type := tab(upto(','))           
+            type := tab(upto(','))
             tab(upto(&digits))
             size := integer(tab(many('0123456789.')))
             tab(many(','))
@@ -196,7 +196,7 @@ end
 #231|Items|list|11|class|CanvasLabel|27|Parent Canvas|1|Name|string|lab
 #el_1|Class Name|string|Label|Import Name|string|gui|X Fix|null|Y Fix|n
 #ull|W Fix|null|H Fix|null|W Default|integer|1|H Default|integer|1|X Sp
-#ec|integer|21|Y Spec|integer|31|W Spec|integer|30|H Spec|integer|13|X 
+#ec|integer|21|Y Spec|integer|31|W Spec|integer|30|H Spec|integer|13|X
 #Align|string|l|Y Align|string|t|Is shaded|null|Is Button Subclass|null
 #|Draw Border|null|Attribs|list|0|Tooltip|null|Accel|null|Event Handler
 #s|list|0|Class Variable|integer|1|Parent Component|1|Label|string|Font
@@ -207,7 +207,7 @@ end
 #ger|13|X Align|string|l|Y Align|string|t|Is shaded|null|Is Button Subc
 #lass|null|Draw Border|null|Attribs|list|0|Tooltip|null|Accel|null|Even
 #t Handlers|list|0|Class Variable|integer|1|Parent Component|1|Label|st
-#ring|Font style:|Internal Align|string|l|class|CanvasBorder|28|Parent 
+#ring|Font style:|Internal Align|string|l|class|CanvasBorder|28|Parent
 #Canvas|1|Name|string|border_1|Class Name|string|Border|Import Name|str
 #ing|gui|X Fix|null|Y Fix|null|W Fix|null|H Fix|null|W Default|null|H D
 #efault|null|X Spec|string|37|Y Spec|string|125|W Spec|string|318|H Spe
@@ -220,17 +220,17 @@ end
 #ult|null|X Spec|string|7|Y Spec|string|10|W Spec|string|301|H Spec|str
 #ing|61|X Align|string|l|Y Align|string|t|Is shaded|null|Is Button Subc
 #lass|null|Draw Border|null|Attribs|list|1|string|font=sans,11|Tooltip|
-#null|Accel|null|Event Handlers|list|0|Class Variable|integer|1|Parent 
+#null|Accel|null|Event Handlers|list|0|Class Variable|integer|1|Parent
 #Component|16|Label|string|Sample|Internal Align|string|c|Title Obj|nul
 #l|class|CanvasLabel|27|Parent Canvas|1|Name|string|label_3|Class Name|
 #string|Label|Import Name|string|gui|X Fix|null|Y Fix|null|W Fix|null|H
 # Fix|null|W Default|integer|1|H Default|integer|1|X Spec|integer|277|Y
 # Spec|integer|33|W Spec|integer|30|H Spec|integer|13|X Align|string|l|
 #Y Align|string|t|Is shaded|null|Is Button Subclass|null|Draw Border|nu
-#ll|Attribs|list|0|Tooltip|null|Accel|null|Event Handlers|list|0|Class 
+#ll|Attribs|list|0|Tooltip|null|Accel|null|Event Handlers|list|0|Class
 #Variable|integer|1|Parent Component|1|Label|string|Size:|Internal Alig
 #n|string|l|class|CanvasEditList|29|Parent Canvas|1|Name|string|edit_fo
-#ntname|Class Name|string|EditList|Import Name|string|gui|X Fix|null|Y 
+#ntname|Class Name|string|EditList|Import Name|string|gui|X Fix|null|Y
 #Fix|null|W Fix|null|H Fix|null|W Default|null|H Default|integer|1|X Sp
 #ec|integer|22|Y Spec|integer|60|W Spec|integer|114|H Spec|integer|23|X
 # Align|string|l|Y Align|string|t|Is shaded|null|Is Button Subclass|nul
@@ -281,8 +281,8 @@ end
 #h|null|Img Height|null|Is Checked Flag|null|Is Checkbox Flag|null|Pare
 #nt CheckBoxGroup|null|Parent Button Group|null|Internal Align|string|c
 #|class|CanvasLabel|27|Parent Canvas|1|Name|string|label_4|Class Name|s
-#tring|Label|Import Name|string|gui|X Fix|null|Y Fix|null|W Fix|null|H 
-#Fix|null|W Default|integer|1|H Default|integer|1|X Spec|integer|399|Y 
+#tring|Label|Import Name|string|gui|X Fix|null|Y Fix|null|W Fix|null|H
+#Fix|null|W Default|integer|1|H Default|integer|1|X Spec|integer|399|Y
 #Spec|integer|33|W Spec|integer|36|H Spec|integer|13|X Align|string|l|Y
 # Align|string|t|Is shaded|null|Is Button Subclass|null|Draw Border|nul
 #l|Attribs|list|0|Tooltip|null|Accel|null|Event Handlers|list|0|Class V
@@ -290,7 +290,7 @@ end
 #n|string|l|class|CanvasEditList|29|Parent Canvas|1|Name|string|edit_fo
 #ntcolor|Class Name|string|EditList|Import Name|string|gui|X Fix|null|Y
 # Fix|null|W Fix|null|H Fix|null|W Default|null|H Default|integer|1|X S
-#pec|string|400|Y Spec|string|59|W Spec|string|100|H Spec|integer|23|X 
+#pec|string|400|Y Spec|string|59|W Spec|string|100|H Spec|integer|23|X
 #Align|string|l|Y Align|string|t|Is shaded|null|Is Button Subclass|null
 #|Draw Border|null|Attribs|list|0|Tooltip|null|Accel|null|Event Handler
 #s|list|1|list|2|string|SELECTION_CHANGED_EVENT|string|on_edit_fontcolo

--- a/uni/gui/gui_utils.icn
+++ b/uni/gui/gui_utils.icn
@@ -91,7 +91,7 @@ class Gui : Class (editColor)
        lab.set_label(label)
        return lab
     end
- 
+
     #<p>
     #  Produce a <tt>TextField</tt>.
     #</p>
@@ -110,7 +110,7 @@ class Gui : Class (editColor)
        field.set_contents(contents)
        return field
     end
- 
+
     #<p>
     #  Produce a <tt>TextButton</tt>.
     #</p>
@@ -126,7 +126,7 @@ class Gui : Class (editColor)
        button.set_internal_alignment(align)
        return button
     end
- 
+
     #<p>
     #  Produce a <tt>EditableTextList</tt>.
     #</p>
@@ -176,7 +176,7 @@ class Gui : Class (editColor)
        area.set_select_one()
        return area
     end
- 
+
     #<p>
     #  Produce a <tt>CheckBox</tt>.
     #</p>
@@ -241,7 +241,7 @@ class Gui : Class (editColor)
         bar.set_pos(x,y)
         return bar
     end
- 
+
     initially ()
         editColor := "white"
         Gui := create |self

--- a/uni/gui/guiprocs.icn
+++ b/uni/gui/guiprocs.icn
@@ -9,7 +9,7 @@
 package gui
 link graphics
 
-$include "guih.icn"     
+$include "guih.icn"
 
 procedure EraseRectangle(W, x, y, w, h)
    if x < 0 then {
@@ -64,7 +64,7 @@ procedure get_extended_image(W, img)
       s1 := s2 := ""
       spec ? repeat {
          tab(many('; '))
-         if pos(0) then 
+         if pos(0) then
             break
          s1 ||:= move(1) | fail
          ="=" | fail
@@ -81,12 +81,12 @@ end
 
 procedure CursorLine(W, x, y, w, h)
    fc := Fg(W)
-   Fg(W, "black") 
+   Fg(W, "black")
    #DrawLine(W, x-1, y-1, x-1, y+h+1)
    DrawLine(W, x, y-1, x, y+h+1)
    DrawLine(W, x-1, y-1, x+2, y-1)
    DrawLine(W, x-1, y+h+1, x+2, y+h+1)
-   Fg(W, fc ) 
+   Fg(W, fc )
 end
 
 
@@ -134,7 +134,7 @@ procedure TextWidthEx(win, s, i, j, tw)
          repeat {
             w +:= TextWidth(win, " ")
             tp +:= 1
-            if tp % tw = 0 then 
+            if tp % tw = 0 then
                break
          }
       } else {
@@ -216,14 +216,14 @@ procedure center_string(win, x, y, s, k)
    left_string(win, x - TextWidth(win, s) / 2, y, s, k)
 end
 
-procedure right_string(win, x, y, s, k) 
+procedure right_string(win, x, y, s, k)
    left_string(win, x - TextWidth(win, s), y, s, k)
 end
 
 procedure img_width(s)
    s ? {
       if ="(" then {
-         tab(upto(')')) 
+         tab(upto(')'))
          move(1)
       }
       return integer(tab(upto(',')))
@@ -234,7 +234,7 @@ procedure img_height(s)
    local w
    s ? {
       if ="(" then {
-         tab(upto(')')) 
+         tab(upto(')'))
          move(1)
       }
       w := integer(tab(upto(',')))

--- a/uni/gui/icon.icn
+++ b/uni/gui/icon.icn
@@ -21,8 +21,8 @@ $include "guih.icn"
 # requested.
 #
 class Icon : Component(
-   img,                     #           
-   img_w,                   #             
+   img,                     #
+   img_w,                   #
    img_h                    #
    )
 

--- a/uni/gui/iconbutton.icn
+++ b/uni/gui/iconbutton.icn
@@ -19,7 +19,7 @@ $include "guih.icn"
 # equivalent Icon image string, which can then be inserted
 # into a program.  See also the X window programs sxpm and
 # pixmap for viewing and editing xpm files respectively.
-# 
+#
 # A border may be requested with {set_draw_border().}
 #
 # Unless explicitly specified, the size will default to the

--- a/uni/gui/label.icn
+++ b/uni/gui/label.icn
@@ -12,13 +12,13 @@ link graphics
 $include "guih.icn"
 
 #
-# This class implements a Text label.  The default width and 
+# This class implements a Text label.  The default width and
 # height are determined by dimensions of text
 #
 class Label : Component(
-   label,                   #             
-   internal_alignment,      #                          
-   tx,                      #          
+   label,                   #
+   internal_alignment,      #
+   tx,                      #
    tw,                      #
    linked_accel
    )
@@ -82,7 +82,7 @@ class Label : Component(
    method display(buffer_flag)
       local yoff, key, dwin
 
-      dwin := if /self.transparent then cbwin else cwin 
+      dwin := if /self.transparent then cbwin else cwin
 
       if /self.transparent then
          EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
@@ -100,12 +100,12 @@ class Label : Component(
          "l" : left_string(dwin, self.tx, yoff, self.label, key)
          "r" : right_string(dwin, self.tx + self.tw, yoff, self.label, key)
          default : fatal("incorrect internal_alignment specifier: " || image(self.internal_alignment))
-      }         
+      }
 
       Clip(dwin)
 
       if \self.has_focus then {
-         DashedRectangle(dwin, self.tx - HIGHLIGHT_TEXT_SPACING, self.y, 
+         DashedRectangle(dwin, self.tx - HIGHLIGHT_TEXT_SPACING, self.y,
                          self.tw + 2 * HIGHLIGHT_TEXT_SPACING, self.h)
       }
 

--- a/uni/gui/line.icn
+++ b/uni/gui/line.icn
@@ -44,19 +44,19 @@ class Line : Component(is_vertical_flag)
       W := if /buffer_flag then self.cwin else self.cbwin
       EraseRectangle(W, self.x, self.y, self.w, self.h)
       if /self.is_vertical_flag then
-         DrawEtchedLine(W, 
-                        self.x, self.y + self.h / 2, 
+         DrawEtchedLine(W,
+                        self.x, self.y + self.h / 2,
                         self.x + self.w, self.y + self.h / 2)
       else
-         DrawEtchedLine(W, 
-                        self.x + self.w / 2, self.y, 
+         DrawEtchedLine(W,
+                        self.x + self.w / 2, self.y,
                         self.x + self.w / 2, self.y + self.h)
       self.do_shading(W)
    end
 
    method set_one(attr, val)
       case attr of {
-         "is_vertical" : if test_flag(attr, val) then 
+         "is_vertical" : if test_flag(attr, val) then
             set_is_vertical()
          else
             clear_is_vertical()

--- a/uni/gui/linebasedscrollarea.icn
+++ b/uni/gui/linebasedscrollarea.icn
@@ -27,7 +27,7 @@ class LineBasedScrollArea : DrawScrollArea(
    end
 
    #
-   # Initialize the line_height variable 
+   # Initialize the line_height variable
    #
    # @p
    method init()
@@ -46,7 +46,7 @@ class LineBasedScrollArea : DrawScrollArea(
       else
          return t / line_height + 2
    end
-   
+
    #
    # The maximum number of lines which can be displayed  in the area
    #
@@ -83,7 +83,7 @@ class LineBasedScrollArea : DrawScrollArea(
    #
    # Ensure the given row is visible
    #
-   method ensure_row_visible(row) 
+   method ensure_row_visible(row)
       local i, j
       i := get_first_line()
       j := get_last_line()
@@ -135,13 +135,13 @@ class LineBasedScrollArea : DrawScrollArea(
    end
 
    #
-   #  Reset the height of the scroll area so it is exactly the 
-   #  line_height * number of lines and that there is no extra space 
-   #  or gap at the bottom of the scroll area. 
+   #  Reset the height of the scroll area so it is exactly the
+   #  line_height * number of lines and that there is no extra space
+   #  or gap at the bottom of the scroll area.
    #  This allows correct positioning when hitting page up/down or the scroll
    #  bar. Without this, lines are skipped while scrolling unless the
    #  scroll area height is an exact multiple of font height.
-   #  
+   #
    method reset_height()
    local ml := 1
 
@@ -149,18 +149,18 @@ class LineBasedScrollArea : DrawScrollArea(
 
       #
       # For horizontal scroll bar & vsb need to reset the view.h to
-      # to initial min height & width to recalculate max_lines 
-      # 
+      # to initial min height & width to recalculate max_lines
+      #
       ml := self.get_max_lines() | 1
       line_height :=  self.get_line_height()
-      self.view.h := ml * line_height 
+      self.view.h := ml * line_height
 
       view.set_size(self.view.w, self.view.h)
       view.resize()
-   end 
+   end
 
    #
-   # This method is overridden by the subclass to draw the given 
+   # This method is overridden by the subclass to draw the given
    # line at the given position, into the buffer window cbwin.
    # @param xp  The left position it should be drawn at
    # @param yp   The y position it should be drawn at

--- a/uni/gui/list.icn
+++ b/uni/gui/list.icn
@@ -21,7 +21,7 @@ class ListLabel:Label()
       if \self.has_focus then {
          if e === Key_Up then
             parent.go_up(e)
-         else if e === Key_Down then 
+         else if e === Key_Down then
             parent.go_down(e)
       }
    end
@@ -32,10 +32,10 @@ end
 # This component is for selecting one string from a list of
 # several.  When a button is pressed a list appears (possibly
 # with a scroll bar) from which one item can be selected.
-# 
+#
 # A SELECTION_CHANGED_EVENT is generated whenever an item is selected from the
 # list.
-# 
+#
 # @example
 # @ l := List()
 # @ l.set_selection_list(["Red", "Green", "Yellow", "Blue", "Orange"])
@@ -45,7 +45,7 @@ end
 # @ self.add(l)
 #
 class List : DropDown(
-   l,                       #         
+   l,                       #
    constant_label           #
    )
 
@@ -78,7 +78,7 @@ class List : DropDown(
       #
       if \self.tl then {
          self.close_textlist()
-         self.unique_end()  
+         self.unique_end()
       }
 
       /self.h_spec := WAttrib(self.cwin, "fheight") + 2 * DEFAULT_TEXT_Y_SURROUND
@@ -108,7 +108,7 @@ class List : DropDown(
 
    method display(buffer_flag)
       #
-      # Draw text element 
+      # Draw text element
       #
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
       DrawSunkenRectangle(self.cbwin, self.x, self.y, self.w, self.h)

--- a/uni/gui/menu.icn
+++ b/uni/gui/menu.icn
@@ -18,13 +18,13 @@ $include "guih.icn"
 # within it are formatted within the menu automatically.
 #
 class Menu : SubMenu(
-   w,                       #         
-   h,                       #         
-   max_label_left_w,        #                        
-   max_label_mid_w,         #                       
-   max_label_right_w,       #                         
-   temp_win,                #                
-   which_open,              #                  
+   w,                       #
+   h,                       #
+   max_label_left_w,        #
+   max_label_mid_w,         #
+   max_label_right_w,       #
+   temp_win,                #
+   which_open,              #
    which_highlight,         #
    children                 #
    )
@@ -43,7 +43,7 @@ class Menu : SubMenu(
    # @          is appended to the end.
    #
    method add(c, i)
-      if /i then 
+      if /i then
          put(self.children, c)
       else
          self.children := self.children[1 : i] ||| [c] ||| self.children[i : 0]
@@ -152,7 +152,7 @@ class Menu : SubMenu(
       #
       every c := !self.children do {
          c.display_label(self.max_label_left_w, self.max_label_mid_w, self.max_label_right_w)
-         if c === \self.which_highlight then 
+         if c === \self.which_highlight then
             DrawRaisedRectangle(cw, c.label_x, c.label_y, self.w - 2 * BORDER_WIDTH, c.label_h)
       }
       CopyArea(cw, self.parent_component.cwin, self.x, self.y, self.w, self.h, self.x, self.y)
@@ -231,7 +231,7 @@ class Menu : SubMenu(
          self.which_open.handle_event(e)
          return
       }
- 
+
       every m := !children do {
          if \last & m === which_highlight then {
             set_which_highlight(last)
@@ -244,7 +244,7 @@ class Menu : SubMenu(
 
    method handle_key_down(e)
       local m, t, first
-      
+
       if \self.which_open then {
          self.which_open.handle_event(e)
          return
@@ -265,7 +265,7 @@ class Menu : SubMenu(
    end
 
    method handle_key_right(e)
-      if \self.which_open then 
+      if \self.which_open then
          self.which_open.handle_event(e)
       else if /self.which_highlight then
          self.cursor_on() | parent_component.go_right()
@@ -277,7 +277,7 @@ class Menu : SubMenu(
    end
 
    method handle_key_left(e)
-      if \self.which_open then 
+      if \self.which_open then
          self.which_open.handle_event(e)
       else if /parent then
          parent_component.go_left()
@@ -286,7 +286,7 @@ class Menu : SubMenu(
    end
 
    method handle_key_escape(e)
-      if \self.which_open then 
+      if \self.which_open then
          self.which_open.handle_event(e)
       else if /parent then
          parent_component.make_partial()
@@ -295,7 +295,7 @@ class Menu : SubMenu(
    end
 
    method handle_key_return(e)
-      if \self.which_open then 
+      if \self.which_open then
          self.which_open.handle_event(e)
       else if \self.which_highlight then {
          if self.which_highlight.is_sub_menu() then {
@@ -351,7 +351,7 @@ class Menu : SubMenu(
                self.which_highlight.succeed(e)
          } else
             #
-            # Close completely, don't pass on event. 
+            # Close completely, don't pass on event.
             #
             close_all(1)
       } else {
@@ -406,7 +406,7 @@ class Menu : SubMenu(
             #
             # Clear present selection, except sub-menus.
             #
-            self.drag_off()        
+            self.drag_off()
       }
    end
 
@@ -435,11 +435,11 @@ class Menu : SubMenu(
    end
 
    method handle_event(e)
-      if e === (&lpress | &rpress | &mpress) then 
+      if e === (&lpress | &rpress | &mpress) then
          handle_press(e)
-      else if e === (&lrelease | &rrelease | &mrelease) then 
+      else if e === (&lrelease | &rrelease | &mrelease) then
          handle_release(e)
-      else if e === (-12 | &ldrag | &rdrag | &mdrag) then 
+      else if e === (-12 | &ldrag | &rdrag | &mdrag) then
          handle_drag(e)
       else {
          case e of {

--- a/uni/gui/menubutton.icn
+++ b/uni/gui/menubutton.icn
@@ -18,8 +18,8 @@ $include "guih.icn"
 # the dialog, whereas a {MenuBar} would invariably be placed along the top.
 #
 class MenuButton : Component(
-   menu,                    #            
-   img,                     #           
+   menu,                    #
+   img,                     #
    is_open                  #
    )
 
@@ -123,11 +123,11 @@ class MenuButton : Component(
    end
 
    method handle_event(e)
-      if e === (&lpress | &rpress | &mpress) then 
+      if e === (&lpress | &rpress | &mpress) then
          handle_press(e)
-      else if e === (&lrelease | &rrelease | &mrelease) then 
+      else if e === (&lrelease | &rrelease | &mrelease) then
          handle_release(e)
-      else 
+      else
          handle_default(e)
    end
 
@@ -147,7 +147,7 @@ class MenuButton : Component(
       /self.h_spec := WAttrib(self.cwin, "fheight") +  2 * DEFAULT_TEXT_Y_SURROUND
       self.Component.resize()
 
-      self.menu.set_parent_component(self)         
+      self.menu.set_parent_component(self)
       self.menu.set_abs_coords(self.x, self.y + self.h)
       self.menu.size_label()
       self.menu.resize()

--- a/uni/gui/menucomponent.icn
+++ b/uni/gui/menucomponent.icn
@@ -21,24 +21,24 @@ $include "guih.icn"
 # {SubMenu}.
 #
 class MenuComponent : SetFields : Connectable: Object(
-   label,                   #             
-   label_x,                 #               
-   label_y,                 #               
-   label_h,                 #               
-   label_left_w,            #                    
-   label_right_w,           #                     
-   label_mid_w,             #                   
-   is_sub_menu_flag,        #                        
-   parent_component,        #                       
-   is_shaded_flag,          #                      
-   label_left,              #                  
-   img_left,                #                
-   img_left_h,              #                  
-   img_left_w,              #                  
-   label_right,             #                   
-   img_right,               #                 
-   img_right_h,             #                   
-   img_right_w,             #                   
+   label,                   #
+   label_x,                 #
+   label_y,                 #
+   label_h,                 #
+   label_left_w,            #
+   label_right_w,           #
+   label_mid_w,             #
+   is_sub_menu_flag,        #
+   parent_component,        #
+   is_shaded_flag,          #
+   label_left,              #
+   img_left,                #
+   img_left_h,              #
+   img_left_w,              #
+   label_right,             #
+   img_right,               #
+   img_right_h,             #
+   img_right_w,             #
    parent,                  #
    accel
    )
@@ -73,7 +73,7 @@ class MenuComponent : SetFields : Connectable: Object(
    method set_img_left(x)
       self.img_left := x
       self.img_left_w := img_width(self.img_left)
-      self.img_left_h := img_height(self.img_left) 
+      self.img_left_h := img_height(self.img_left)
       possibly_invalidate()
    end
 
@@ -83,7 +83,7 @@ class MenuComponent : SetFields : Connectable: Object(
    method set_img_right(x)
       self.img_right := x
       self.img_right_w := img_width(self.img_right)
-      self.img_right_h := img_height(self.img_right) 
+      self.img_right_h := img_height(self.img_right)
       possibly_invalidate()
    end
 
@@ -176,7 +176,7 @@ class MenuComponent : SetFields : Connectable: Object(
       else if \self.img_right then
          DrawImageEx(cw, self.label_x + lw + mw, self.label_y + (self.label_h - img_right_h) / 2, img_right)
 
-      #  
+      #
       # Draw the centre label
       #
       left_string(cw, self.label_x + lw + DEFAULT_TEXT_X_SURROUND, self.label_y + self.label_h / 2, self.label, self.accel)
@@ -274,7 +274,7 @@ class MenuComponent : SetFields : Connectable: Object(
          "label_left" : set_label_left(string_val(attr, val))
          "label_right" : set_label_right(string_val(attr, val))
          "accel" : set_accel(string_val(attr, val))
-         "is_shaded" : 
+         "is_shaded" :
             if test_flag(attr, val) then
                set_is_shaded()
             else

--- a/uni/gui/node.icn
+++ b/uni/gui/node.icn
@@ -89,7 +89,7 @@ class Node : SetFields : Object(
 
    #
    # Set the bitmaps for this node.  The parameter should provide a list of 3
-   # bitmaps.  The first is displayed if the {Node} is open and has subnodes, the 
+   # bitmaps.  The first is displayed if the {Node} is open and has subnodes, the
    # second is displayed if the {Node} is closed and has subnodes, and the third is
    # displayed if the node has no subnodes.
    # @param x  A list of 3 bitmaps.
@@ -151,7 +151,7 @@ class Node : SetFields : Object(
    method clear_expanded()
       return is_expanded_flag := &null
    end
-      
+
    #
    # Toggle the opened status of the {Node}. Note that this will not update the GUI, to do that
    # call tree.tree_structure_changed() on the tree in which the node resides.
@@ -192,12 +192,12 @@ class Node : SetFields : Object(
          "label" : set_label(string_val(attr, val))
          "always_expandable" :
             if test_flag(attr, val) then
-               set_always_expandable() 
+               set_always_expandable()
             else
                clear_always_expandable()
          "expanded" :
             if test_flag(attr, val) then
-               set_expanded() 
+               set_expanded()
             else
                clear_expanded()
          default : field_error("Unknown attribute " || attr)

--- a/uni/gui/popupmenu.icn
+++ b/uni/gui/popupmenu.icn
@@ -12,12 +12,12 @@ link graphics
 $include "guih.icn"
 
 #
-# This is a popup menu class, namely a menu which pops up under the 
+# This is a popup menu class, namely a menu which pops up under the
 # cursor under the direction of the program (for example when a right
 # click has occurred.
 #
 class PopupMenu : Component(
-   menu,                    #            
+   menu,                    #
    is_open                  #
    )
 
@@ -72,7 +72,7 @@ class PopupMenu : Component(
       if \self.is_open then {
          if not(e === (&lrelease | &rrelease | &mrelease) & &x = self.x & &y = self.y) then
             self.menu.handle_event(e)
-      } 
+      }
    end
 
    method resize()
@@ -101,13 +101,13 @@ class PopupMenu : Component(
       W := self.get_parent_win()
       self.set_pos(WAttrib(W, "pointerx"), WAttrib(W,"pointery"))
       self.resize()
-      self.menu.set_parent_component(self)         
+      self.menu.set_parent_component(self)
       self.menu.set_abs_coords(self.x, self.y + self.h)
       self.menu.resize()
 
       if self.menu.y + self.menu.h > WAttrib(W, "height") then
          y1 := 0 <= WAttrib(W, "height") - self.menu.h
-      
+
       if self.menu.x + self.menu.w > WAttrib(W, "width") then
          x1 := 0 <= WAttrib(W, "pointerx") - self.menu.w
 

--- a/uni/gui/progressbar.icn
+++ b/uni/gui/progressbar.icn
@@ -35,7 +35,7 @@ class ProgressBar : Component(
       bar_x := self.x + DEFAULT_TEXT_X_SURROUND
       bar_y := self.y + BORDER_WIDTH + 3
       bar_w := self.w - 2 * DEFAULT_TEXT_X_SURROUND
-      bar_h := self.h - 2 * (BORDER_WIDTH + 3) 
+      bar_h := self.h - 2 * (BORDER_WIDTH + 3)
    end
 
    method display(buffer_flag)

--- a/uni/gui/rangespin.icn
+++ b/uni/gui/rangespin.icn
@@ -59,7 +59,7 @@ class RangeSpin : EditSpin(lo, hi, increment_size)
          else if x > \self.hi then
             tf.set_contents(self.hi)
          fire(SELECTION_CHANGED_EVENT, ev)
-      } 
+      }
    end
 
    #

--- a/uni/gui/scrollbar.icn
+++ b/uni/gui/scrollbar.icn
@@ -16,11 +16,11 @@ $define MIN_BAR_SIZE 8
 #
 # Component representing the bar area
 #
-class BarArea : Component( 
-   bar_x,                   #             
-   bar_y,                   #             
-   bar_w,                   #             
-   bar_h                    #             
+class BarArea : Component(
+   bar_x,                   #
+   bar_y,                   #
+   bar_w,                   #
+   bar_h                    #
 )
    method display(buffer_flag)
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
@@ -43,7 +43,7 @@ end
 # be set with the {set_value()} method.
 # @example
 # @ vb := ScrollBar()
-# @ vb.set_pos("85%", "25%")      
+# @ vb.set_pos("85%", "25%")
 # @ vb.set_size(20, "40%")
 # @ vb.set_total_size(130)
 # @ vb.set_page_size(30)
@@ -61,7 +61,7 @@ end
 # range settings if desired.
 # @example
 # @ vb := ScrollBar()
-# @ vb.set_pos("85%", "25%")      
+# @ vb.set_pos("85%", "25%")
 # @ vb.set_size(20, "40%")
 # @ vb.set_range(2, 25)
 # @ vb.set_value(10)
@@ -76,24 +76,24 @@ end
 # listen for SCROLLBAR_PRESSED_EVENT.
 #
 class ScrollBar : Component(
-   value,                   #             
-   page_size,               #                 
-   increment_size,          #                      
-   total_size,              #                  
-   hi,                      #          
-   lo,                      #          
-   bar_down,                #                
+   value,                   #
+   page_size,               #
+   increment_size,          #
+   total_size,              #
+   hi,                      #
+   lo,                      #
+   bar_down,                #
    is_paging,               #
    repeat_delay,            #
-   bar_down_offset,         #                       
+   bar_down_offset,         #
    bar_area,                #
-   b1,                      #          
-   b2,                      #          
-   is_horizontal_flag,      #                          
+   b1,                      #
+   b2,                      #
+   is_horizontal_flag,      #
    bar_pos,                 #  Orientation independent bar pos
-   bar_size,                #                
+   bar_size,                #
    bar_area_pos,            #  Orientation independent bararea pos
-   bar_area_size,           #                     
+   bar_area_size,           #
    is_range_flag            #
    )
 
@@ -194,7 +194,7 @@ class ScrollBar : Component(
       if /self.is_horizontal_flag then
          self.bar_area.bar_y := self.bar_pos
       else
-         self.bar_area.bar_x := self.bar_pos        
+         self.bar_area.bar_x := self.bar_pos
       self.bar_area.invalidate()
    end
 
@@ -228,17 +228,17 @@ class ScrollBar : Component(
             self.bar_down_offset := &y - self.bar_area.bar_y
          else
             self.bar_down_offset := &x - self.bar_area.bar_x
-         fire(SCROLLBAR_PRESSED_EVENT, e)     
+         fire(SCROLLBAR_PRESSED_EVENT, e)
       } else if (/self.is_horizontal_flag & (self.bar_area.x <= &x < self.bar_area.x + self.bar_area.w) & (self.bar_area.y  <= &y < self.bar_area.bar_y)) | ((self.bar_area.y <= &y < self.bar_area.y + self.bar_area.h) & (self.bar_area.x  <= &x < self.bar_area.bar_x)) then {
          self.move_value(self.get_value() - self.page_size)
          self.set_pos_from_value()
          start_paging(1)
-         fire(SCROLLBAR_PRESSED_EVENT, e)     
+         fire(SCROLLBAR_PRESSED_EVENT, e)
       } else  if (/self.is_horizontal_flag & (self.bar_area.x <= &x < self.bar_area.x + self.bar_area.w) & ( self.bar_area.bar_y + self.bar_area.bar_h  <= &y <  self.bar_area.y + self.bar_area.h)) | ((self.bar_area.y <= &y < self.bar_area.y + self.bar_area.h) & ( self.bar_area.bar_x + self.bar_area.bar_w  <= &x <  self.bar_area.x + self.bar_area.w)) then {
          self.move_value(self.get_value() + self.page_size)
          self.set_pos_from_value()
          start_paging(2)
-         fire(SCROLLBAR_PRESSED_EVENT, e)     
+         fire(SCROLLBAR_PRESSED_EVENT, e)
       }
    end
 
@@ -248,19 +248,19 @@ class ScrollBar : Component(
          # Released; clear flag
          #
          self.bar_down := &null
-         fire(SCROLLBAR_PRESSED_EVENT, e)     
+         fire(SCROLLBAR_PRESSED_EVENT, e)
       } else if \self.is_paging then
          stop_paging()
    end
 
    method tick()
       if dispatcher.curr_time_of_day() > self.repeat_delay then {
-         if self.is_paging === 1 then 
+         if self.is_paging === 1 then
             self.move_value(self.get_value() - self.page_size)
          else
             self.move_value(self.get_value() + self.page_size)
          self.set_pos_from_value()
-         fire(SCROLLBAR_PRESSED_EVENT)     
+         fire(SCROLLBAR_PRESSED_EVENT)
       }
    end
 
@@ -302,15 +302,15 @@ class ScrollBar : Component(
       else
          self.move_bar_pos(&x - self.bar_down_offset)
       self.set_value_from_pos()
-      fire(SCROLLBAR_DRAGGED_EVENT, e)     
+      fire(SCROLLBAR_DRAGGED_EVENT, e)
    end
 
    method handle_event(e)
       b1.handle_event(e)
       b2.handle_event(e)
-      if e === (&lpress | &rpress | &mpress) then 
+      if e === (&lpress | &rpress | &mpress) then
          handle_press(e)
-      else if e === (&lrelease | &rrelease | &mrelease) then 
+      else if e === (&lrelease | &rrelease | &mrelease) then
          handle_release(e)
       else if \self.bar_down & (e === (&ldrag | &rdrag | &mdrag)) then
          handle_drag(e)
@@ -380,7 +380,7 @@ class ScrollBar : Component(
             # Total <= page; these settings produce an immovable full size bar.
             #
             self.hi := 0
-            self.bar_size := self.bar_area_size 
+            self.bar_size := self.bar_area_size
          }
       } else {
          #
@@ -430,7 +430,7 @@ class ScrollBar : Component(
          self.bar_area_pos := self.bar_area.y
          self.bar_area.bar_w := self.bar_area.w
          self.bar_area_size := self.bar_area.h
-   
+
          #
          # Set button positions
          #
@@ -458,15 +458,15 @@ class ScrollBar : Component(
          b2.set_img(img_style("arrow_right"))
       }
 
-      b1.resize()      
-      b2.resize()      
+      b1.resize()
+      b2.resize()
 
       reconfigure()
    end
 
    method set_one(attr, val)
       case attr of {
-         "is_horizontal" : if test_flag(attr, val) then 
+         "is_horizontal" : if test_flag(attr, val) then
             set_is_horizontal()
          else
             clear_is_horizontal()

--- a/uni/gui/sizer.icn
+++ b/uni/gui/sizer.icn
@@ -20,7 +20,7 @@ $include "guih.icn"
 #
 class Sizer : Component(
    is_held,
-   is_horizontal_flag,      #                          
+   is_horizontal_flag,      #
    temp_win,                #
    temp_w,
    temp_h,
@@ -133,8 +133,8 @@ class Sizer : Component(
          if self.in_region() then {
             unique_start()
             self.is_held := 1
-            temp_w := parent_dialog.get_w_reference() 
-            temp_h := parent_dialog.get_h_reference() 
+            temp_w := parent_dialog.get_w_reference()
+            temp_h := parent_dialog.get_h_reference()
             self.temp_win := WOpen("canvas=hidden", "size=" || temp_w || "," || temp_h)
             CopyArea(cwin, temp_win, 0, 0, temp_w, temp_h, 0, 0)
             if \self.is_horizontal_flag then {
@@ -162,7 +162,7 @@ class Sizer : Component(
 
    method set_one(attr, val)
       case attr of {
-         "is_horizontal" : if test_flag(attr, val) then 
+         "is_horizontal" : if test_flag(attr, val) then
             set_is_horizontal()
          else
             clear_is_horizontal()

--- a/uni/gui/slider.icn
+++ b/uni/gui/slider.icn
@@ -21,7 +21,7 @@ $define TICK_H 10
 #
 # Component representing the slider area
 # @p
-class SliderArea : Component(inner_x, inner_y, inner_w, inner_h, slider_x, slider_y, slider_w, slider_h) 
+class SliderArea : Component(inner_x, inner_y, inner_w, inner_h, slider_x, slider_y, slider_w, slider_h)
    method display(buffer_flag)
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
       DrawSunkenRectangle(self.cbwin, self.inner_x, self.inner_y, self.inner_w, self.inner_h)
@@ -39,7 +39,7 @@ end
 #
 # @example
 # @ s := Slider()
-# @ s.set_pos("85%", "25%")      
+# @ s.set_pos("85%", "25%")
 # @ s.set_size(, "40%") # Width defaults for a vertical slider
 # @ s.set_range(0,5)
 # @ s.set_value(2)
@@ -49,14 +49,14 @@ end
 # @ self.add(s)
 #
 class Slider : Component(
-   value,                   
+   value,
    slider_down,
    slider_down_offset,
    slider_area,
    slider_pos,
    slider_area_pos,
    slider_area_size,
-   is_horizontal_flag,                                
+   is_horizontal_flag,
    discrete_vals,
    ticks,
    labels,
@@ -65,9 +65,9 @@ class Slider : Component(
    labels_pos,
    is_paging,
    increment_size,
-   repeat_delay,            
-   hi,                                
-   lo                                 
+   repeat_delay,
+   hi,
+   lo
 )
 
    #
@@ -85,7 +85,7 @@ class Slider : Component(
    end
 
    #
-   # Configure so that on release after a drag, the value will snap to 
+   # Configure so that on release after a drag, the value will snap to
    # the nearest multiple of n.
    #
    method set_snaps(n)
@@ -210,17 +210,17 @@ class Slider : Component(
             self.slider_down_offset := &y - self.slider_pos
          else
             self.slider_down_offset := &x - self.slider_pos
-         fire(SLIDER_PRESSED_EVENT, e)     
+         fire(SLIDER_PRESSED_EVENT, e)
       } else if (/self.is_horizontal_flag & (self.slider_area.x <= &x < self.slider_area.x + self.slider_area.w) & (self.slider_area.y  <= &y < self.slider_area.slider_y)) | ((self.slider_area.y <= &y < self.slider_area.y + self.slider_area.h) & (self.slider_area.x  <= &x < self.slider_area.slider_x)) then {
          self.move_value(self.get_value() - self.increment_size)
          self.set_pos_from_value()
          start_paging(1)
-         fire(SLIDER_PRESSED_EVENT, e)     
+         fire(SLIDER_PRESSED_EVENT, e)
       } else  if (/self.is_horizontal_flag & (self.slider_area.x <= &x < self.slider_area.x + self.slider_area.w) & ( self.slider_area.slider_y + self.slider_area.slider_h  <= &y <  self.slider_area.y + self.slider_area.h)) | ((self.slider_area.y <= &y < self.slider_area.y + self.slider_area.h) & ( self.slider_area.slider_x + self.slider_area.slider_w  <= &x <  self.slider_area.x + self.slider_area.w)) then {
          self.move_value(self.get_value() + self.increment_size)
          self.set_pos_from_value()
          start_paging(2)
-         fire(SLIDER_PRESSED_EVENT, e)     
+         fire(SLIDER_PRESSED_EVENT, e)
       }
    end
 
@@ -234,14 +234,14 @@ class Slider : Component(
             self.value +:= self.snaps / 2
             self.set_value(self.value - (self.value % snaps))
          }
-         fire(SLIDER_PRESSED_EVENT, e)     
+         fire(SLIDER_PRESSED_EVENT, e)
       } else if \self.is_paging then
          stop_paging()
    end
 
    method tick()
       if dispatcher.curr_time_of_day() > self.repeat_delay then {
-         if self.is_paging === 1 then 
+         if self.is_paging === 1 then
             self.move_value(self.get_value() - self.increment_size)
          else
             self.move_value(self.get_value() + self.increment_size)
@@ -270,13 +270,13 @@ class Slider : Component(
       else
          self.move_slider_pos(&x - self.slider_down_offset)
       self.set_value_from_pos()
-      fire(SLIDER_DRAGGED_EVENT, e)     
+      fire(SLIDER_DRAGGED_EVENT, e)
    end
 
    method handle_event(e)
-      if e === (&lpress | &rpress | &mpress) then 
+      if e === (&lpress | &rpress | &mpress) then
          handle_press()
-      else if e === (&lrelease | &rrelease | &mrelease) then 
+      else if e === (&lrelease | &rrelease | &mrelease) then
          handle_release()
       else if \self.slider_down & (e === (&ldrag | &rdrag | &mdrag)) then
          handle_drag()
@@ -426,7 +426,7 @@ class Slider : Component(
 
    method set_one(attr, val)
       case attr of {
-         "is_horizontal" : if test_flag(attr, val) then 
+         "is_horizontal" : if test_flag(attr, val) then
             set_is_horizontal()
          else
             clear_is_horizontal()

--- a/uni/gui/spin.icn
+++ b/uni/gui/spin.icn
@@ -45,7 +45,7 @@ class Spin : Component(up, down)
       do_decrement()
       fire(SELECTION_CHANGED_EVENT, e)
    end
-   
+
    initially()
       self.Component.initially()
       self.up := IconButton()

--- a/uni/gui/staticspin.icn
+++ b/uni/gui/staticspin.icn
@@ -16,7 +16,7 @@ class SpinLabel:Label()
       if \self.has_focus then {
          if e === Key_Up then
             parent.go_up(e)
-         else if e === Key_Down then 
+         else if e === Key_Down then
             parent.go_down(e)
       }
    end
@@ -55,7 +55,7 @@ class StaticSpin : Spin(lab)
 
    method display(buffer_flag)
       #
-      # Draw text element 
+      # Draw text element
       #
       EraseRectangle(self.cbwin, self.x, self.y, self.w, self.h)
       DrawSunkenRectangle(self.cbwin, self.x, self.y, self.w, self.h)

--- a/uni/gui/submenu.icn
+++ b/uni/gui/submenu.icn
@@ -17,8 +17,8 @@ $include "guih.icn"
 # see for example the Palette class.
 #
 class SubMenu : MenuComponent(
-   x,                       #         
-   y                        #         
+   x,                       #
+   y                        #
    )
 
    #

--- a/uni/gui/tabitem.icn
+++ b/uni/gui/tabitem.icn
@@ -26,10 +26,10 @@ $include "guih.icn"
 # font, colour and so on.
 #
 class TabItem : Component(
-   label,                   #             
-   label_x,                 #               
-   line_no,                 #               
-   label_w                  #               
+   label,                   #
+   label_x,                 #
+   line_no,                 #
+   label_w                  #
    )
 
    #
@@ -38,11 +38,11 @@ class TabItem : Component(
    method set_label(x)
       return self.label := x
    end
- 
+
    method get_label()
       return .(self.label)
    end
- 
+
    method check_label()
       if /self.label then
          fatal("no label specified")

--- a/uni/gui/table.icn
+++ b/uni/gui/table.icn
@@ -29,7 +29,7 @@ class TableContent : SelectableScrollArea()
 
    #
    # Draw an individual column for one row's data.  This could
-   # be over-ridden to give a custom table with data 
+   # be over-ridden to give a custom table with data
    # other than strings.
    #
    # @param row the row number to draw
@@ -72,7 +72,7 @@ class TableContent : SelectableScrollArea()
       if \selection_cw then
          FillRectangle(selection_cw, self.view.x, yp - self.line_height / 2, self.view.w, self.line_height)
 
-      if \cursor_cw then 
+      if \cursor_cw then
          Rectangle(cursor_cw, self.view.x, yp - self.line_height / 2, self.view.w, self.line_height)
 
       if \highlight_cw then
@@ -87,7 +87,7 @@ class TableHeader : Component(
    button_x,
    button_y,
    button_w,
-   button_h   
+   button_h
    )
 
    method get_x_reference()
@@ -327,7 +327,7 @@ class Table : Component(
       sw := 0
       every col := !self.table_header.children do
          (sw +:= \col.column_width) | put(l, col)
-      
+
       if *l = 0 then
          return
 

--- a/uni/gui/tablecolumn.icn
+++ b/uni/gui/tablecolumn.icn
@@ -25,8 +25,8 @@ $define MIN_BUTTON_WIDTH 20
 # parent class, {TextButton}.
 #
 class TableColumn : TextButton(
-   column_width,  
-   is_resizing,       
+   column_width,
+   is_resizing,
    pointer_flag
    )
 
@@ -52,14 +52,14 @@ class TableColumn : TextButton(
 
    method handle_event(e)
       if e === -12 then {
-         if (self.parent.button_x <= &x < self.parent.button_x + self.parent.button_w) & 
+         if (self.parent.button_x <= &x < self.parent.button_x + self.parent.button_w) &
             self.in_region() &
             (self.x + self.w - CHANGE_SIZE_BORDER <= &x < self.x + self.w) then
             pointer_on()
          else
             pointer_off()
       } else if e === (&lpress | &rpress | &mpress) then {
-         if (self.parent.button_x <= &x < self.parent.button_x + self.parent.button_w) & 
+         if (self.parent.button_x <= &x < self.parent.button_x + self.parent.button_w) &
             self.in_region() then {
             if(self.x + self.w - CHANGE_SIZE_BORDER <= &x < self.x + self.w) then {
                self.is_resizing := 1
@@ -112,13 +112,13 @@ class TableColumn : TextButton(
          "l" : left_string(self.cbwin, self.tx, yoff, self.label)
          "r" : right_string(self.cbwin, self.tx + self.tw, yoff, self.label)
          default : fatal("incorrect internal_alignment specifier: " || image(self.internal_alignment))
-      }         
+      }
 
       if \self.is_down then {
          cw := Clone(self.cbwin, "drawop=reverse")
          FillRectangle(cw, self.x, self.y, self.w - CHANGE_SIZE_BORDER, self.h)
          Uncouple(cw)
-      } 
+      }
       DrawRaisedRectangle(self.cbwin, self.x + self.w - CHANGE_SIZE_BORDER, self.y + BORDER_WIDTH, CHANGE_SIZE_BORDER, self.h - 2 * BORDER_WIDTH)
 
       Clip(self.cbwin)

--- a/uni/gui/tabset.icn
+++ b/uni/gui/tabset.icn
@@ -18,10 +18,10 @@ $include "guih.icn"
 # user interaction.
 #
 class TabSet : Component(
-   which_one,               #                 
-   tab_h,                   #             
-   lines,                   #             
-   line_h,                  #              
+   which_one,               #
+   tab_h,                   #
+   lines,                   #
+   line_h,                  #
    line_break               #
    )
 
@@ -124,10 +124,10 @@ class TabSet : Component(
       local m
       if &meta & m := find_key(e) then {
          self.set_which_one(m)
-         fire(SELECTION_CHANGED_EVENT, e)     
+         fire(SELECTION_CHANGED_EVENT, e)
       } else if e === (&lpress | &rpress | &mpress) & (self.y <= &y < self.y + self.tab_h) then {
          self.set_which_one(which_tab())
-         fire(SELECTION_CHANGED_EVENT, e)     
+         fire(SELECTION_CHANGED_EVENT, e)
       }
 
       which_one.handle_event(e)
@@ -135,7 +135,7 @@ class TabSet : Component(
 
    #
    # Find the TabItem with the given accelerator.  This isn't done using
-   # the handle_accel method in the TabItem because only the current 
+   # the handle_accel method in the TabItem because only the current
    # TabItem is treated as being unhidden.
    # @p
    method find_key(k)

--- a/uni/gui/textdisplay.icn
+++ b/uni/gui/textdisplay.icn
@@ -14,9 +14,9 @@ $include "guih.icn"
 #
 # This class displays a list of strings.
 #
-class TextDisplay : DisplayScrollArea(contents, 
+class TextDisplay : DisplayScrollArea(contents,
                                       wrap_mode,
-                                      view_list, 
+                                      view_list,
                                       line_splitter,
                                       tab_width)
    method get_line_count()
@@ -86,7 +86,7 @@ class TextDisplay : DisplayScrollArea(contents,
          s := self.contents[i]
          every j := line_splitter.split(s) do {
             p := s[pos:j]
-            put(view_list, ViewLine(i, p, pos, j - 1, 
+            put(view_list, ViewLine(i, p, pos, j - 1,
                                     TextWidthEx(self.cwin, p,,, self.tab_width)))
             pos := j
          }
@@ -95,7 +95,7 @@ class TextDisplay : DisplayScrollArea(contents,
 
    method set_internal_fields()
       local had_vsb
-      
+
       had_vsb := self.vsb
 
       if /view_list then

--- a/uni/gui/textlist.icn
+++ b/uni/gui/textlist.icn
@@ -40,7 +40,7 @@ class TextList : SelectableScrollArea()
       s := contents[i]
 
       #
-      # Cosmetic - add a little to the left of xp; this looks better 
+      # Cosmetic - add a little to the left of xp; this looks better
       # with the cursor, selection and highlight.
       #
       left_string(self.cbwin, xp + HIGHLIGHT_TEXT_SPACING, yp, detab(s))

--- a/uni/gui/ticker.icn
+++ b/uni/gui/ticker.icn
@@ -58,7 +58,7 @@ class Ticker : Object : Connectable(
    # Start the ticker process, with the {tick()}
    # method being invoked approximately every {n} milliseconds.
    #
-   # @param n   the ticker interval in milliseconds (default 0, ie 
+   # @param n   the ticker interval in milliseconds (default 0, ie
    #            repeat as regularly as possible).
    # @param d   the initial delay, if any (default 0)
    # @param c   the number of times to invoke (default infinite).

--- a/uni/gui/tree.icn
+++ b/uni/gui/tree.icn
@@ -68,7 +68,7 @@ class Tree : SelectableScrollArea(
    method set_default_bmps(l)
       return default_bmps := l
    end
-   
+
    #
    # Set the root node of the {Tree}.
    #
@@ -171,7 +171,7 @@ class Tree : SelectableScrollArea(
             flatten2(l, root_node.subnodes[1], "n")
          } else {
             flatten2(l, root_node.subnodes[1], "d")
-            every sub := root_node.subnodes[2 to *root_node.subnodes - 1] do 
+            every sub := root_node.subnodes[2 to *root_node.subnodes - 1] do
                flatten2(l, sub, "f")
             flatten2(l, root_node.subnodes[-1], "u")
          }
@@ -186,7 +186,7 @@ class Tree : SelectableScrollArea(
       n.depth := *dl
       put(l, n)
       if n.is_expanded() then {
-         every sub := n.subnodes[1 to *n.subnodes - 1] do 
+         every sub := n.subnodes[1 to *n.subnodes - 1] do
             flatten2(l, sub, dl || "f")
          flatten2(l, n.subnodes[-1], dl || "u")
       }
@@ -241,7 +241,7 @@ class Tree : SelectableScrollArea(
       every j := 1 to N.depth - 1 do {
          if N.draw_line[j] == ("f"|"d") then
             DrawLine(dashed, lp + col_w / 2, yp - self.line_height / 2, lp + col_w / 2, yp + self.line_height / 2)
-         
+
          lp +:= col_w
       }
       if N.depth > 0 then {
@@ -300,7 +300,7 @@ class Tree : SelectableScrollArea(
                set_show_root()
             else
                clear_show_root()
-         "show_root_handles" : 
+         "show_root_handles" :
             if test_flag(attr, val) then
                set_show_root_handles()
             else

--- a/uni/gui/treetable.icn
+++ b/uni/gui/treetable.icn
@@ -61,7 +61,7 @@ class TreeTableContent:Tree()
 
    #
    # Draw an individual column for one row's data.  This could
-   # be over-ridden to give a custom table with data 
+   # be over-ridden to give a custom table with data
    # other than strings.
    #
    # @param row the row number to draw
@@ -72,7 +72,7 @@ class TreeTableContent:Tree()
    # @param ch the height of the cell
    #
    method draw_cell(row, col, cx, cy, cw, ch)
-      local s, l 
+      local s, l
 
       s := self.contents[row].get_col(col) | fail
       case get_column(col).internal_alignment of {

--- a/uni/ide/definitions.icn
+++ b/uni/ide/definitions.icn
@@ -1,7 +1,7 @@
 #
 # Definitions Proc:
 procedure definitions(s)
-   
+
    return case s of {
 
       "break":
@@ -9,19 +9,19 @@ procedure definitions(s)
           " ",
           "The break expression exits the nearest enclosing loop. expr is evaluated",
           "and treated as the result of the entire loop expression. If",
-          "expr is another break expression, multiple loops will be exited."] 
+          "expr is another break expression, multiple loops will be exited."]
 
       "case":
          ["case expr of { ? }"||repl(" ",42)||"select expression",
           " ",
           "The case expression selects one of several branches of code to be executed."]
-      
+
       "class":
          ["class name [: superclass]* (fields) methods [initially] end class declaration",
           " ",
           "The class declaration introduces a new object type into the program. The class declaration",
           "may include a list of superclasses, fields, methods, and an optional initially section.",
-          " "] ||| definitions("method") |||[" "] ||| definitions("initially") |||[" "] 
+          " "] ||| definitions("method") |||[" "] ||| definitions("initially") |||[" "]
 
       "create":
          ["create expr"||repl(" ",27)||"create co-expression",
@@ -38,7 +38,7 @@ procedure definitions(s)
           " ",
           "The do reserved word specifies an expression to be executed for each iteration of a",
           "preceding while, every, or suspend loop (yes, suspend is a looping construct)."]
-      
+
       "else":
          ["  if expr1 then expr2 else expr3                                 else branch",
           " ",
@@ -93,7 +93,7 @@ procedure definitions(s)
 
       "invocable":
          ["invocable procedure [, procedure]*                           allow string invocation"]
-      
+
       "invocable all":
          ["invocable all                  allow string invocation",
           " ",
@@ -110,7 +110,7 @@ procedure definitions(s)
           " ",
           "The local declaration introduces one or more local variables into the current procedure or",
           "method body. Variable declarations must be at the beginning of a procedure or method."]
-      
+
       "method":
          ["method name (params) body end" || right("declare method", 82),
           " ",
@@ -141,7 +141,7 @@ procedure definitions(s)
        "The package declaration segregates the global names in the current source file. In order to",
        "refer to them, client code must either import the package, or prepend name . (the package",
        "name followed by a period) onto the front of a name in the package."]
-      
+
       "procedure":
          ["procedure name (params) body end" ||  right("declare procedure",80),
           " ",
@@ -168,13 +168,13 @@ procedure definitions(s)
           " ",
           "The return expression exits a procedure or method invocation, producing expr as its",
           "result. The invocation may not be resumed."]
-      
+
       "static":
          ["   static var [, var]*                   declare static variables",
           " ",
           "The static declaration introduces one or more local variables into the current procedure or",
           "method body. Variable declarations must be at the beginning of a procedure or method."]
-      
+
       "suspend":
          ["suspend expr [do expr]"||right("produce result from invocation",88),
           " ",
@@ -202,11 +202,11 @@ procedure definitions(s)
           " ",
           "The until expression loops as long as expr1 fails.",
           " "] ||| definitions("do")
-      
+
       "while":
          ["while expr1 [do expr2]                          loop until failure",
           " ",
           "The while expression loops as long as expr1 succeeds.",
-          " "] ||| definitions("do")  
+          " "] ||| definitions("do")
    }
 end

--- a/uni/ide/ivib/basiccanvascomponentui.icn
+++ b/uni/ide/ivib/basiccanvascomponentui.icn
@@ -35,7 +35,7 @@ class BasicCanvasComponentUI : CanvasComponentUI(category, name, icon)
       return n
    end
 
-   method get_button() 
+   method get_button()
       local b
       if /icon then
          fail

--- a/uni/ide/ivib/canvasborder.icn
+++ b/uni/ide/ivib/canvasborder.icn
@@ -45,7 +45,7 @@ class CanvasBorder : CanvasComponent : Border()
    #
    method cp()
       local c, e
-      c := CanvasBorder() 
+      c := CanvasBorder()
       self.CanvasComponent.cp(c)
       every e := !self.children do {
          c.add(e.cp())
@@ -97,7 +97,7 @@ class CanvasBorder : CanvasComponent : Border()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Internal Alignment", "internal_alignment"],
           ["Children", "children"],
           ["Title Obj", "title_obj"]
@@ -112,7 +112,7 @@ class CanvasBorder : CanvasComponent : Border()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local e, o
@@ -153,7 +153,7 @@ class CanvasBorder : CanvasComponent : Border()
          if o := e.inside(c) then
             return o
 
-      if (c ~=== self) & (((self.x + self.w - INSIDE_BOX <= c.x < self.x + self.w) & (self.y + self.h - INSIDE_BOX <= c.y < self.y + self.h) & /title_obj) | ((self.x <= c.x < self.x + self.w) & (self.y <= c.y < self.y + self.h) & (self.x <= c.x + c.w <= self.x + self.w) & (self.y <= c.y + c.h <= self.y + self.h))) then 
+      if (c ~=== self) & (((self.x + self.w - INSIDE_BOX <= c.x < self.x + self.w) & (self.y + self.h - INSIDE_BOX <= c.y < self.y + self.h) & /title_obj) | ((self.x <= c.x < self.x + self.w) & (self.y <= c.y < self.y + self.h) & (self.x <= c.x + c.w <= self.x + self.w) & (self.y <= c.y + c.h <= self.y + self.h))) then
          return self
    end
 

--- a/uni/ide/ivib/canvasborderdialog.icn
+++ b/uni/ide/ivib/canvasborderdialog.icn
@@ -14,8 +14,8 @@ import gui
 #
 #
 class CanvasBorderDialog : CanvasComponentDialog(
-   c,                       #         
-   internal_alignment,      #                          
+   c,                       #
+   internal_alignment,      #
    internal_alignment_list  #
    )
 

--- a/uni/ide/ivib/canvasborderui.icn
+++ b/uni/ide/ivib/canvasborderui.icn
@@ -17,7 +17,7 @@ class CanvasBorderUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Containers", 
+      self.BasicCanvasComponentUI.initially("Containers",
                                             "Border",
                                             $include "icon/icn4.icon"
                                             )

--- a/uni/ide/ivib/canvasbutton.icn
+++ b/uni/ide/ivib/canvasbutton.icn
@@ -12,7 +12,7 @@
 ############################################################################
 #
 # Class for representing Buttons.
-# 
+#
 class CanvasButton : CanvasComponent()
    #
    # Generate code into Code object c.
@@ -34,7 +34,7 @@ class CanvasButton : CanvasComponent()
          c.line(name || ".set_toggles()")
       else
          c.line(name || ".clear_toggles()")
-         
+
       if \self.parent_button_group then
          c.line(self.parent_button_group.name || ".add(" || name || ")")
 
@@ -46,14 +46,14 @@ class CanvasButton : CanvasComponent()
             c.line(self.parent_check_box_group.name || ".set_which_one(" || name || ")")
          else
             c.line(name || ".set_is_checked()")
-      }         
+      }
    end
 
    #
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Label", "label"],
           ["No Keyboard", "no_keyboard_flag"],
           ["Img Up", "img_up"],
@@ -95,7 +95,7 @@ class CanvasButton : CanvasComponent()
          if \c.parent_check_box_group then
             c.parent_check_box_group.which_one := c
          c.set_is_checked()
-      }         
+      }
       return c
    end
 

--- a/uni/ide/ivib/canvasbuttondialog.icn
+++ b/uni/ide/ivib/canvasbuttondialog.icn
@@ -15,15 +15,15 @@ $include "guih.icn"
 #
 #
 class CanvasButtonDialog : CanvasComponentDialog(
-   label_str,               #                 
-   button_group_list,       #                  
-   in_checkbox_group,       #                          
-   browse_up,               #                     
-   browse_down,             #                     
+   label_str,               #
+   button_group_list,       #
+   in_checkbox_group,       #
+   browse_up,               #
+   browse_down,             #
    icon_up,
    icon_down,
-   keyboard,                #                
-   checkbox_group_list,     #                  
+   keyboard,                #
+   checkbox_group_list,     #
    in_button_group,         #
    button_tab_set,
    tab_basic,
@@ -46,7 +46,7 @@ class CanvasButtonDialog : CanvasComponentDialog(
       }
       return
    end
-      
+
    method set_vals(c)
       self.CanvasComponentDialog.set_vals(c)
       if not tab_images.is_shaded() then
@@ -60,7 +60,7 @@ class CanvasButtonDialog : CanvasComponentDialog(
       # a different one.
       #
       if (\c.parent_check_box_group).which_one === c then
-         c.parent_check_box_group.which_one := &null                 
+         c.parent_check_box_group.which_one := &null
 
       if in_checkbox_group.is_checked() then {
          #
@@ -68,7 +68,7 @@ class CanvasButtonDialog : CanvasComponentDialog(
          #
          c.set_parent_check_box_group(c.parent_Canvas.checkbox_groups.group_number(checkbox_group_list.get_selection()))
          if initially_checked.is_checked() then {
-            #      
+            #
             # Turn off current one on, if any; turn self on.
             #
             (\c.parent_check_box_group.which_one).is_checked_flag := &null
@@ -180,7 +180,7 @@ class CanvasButtonDialog : CanvasComponentDialog(
       checkbox_group_list.set_selection_list(c.parent_Canvas.checkbox_groups.string_rep())
       tab_groups.add(checkbox_group_list)
       add_tab(tab_groups)
-      
+
       tab_images := TabItem("label=Images", "accel=i")
       panel_1 := Border()
       panel_1.set_pos("100%-50", "50%")
@@ -272,7 +272,7 @@ class CanvasButtonDialog : CanvasComponentDialog(
          if \c.parent_button_group then {
             in_button_group.set_is_checked()
             button_group_list.set_selection(c.parent_Canvas.button_groups.group_index(c.parent_button_group))
-         } else 
+         } else
             button_group_list.set_is_shaded()
       }
 

--- a/uni/ide/ivib/canvascheckbox.icn
+++ b/uni/ide/ivib/canvascheckbox.icn
@@ -17,8 +17,8 @@ class CanvasCheckBox : CanvasButton : CheckBox()
    method set_parent_check_box_group(x)
       #
       # Set the images to the standard diamonds, unless custom images already set.
-      #  
-      if self.img_up == img_style("box_up") & self.img_down == img_style("box_down") then 
+      #
+      if self.img_up == img_style("box_up") & self.img_down == img_style("box_down") then
          self.set_imgs(img_style("diamond_up"), img_style("diamond_down"))
 
       self.CheckBox.set_parent_check_box_group(x)
@@ -31,7 +31,7 @@ class CanvasCheckBox : CanvasButton : CheckBox()
       self.CanvasButton.gen_code(c)
 
       c.line(name || ".set_label(" || image(self.label) || ")")
-      if not((/self.parent_check_box_group & self.img_up == img_style("box_up") & self.img_down == img_style("box_down")) | 
+      if not((/self.parent_check_box_group & self.img_up == img_style("box_up") & self.img_down == img_style("box_down")) |
              (\self.parent_check_box_group & self.img_up == img_style("diamond_up") & self.img_down == img_style("diamond_down"))) then
          c.line(name || ".set_imgs(" || image(self.img_up) || ", " || image(self.img_down) || ")")
    end

--- a/uni/ide/ivib/canvascheckboxgroup.icn
+++ b/uni/ide/ivib/canvascheckboxgroup.icn
@@ -22,7 +22,7 @@ class CanvasCheckBoxGroup : Group : CheckBoxGroup()
          [["Which One", "which_one"]]
    end
 
-   # 
+   #
    # Duplicate object
    #
    method dup()

--- a/uni/ide/ivib/canvascheckboxmenuedit.icn
+++ b/uni/ide/ivib/canvascheckboxmenuedit.icn
@@ -15,27 +15,27 @@ $include "guih.icn"
 #
 #
 class CanvasCheckBoxMenuEdit : MenuComponentEdit(
-   c,                       #         
+   c,                       #
    tab_basic,
    tab_images,
-   browse_up,               #                     
-   browse_down,             #                     
+   browse_up,               #
+   browse_down,             #
    icon_up,
    icon_down,
    cp_img,
-   label,                   #             
-   right_icon,              #                  
-   browse_right,            #                    
-   right_label,             #                   
-   use_right_label,         #                       
-   use_right_icon,          #                      
-   use_right_neither,       #                         
-   img_right,               #                 
-   cbg_right,               #                 
-   shaded,                  #              
-   browse_custom,           #                     
-   group_list,              #                  
-   in_checkbox_group,       #                          
+   label,                   #
+   right_icon,              #
+   browse_right,            #
+   right_label,             #
+   use_right_label,         #
+   use_right_icon,          #
+   use_right_neither,       #
+   img_right,               #
+   cbg_right,               #
+   shaded,                  #
+   browse_custom,           #
+   group_list,              #
+   in_checkbox_group,       #
    initially_checked        #
    )
 
@@ -53,7 +53,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
          }
       }
    end
-   
+
    method on_browse_up()
       local fd, s
       fd := FileDialog()
@@ -87,7 +87,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
    method on_okay()
       if img_width(icon_up.img) ~= img_width(icon_down.img) then
          return alert_error("Up/down image widths differ")
-      
+
       if img_height(icon_up.img) ~= img_height(icon_down.img) then
          return alert_error("Up/down image heights differ")
 
@@ -100,7 +100,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
       # a different one.
       #
       if (\c.parent_check_box_group).which_one === c then
-         c.parent_check_box_group.which_one := &null                 
+         c.parent_check_box_group.which_one := &null
 
       if in_checkbox_group.is_checked() then {
          #
@@ -108,7 +108,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
          #
          c.set_parent_check_box_group(c.parent_component.parent_Canvas.checkbox_groups.group_number(group_list.get_selection()))
          if initially_checked.is_checked() then {
-            #      
+            #
             # Turn off current one on, if any; turn self on.
             #
             (\c.parent_check_box_group.which_one).is_checked_flag := &null
@@ -129,12 +129,12 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
             c.img_right := &null
             c.set_label_right(right_label.get_contents())
          }
-         
+
          use_right_icon : {
             c.set_img_right(self.img_right)
             c.label_right := &null
          }
-         
+
          use_right_neither : {
             c.img_right := c.label_right := &null
          }
@@ -167,7 +167,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
       fd.set_fields(global_attribs)
       fd.show_modal(self)
       self.c.parent_component.parent_Canvas.parent_dialog.last_icon_dir := fd.get_directory()
-      if self.img_right := util_read_icon(self, fd.get_result()) then 
+      if self.img_right := util_read_icon(self, fd.get_result()) then
          right_icon.set_img(self.img_right)
    end
 
@@ -330,7 +330,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
       right_label.set_is_shaded()
       right_label.set_contents(\c.label_right)
       p_right.add(right_label)
-      
+
       use_right_icon := CheckBox()
       use_right_icon.connect(self, "on_use_right_icon", ACTION_EVENT)
       use_right_icon.set_pos(50, "50%")
@@ -349,7 +349,7 @@ class CanvasCheckBoxMenuEdit : MenuComponentEdit(
       right_icon.set_img(self.img_right)
       p_right.add(right_icon)
 
-      browse_right := TextButton() 
+      browse_right := TextButton()
       browse_right.connect(self, "on_browse_right", ACTION_EVENT)
       browse_right.set_label("Browse...")
       browse_right.set_pos(250, "50%")

--- a/uni/ide/ivib/canvascheckboxmenuitem.icn
+++ b/uni/ide/ivib/canvascheckboxmenuitem.icn
@@ -20,7 +20,7 @@ class CanvasCheckBoxMenuItem : CanvasMenuComponent : CheckBoxMenuItem()
    method gen_code(c)
       (\self.parent_check_box_group).gen_code(c)
       self.CanvasMenuComponent.gen_code(c)
-      if not((/self.parent_check_box_group & self.img_up == img_style("box_up") & self.img_down == img_style("box_down")) | 
+      if not((/self.parent_check_box_group & self.img_up == img_style("box_up") & self.img_down == img_style("box_down")) |
              (\self.parent_check_box_group & self.img_up == img_style("diamond_up") & self.img_down == img_style("diamond_down"))) then
          c.line(name || ".set_imgs(" || image(self.img_up) || ", " || image(self.img_down) || ")")
       if \self.label_right then
@@ -36,7 +36,7 @@ class CanvasCheckBoxMenuItem : CanvasMenuComponent : CheckBoxMenuItem()
             c.line(self.parent_check_box_group.name || ".set_which_one(" || name || ")")
          else
             c.line(name || ".set_is_checked()")
-      }         
+      }
    end
 
    #
@@ -63,7 +63,7 @@ class CanvasCheckBoxMenuItem : CanvasMenuComponent : CheckBoxMenuItem()
       if \self.is_checked_flag then {
          if /c.parent_check_box_group then
             c.set_is_checked()
-      }         
+      }
       return c
    end
 
@@ -79,7 +79,7 @@ class CanvasCheckBoxMenuItem : CanvasMenuComponent : CheckBoxMenuItem()
          if \c.parent_check_box_group then
             c.parent_check_box_group.which_one := c
          c.set_is_checked()
-      }         
+      }
       return c
    end
 
@@ -87,7 +87,7 @@ class CanvasCheckBoxMenuItem : CanvasMenuComponent : CheckBoxMenuItem()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasMenuComponent.get_template() ||| 
+      return self.CanvasMenuComponent.get_template() |||
          [["Img Up", "img_up"],
           ["Img Down", "img_down"],
           ["Is Checked Flag", "is_checked_flag"],

--- a/uni/ide/ivib/canvascheckboxui.icn
+++ b/uni/ide/ivib/canvascheckboxui.icn
@@ -18,7 +18,7 @@ class CanvasCheckBoxUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Buttons", 
+      self.BasicCanvasComponentUI.initially("Buttons",
                                             "CheckBox",
                                             $include "icon/icn8.icon"
                                             )

--- a/uni/ide/ivib/canvascomponent.icn
+++ b/uni/ide/ivib/canvascomponent.icn
@@ -30,7 +30,7 @@ class CanvasComponent : SelectiveClassCoding(
    y_fixed,                 #
    w_fixed,                 #
    h_fixed,                 #
-   w_default,               # Flags - if on size defaults 
+   w_default,               # Flags - if on size defaults
    h_default,               #
    class_variable,          # Non-null if the component should have a class variable
    event_handlers           # List of event, handler pairs
@@ -43,7 +43,7 @@ class CanvasComponent : SelectiveClassCoding(
    #
    # An adjustment to add to the object's absolute x position,
    # depending upon its alignment.
-   # 
+   #
    method get_x_alignment_offset()
       return case self.x_align of {
          "l" : 0
@@ -52,7 +52,7 @@ class CanvasComponent : SelectiveClassCoding(
       }
    end
 
-   # 
+   #
    # As above, for the y value.
    #
    method get_y_alignment_offset()
@@ -388,7 +388,7 @@ class CanvasComponent : SelectiveClassCoding(
       #
       # Add c to the object.
       #
-      self.add(c)      
+      self.add(c)
 
       #
       # Set c's x and y position, and set size to the current absolute size.

--- a/uni/ide/ivib/canvascomponentdialog.icn
+++ b/uni/ide/ivib/canvascomponentdialog.icn
@@ -17,38 +17,38 @@ $include "guih.icn"
 #
 class CanvasComponentDialog : CommonDialog(
    size_list,               # List of sizes to select from
-   align_list,              # List of alignments   
+   align_list,              # List of alignments
    x_spec,                  # EditLists for pos & size
-   y_spec,                  #              
-   w_spec,                  #              
-   h_spec,                  #              
-   set_w_default,           # CheckBoxes                     
-   set_h_default,           #                     
-   align_spec,              # List for align specification                 
-   draw_border,             # CheckBoxes                  
-   shaded,                  #              
-   name,                    # TextField - object name           
+   y_spec,                  #
+   w_spec,                  #
+   h_spec,                  #
+   set_w_default,           # CheckBoxes
+   set_h_default,           #
+   align_spec,              # List for align specification
+   draw_border,             # CheckBoxes
+   shaded,                  #
+   name,                    # TextField - object name
    class_name,              # TextField - class name
    import_name,             # TextField - import name
    tooltip_flag,            # Tooltip on/off
    tooltip_field,           # TextField - tooltip
    accel_flag,              # Accel on/off
    accel,                   # TextField - accel
-   okay,                    # Buttons           
-   cancel,                  #              
-   pos_tab,                 # Tabs in TabSet              
-   name_tab,                #                 
-   other_tab,               #                 
+   okay,                    # Buttons
+   cancel,                  #
+   pos_tab,                 # Tabs in TabSet
+   name_tab,                #
+   other_tab,               #
    code_tab,                #
-   tabset,                  #                  
-   set_x_fixed,             # CheckBoxes to fix pos/size                  
-   set_y_fixed,             #                   
-   set_w_fixed,             #                   
-   set_h_fixed,             #                   
+   tabset,                  #
+   set_x_fixed,             # CheckBoxes to fix pos/size
+   set_y_fixed,             #
+   set_w_fixed,             #
+   set_h_fixed,             #
    var_category0,           # Checkboxes for variable category
-   var_category1,           #  
+   var_category1,           #
    var_category_cbg,        #
-   has_initial_focus,       # CheckBox                        
+   has_initial_focus,       # CheckBox
    attrib_tab,              # Attribs tab
    event_tab,               # Event tab
    label,                   # Dialog title
@@ -87,14 +87,14 @@ class CanvasComponentDialog : CommonDialog(
    #
    # Add the tab to the TabSet
    #
-   method add_tab(t) 
+   method add_tab(t)
       tabset.add(t)
    end
 
    #
    # Add the tab to the TabSet, as the first item
    #
-   method add_tab_at_front(t) 
+   method add_tab_at_front(t)
       tabset.add(t, 1)
    end
 
@@ -164,7 +164,7 @@ class CanvasComponentDialog : CommonDialog(
            "cc" : 5
            "cb" : 6
            "rt" : 7
-           "rc" : 8 
+           "rc" : 8
            "rb" : 9 })
 
       pos_tab.add(align_spec)

--- a/uni/ide/ivib/canvascomponentui.icn
+++ b/uni/ide/ivib/canvascomponentui.icn
@@ -14,5 +14,5 @@ class CanvasComponentUI : Object()
 
    abstract method add_to_menu(m)
 
-   abstract method get_button() 
+   abstract method get_button()
 end

--- a/uni/ide/ivib/canvascustom.icn
+++ b/uni/ide/ivib/canvascustom.icn
@@ -11,15 +11,15 @@
 ############################################################################
 #
 # Class for representing a Custom on the canvas.
-# 
+#
 class CanvasCustom : CanvasComponent : Custom()
    #
    # Copy fields from self to c.
    #
    method cp_fields(c)
    end
- 
-   # 
+
+   #
    # Duplicate object
    #
    method dup(pc)

--- a/uni/ide/ivib/canvascustomui.icn
+++ b/uni/ide/ivib/canvascustomui.icn
@@ -19,7 +19,7 @@ class CanvasCustomUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Other", 
+      self.BasicCanvasComponentUI.initially("Other",
                                             "Custom",
                                             $include "icon/icn21.icon"
                                             )

--- a/uni/ide/ivib/canvaseditabletextlist.icn
+++ b/uni/ide/ivib/canvaseditabletextlist.icn
@@ -20,7 +20,7 @@ class CanvasEditableTextList : CanvasComponent : EditableTextList()
       # 14 + 8*2 + 22
       return 52
    end
- 
+
    method min_width()
       # need a smart calculation font height + borders + scrollbar
       # for now based on constants in gui.icn, guiconst.icn we go with
@@ -69,7 +69,7 @@ class CanvasEditableTextList : CanvasComponent : EditableTextList()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Contents", "contents"]
          ]
    end

--- a/uni/ide/ivib/canvaseditabletextlistdialog.icn
+++ b/uni/ide/ivib/canvaseditabletextlistdialog.icn
@@ -14,8 +14,8 @@ $include "guih.icn"
 #
 #
 class CanvasEditableTextListDialog : CanvasComponentDialog(
-   c,                       #         
-   contents                 #                
+   c,                       #
+   contents                 #
    )
 
    method on_okay()

--- a/uni/ide/ivib/canvaseditabletextlistui.icn
+++ b/uni/ide/ivib/canvaseditabletextlistui.icn
@@ -18,7 +18,7 @@ class CanvasEditableTextListUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Text", 
+      self.BasicCanvasComponentUI.initially("Text",
                                             "EditableTextList",
                                             $include "icon/icn17.icon"
                                             )

--- a/uni/ide/ivib/canvaseditlist.icn
+++ b/uni/ide/ivib/canvaseditlist.icn
@@ -14,7 +14,7 @@ import gui
 # Class for representing a EditList on the canvas.
 #
 class CanvasEditList : CanvasComponent : EditList(
-   tmp, 
+   tmp,
    filter_str
    )
 
@@ -75,7 +75,7 @@ class CanvasEditList : CanvasComponent : EditList(
       self.cp_fields(c)
       return c
    end
-      
+
    #
    # I/o template.  The tmp field is necessary to save/set the
    # contents of the tf (TextField) structure.
@@ -84,7 +84,7 @@ class CanvasEditList : CanvasComponent : EditList(
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Contents", "tmp"],
           ["Selection", "selection"],
           ["Selection List", "selection_list"],

--- a/uni/ide/ivib/canvaseditlistdialog.icn
+++ b/uni/ide/ivib/canvaseditlistdialog.icn
@@ -14,13 +14,13 @@ $include "guih.icn"
 #
 #
 class CanvasEditListDialog : CanvasComponentDialog(
-   c,                       #         
-   selection_list,          #                      
-   set_selection,           #                     
-   selection,               #                 
-   set_initial_text,        #                        
-   initial_text,            #                    
-   group,                   #             
+   c,                       #
+   selection_list,          #
+   set_selection,           #
+   selection,               #
+   set_initial_text,        #
+   initial_text,            #
+   group,                   #
    filter,                  #
    default_setting          #
    )
@@ -48,18 +48,18 @@ class CanvasEditListDialog : CanvasComponentDialog(
 
    method on_set_initial_text()
       selection.set_is_shaded()
-      initial_text.clear_is_shaded() 
+      initial_text.clear_is_shaded()
    end
 
    method on_set_selection()
       selection.clear_is_shaded()
-      initial_text.set_is_shaded() 
+      initial_text.set_is_shaded()
    end
 
    method on_default_setting()
       c.set_selection(1)
       selection.set_is_shaded()
-      initial_text.set_is_shaded() 
+      initial_text.set_is_shaded()
    end
 
    initially
@@ -136,7 +136,7 @@ class CanvasEditListDialog : CanvasComponentDialog(
       l.set_pos(200, 185)
       l.set_align("l", "c")
       p.add(l)
-      
+
       filter := TextField()
       filter.set_pos(350, 185)
       filter.set_size(100)

--- a/uni/ide/ivib/canvaseditlistui.icn
+++ b/uni/ide/ivib/canvaseditlistui.icn
@@ -19,7 +19,7 @@ class CanvasEditListUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("List", 
+      self.BasicCanvasComponentUI.initially("List",
                                             "EditList",
                                             $include "icon/icn19.icon"
                                             )

--- a/uni/ide/ivib/canvashlineui.icn
+++ b/uni/ide/ivib/canvashlineui.icn
@@ -18,7 +18,7 @@ class CanvasHLineUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Separators", 
+      self.BasicCanvasComponentUI.initially("Separators",
                                             "HLine"
                                             )
 end

--- a/uni/ide/ivib/canvashscrollbarui.icn
+++ b/uni/ide/ivib/canvashscrollbarui.icn
@@ -21,7 +21,7 @@ class CanvasHScrollBarUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("ScrollBar", 
+      self.BasicCanvasComponentUI.initially("ScrollBar",
                                             "HScrollBar",
                                             $include "icon/icn11.icon"
                                             )

--- a/uni/ide/ivib/canvashsizerui.icn
+++ b/uni/ide/ivib/canvashsizerui.icn
@@ -19,7 +19,7 @@ class CanvasHSizerUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Separators", 
+      self.BasicCanvasComponentUI.initially("Separators",
                                             "HSizer"
                                             )
 end

--- a/uni/ide/ivib/canvashsliderui.icn
+++ b/uni/ide/ivib/canvashsliderui.icn
@@ -21,7 +21,7 @@ class CanvasHSliderUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Slider", 
+      self.BasicCanvasComponentUI.initially("Slider",
                                             "HSlider"
                                             )
 end

--- a/uni/ide/ivib/canvasicon.icn
+++ b/uni/ide/ivib/canvasicon.icn
@@ -55,7 +55,7 @@ class CanvasIcon : CanvasComponent : Icon()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Img", "img"],
           ["Img Width", "img_w"],
           ["Img Height", "img_h"]

--- a/uni/ide/ivib/canvasiconbutton.icn
+++ b/uni/ide/ivib/canvasiconbutton.icn
@@ -26,7 +26,7 @@ class CanvasIconButton : CanvasButton : IconButton()
          c.line(name || ".set_imgs(" || image(self.img_up) || ", " || image(self.img_down) || ")")
    end
 
-   # 
+   #
    # Duplicate object
    #
    method dup(pc)

--- a/uni/ide/ivib/canvasiconbuttonui.icn
+++ b/uni/ide/ivib/canvasiconbuttonui.icn
@@ -20,7 +20,7 @@ class CanvasIconButtonUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Buttons", 
+      self.BasicCanvasComponentUI.initially("Buttons",
                                             "IconButton",
                                             $include "icon/icn5.icon"
                                             )

--- a/uni/ide/ivib/canvasicondialog.icn
+++ b/uni/ide/ivib/canvasicondialog.icn
@@ -15,8 +15,8 @@ $include "guih.icn"
 #
 #
 class CanvasIconDialog : CanvasComponentDialog(
-   c,                       #         
-   browse,                  #              
+   c,                       #
+   browse,                  #
    icon                     #
    )
 
@@ -27,10 +27,10 @@ class CanvasIconDialog : CanvasComponentDialog(
       fd.set_fields(global_attribs)
       fd.show_modal(self)
       self.c.parent_Canvas.parent_dialog.last_icon_dir := fd.get_directory()
-      if s := util_read_icon(self, fd.get_result()) then 
+      if s := util_read_icon(self, fd.get_result()) then
          self.icon.set_img(s)
    end
-   
+
    method on_okay()
       self.validate_input() | fail
       self.set_vals(c)
@@ -54,7 +54,7 @@ class CanvasIconDialog : CanvasComponentDialog(
       l.set_pos(50, "50%")
       l.set_align("l", "c")
       p.add(l)
-      
+
       icon := Icon()
       icon.toggle_draw_border()
       icon.set_pos(100, "50%")

--- a/uni/ide/ivib/canvasiconui.icn
+++ b/uni/ide/ivib/canvasiconui.icn
@@ -20,7 +20,7 @@ class CanvasIconUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Image", 
+      self.BasicCanvasComponentUI.initially("Image",
                                             "Icon",
                                             $include "icon/icn6.icon"
                                             )

--- a/uni/ide/ivib/canvasimage.icn
+++ b/uni/ide/ivib/canvasimage.icn
@@ -63,7 +63,7 @@ class CanvasImage : CanvasComponent : Image()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["File name", "filename"],
           ["X Internal Alignment", "x_internal_alignment"],
           ["Y Internal Alignment", "y_internal_alignment"],
@@ -72,7 +72,7 @@ class CanvasImage : CanvasComponent : Image()
    end
 
    #
-   # Overrides Image.display() 
+   # Overrides Image.display()
    #
    method display(buffer_flag)
       local W

--- a/uni/ide/ivib/canvasimagedialog.icn
+++ b/uni/ide/ivib/canvasimagedialog.icn
@@ -54,7 +54,7 @@ class CanvasImageDialog : CanvasComponentDialog(c, filename, internal_align_spec
       l.set_pos(200, "66%")
       l.set_align("l", "c")
       p.add(l)
-      
+
       filename := TextField()
       filename.set_pos(320, "66%")
       filename.set_size(100)
@@ -89,9 +89,9 @@ class CanvasImageDialog : CanvasComponentDialog(c, filename, internal_align_spec
            "cc" : 5
            "cb" : 6
            "rt" : 7
-           "rc" : 8 
+           "rc" : 8
            "rb" : 9 })
 
       p.add(internal_align_spec)
-    
+
 end

--- a/uni/ide/ivib/canvasimageui.icn
+++ b/uni/ide/ivib/canvasimageui.icn
@@ -17,7 +17,7 @@ class CanvasImageUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Image", 
+      self.BasicCanvasComponentUI.initially("Image",
                                             "Image",
                                             $include "icon/icn7.icon"
                                             )

--- a/uni/ide/ivib/canvaslabel.icn
+++ b/uni/ide/ivib/canvaslabel.icn
@@ -64,7 +64,7 @@ class CanvasLabel : CanvasComponent : Label()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Label", "label"],
           ["Internal Align", "internal_alignment"]
          ]

--- a/uni/ide/ivib/canvaslabeldialog.icn
+++ b/uni/ide/ivib/canvaslabeldialog.icn
@@ -14,9 +14,9 @@ import gui
 #
 #
 class CanvasLabelDialog : CanvasComponentDialog(
-   c,                       #         
-   label_str,               #                 
-   internal_alignment,      #                          
+   c,                       #
+   label_str,               #
+   internal_alignment,      #
    internal_alignment_list  #
    )
 
@@ -45,7 +45,7 @@ class CanvasLabelDialog : CanvasComponentDialog(
       l.set_pos(50, "33%")
       l.set_align("l", "c")
       p.add(l)
-      
+
       label_str := TextField()
       label_str.set_pos(200, "33%")
       label_str.set_size(100)

--- a/uni/ide/ivib/canvaslabelui.icn
+++ b/uni/ide/ivib/canvaslabelui.icn
@@ -18,7 +18,7 @@ class CanvasLabelUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Text", 
+      self.BasicCanvasComponentUI.initially("Text",
                                             "Label",
                                             $include "icon/icn2.icon"
                                             )

--- a/uni/ide/ivib/canvasline.icn
+++ b/uni/ide/ivib/canvasline.icn
@@ -70,7 +70,7 @@ class CanvasLine : CanvasComponent : Line()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Is vertical flag", "is_vertical_flag"]]
    end
 

--- a/uni/ide/ivib/canvaslinedialog.icn
+++ b/uni/ide/ivib/canvaslinedialog.icn
@@ -12,7 +12,7 @@
 #
 #
 class CanvasLineDialog : CanvasComponentDialog(
-   c                       #         
+   c                       #
    )
 
    method on_okay()

--- a/uni/ide/ivib/canvaslist.icn
+++ b/uni/ide/ivib/canvaslist.icn
@@ -60,7 +60,7 @@ class CanvasList : CanvasComponent : List()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Constant Label", "constant_label"],
           ["Selection", "selection"],
           ["Selection List", "selection_list"]

--- a/uni/ide/ivib/canvaslistdialog.icn
+++ b/uni/ide/ivib/canvaslistdialog.icn
@@ -15,13 +15,13 @@ $include "guih.icn"
 #
 #
 class CanvasListDialog : CanvasComponentDialog(
-   c,                       #         
-   selection_list,          #                      
-   set_selection,           #                     
-   selection,               #                 
-   use_constant_label,      #                          
-   constant_label,          #                      
-   group,                   #             
+   c,                       #
+   selection_list,          #
+   set_selection,           #
+   selection,               #
+   use_constant_label,      #
+   constant_label,          #
+   group,                   #
    default_setting          #
    )
 
@@ -51,18 +51,18 @@ class CanvasListDialog : CanvasComponentDialog(
 
    method on_use_constant_label()
       selection.set_is_shaded()
-      constant_label.clear_is_shaded() 
+      constant_label.clear_is_shaded()
    end
 
    method on_set_selection()
       selection.clear_is_shaded()
-      constant_label.set_is_shaded() 
+      constant_label.set_is_shaded()
    end
 
    method on_default_setting()
       c.set_selection(1)
       selection.set_is_shaded()
-      constant_label.set_is_shaded() 
+      constant_label.set_is_shaded()
    end
 
    initially

--- a/uni/ide/ivib/canvaslistspin.icn
+++ b/uni/ide/ivib/canvaslistspin.icn
@@ -58,7 +58,7 @@ class CanvasListSpin : CanvasComponent : ListSpin()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [
           ["Selection", "selection"],
           ["Selection List", "selection_list"]

--- a/uni/ide/ivib/canvaslistspindialog.icn
+++ b/uni/ide/ivib/canvaslistspindialog.icn
@@ -15,11 +15,11 @@ $include "guih.icn"
 #
 #
 class CanvasListSpinDialog : CanvasComponentDialog(
-   c,                       #         
-   selection_list,          #                      
-   set_selection,           #                     
-   selection,               #                 
-   group,                   #             
+   c,                       #
+   selection_list,          #
+   set_selection,           #
+   selection,               #
+   group,                   #
    default_setting          #
    )
 

--- a/uni/ide/ivib/canvaslistspinui.icn
+++ b/uni/ide/ivib/canvaslistspinui.icn
@@ -19,7 +19,7 @@ class CanvasListSpinUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Spin", 
+      self.BasicCanvasComponentUI.initially("Spin",
                                             "ListSpin"
                                             )
 end

--- a/uni/ide/ivib/canvaslistui.icn
+++ b/uni/ide/ivib/canvaslistui.icn
@@ -19,7 +19,7 @@ class CanvasListUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("List", 
+      self.BasicCanvasComponentUI.initially("List",
                                             "List",
                                             $include "icon/icn18.icon"
                                             )

--- a/uni/ide/ivib/canvasmenu.icn
+++ b/uni/ide/ivib/canvasmenu.icn
@@ -67,7 +67,7 @@ class CanvasMenu : CanvasMenuComponent : Menu()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasMenuComponent.get_template() ||| 
+      return self.CanvasMenuComponent.get_template() |||
          [["Children", "children"]
          ]
    end
@@ -95,7 +95,7 @@ class CanvasMenu : CanvasMenuComponent : Menu()
       put(s, MenuTreeNode(level, parent, i))
       put(s, MenuTreeNode(level, parent, i, self))
       every sub := self.children[i := 1 to *self.children] do {
-         if sub.is_sub_menu() then 
+         if sub.is_sub_menu() then
             sub.set_string_rep(s, level + 1, self, i)
          else {
             put(s, MenuTreeNode(level + 1, self, i))

--- a/uni/ide/ivib/canvasmenubar.icn
+++ b/uni/ide/ivib/canvasmenubar.icn
@@ -14,7 +14,7 @@ import gui
 # Class for representing a MenuBar on the canvas.
 #
 class CanvasMenuBar : CanvasComponent : MenuBar(
-   string_rep               #                  
+   string_rep               #
    )
 
    #
@@ -61,7 +61,7 @@ class CanvasMenuBar : CanvasComponent : MenuBar(
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Menus", "menus"]
          ]
    end
@@ -87,13 +87,13 @@ class CanvasMenuBar : CanvasComponent : MenuBar(
    method set_string_rep()
       local sub, i
       string_rep := []
-      every sub := self.menus[i := 1 to *self.menus] do 
+      every sub := self.menus[i := 1 to *self.menus] do
          sub.set_string_rep(string_rep, 1, self, i)
       put(string_rep, MenuTreeNode(1, self, *self.menus + 1))
    end
 
    method get_string_rep()
-      return self.string_rep      
+      return self.string_rep
    end
 
    #

--- a/uni/ide/ivib/canvasmenubardialog.icn
+++ b/uni/ide/ivib/canvasmenubardialog.icn
@@ -15,17 +15,17 @@ $include "guih.icn"
 #
 #
 class CanvasMenuBarDialog : CanvasComponentDialog(
-   c,                       #         
-   add_label,               #                 
-   add_menu,                #                
-   add_separator,           #                     
-   add_checkbox,            #                    
-   delete,                  #              
-   edit,                    #            
-   struct,                  #              
-   select_rec,              #                  
-   new_cbg,                 #               
-   icon,                    #            
+   c,                       #
+   add_label,               #
+   add_menu,                #
+   add_separator,           #
+   add_checkbox,            #
+   delete,                  #
+   edit,                    #
+   struct,                  #
+   select_rec,              #
+   new_cbg,                 #
+   icon,                    #
    browse                   #
    )
 
@@ -81,7 +81,7 @@ class CanvasMenuBarDialog : CanvasComponentDialog(
             add_label.set_is_shaded()
             add_separator.set_is_shaded()
             add_checkbox.set_is_shaded()
-            if lang::get_class_name(c) == "CanvasMenuButton" then 
+            if lang::get_class_name(c) == "CanvasMenuButton" then
                add_menu.set_is_shaded()
             else
                add_menu.clear_is_shaded()
@@ -251,7 +251,7 @@ class CanvasMenuBarDialog : CanvasComponentDialog(
       add_separator.set_is_shaded()
       add_separator.set_align("c", "t")
       p.add(add_separator)
- 
+
       add_menu := TextButton()
       add_menu.connect(self, "on_add_menu", ACTION_EVENT)
       add_menu.set_label("Add Menu")
@@ -259,7 +259,7 @@ class CanvasMenuBarDialog : CanvasComponentDialog(
       add_menu.set_align("c", "t")
       add_menu.set_is_shaded()
       p.add(add_menu)
-     
+
       add_checkbox := TextButton()
       add_checkbox.connect(self, "on_add_checkbox", ACTION_EVENT)
       add_checkbox.set_label("Add checkbox")

--- a/uni/ide/ivib/canvasmenubarui.icn
+++ b/uni/ide/ivib/canvasmenubarui.icn
@@ -22,7 +22,7 @@ class CanvasMenuBarUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Menu", 
+      self.BasicCanvasComponentUI.initially("Menu",
                                             "MenuBar",
                                             $include "icon/icn9.icon"
                                             )

--- a/uni/ide/ivib/canvasmenubutton.icn
+++ b/uni/ide/ivib/canvasmenubutton.icn
@@ -14,7 +14,7 @@ import gui
 # Class for representing a MenuButton on the canvas.
 #
 class CanvasMenuButton : CanvasComponent : MenuButton(
-   string_rep               #                  
+   string_rep               #
    )
 
    #
@@ -63,7 +63,7 @@ class CanvasMenuButton : CanvasComponent : MenuButton(
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Img", "img"],
           ["Menu", "menu"]
          ]
@@ -77,7 +77,7 @@ class CanvasMenuButton : CanvasComponent : MenuButton(
    end
 
    method get_string_rep()
-      return self.string_rep      
+      return self.string_rep
    end
 
    #

--- a/uni/ide/ivib/canvasmenubuttonui.icn
+++ b/uni/ide/ivib/canvasmenubuttonui.icn
@@ -21,7 +21,7 @@ class CanvasMenuButtonUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Menu", 
+      self.BasicCanvasComponentUI.initially("Menu",
                                             "MenuButton",
                                             $include "icon/icn14.icon"
                                             )

--- a/uni/ide/ivib/canvasmenucomponent.icn
+++ b/uni/ide/ivib/canvasmenucomponent.icn
@@ -14,8 +14,8 @@ import lang
 #
 #
 class CanvasMenuComponent : SelectiveClassCoding(
-   name, 
-   class_name, 
+   name,
+   class_name,
    import_name,             # Name of import file
    class_variable,          # Non-null if the component should have a class variable
    event_method            # Name of action listener method, or &null if none
@@ -29,7 +29,7 @@ class CanvasMenuComponent : SelectiveClassCoding(
 
       if \self.label then
          c.line(name || ".set_label(" || image(self.label) || ")")
-     
+
       if \self.is_shaded_flag then
          c.line(name || ".set_is_shaded()")
 
@@ -44,7 +44,7 @@ class CanvasMenuComponent : SelectiveClassCoding(
 
       c.add_var(name, class_variable)
       c.add_import(self.import_name)
-   end    
+   end
 
    #
    # Set the object name

--- a/uni/ide/ivib/canvasmenucomponentdialog.icn
+++ b/uni/ide/ivib/canvasmenucomponentdialog.icn
@@ -14,24 +14,24 @@ $include "guih.icn"
 #
 #
 class CanvasMenuComponentDialog : MenuComponentEdit(
-   c,                       #         
-   label,                   #             
-   left_icon,               #                 
-   browse_left,             #                   
-   left_label,              #                  
-   use_left_label,          #                      
-   use_left_icon,           #                     
-   use_left_neither,        #                        
-   img_left,                #                
-   cbg_left,                #                
-   right_icon,              #                  
-   browse_right,            #                    
-   right_label,             #                   
-   use_right_label,         #                       
-   use_right_icon,          #                      
-   use_right_neither,       #                         
-   img_right,               #                 
-   cbg_right,               #                 
+   c,                       #
+   label,                   #
+   left_icon,               #
+   browse_left,             #
+   left_label,              #
+   use_left_label,          #
+   use_left_icon,           #
+   use_left_neither,        #
+   img_left,                #
+   cbg_left,                #
+   right_icon,              #
+   browse_right,            #
+   right_label,             #
+   use_right_label,         #
+   use_right_icon,          #
+   use_right_neither,       #
+   img_right,               #
+   cbg_right,               #
    shaded,                  #
    accel_flag,              # Accel on/off
    accel                    # TextField - accel
@@ -56,28 +56,28 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
             c.img_left := &null
             c.set_label_left(left_label.get_contents())
          }
-         
+
          use_left_icon : {
             c.set_img_left(self.img_left)
             c.label_left := &null
          }
-         
+
          use_left_neither : {
             c.img_left := c.label_left := &null
          }
       }
-      
+
       case cbg_right.get_which_one() of {
          use_right_label : {
             c.img_right := &null
             c.set_label_right(right_label.get_contents())
          }
-         
+
          use_right_icon : {
             c.set_img_right(self.img_right)
             c.label_right := &null
          }
-         
+
          use_right_neither : {
             c.img_right := c.label_right := &null
          }
@@ -110,7 +110,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       fd.set_fields(global_attribs)
       fd.show_modal(self)
       self.c.parent_component.parent_Canvas.parent_dialog.last_icon_dir := fd.get_directory()
-      if self.img_left := util_read_icon(self, fd.get_result()) then 
+      if self.img_left := util_read_icon(self, fd.get_result()) then
          left_icon.set_img(self.img_left)
    end
 
@@ -139,7 +139,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       fd.set_fields(global_attribs)
       fd.show_modal(self)
       self.c.parent_component.parent_Canvas.parent_dialog.last_icon_dir := fd.get_directory()
-      if self.img_right := util_read_icon(self, fd.get_result()) then 
+      if self.img_right := util_read_icon(self, fd.get_result()) then
          right_icon.set_img(self.img_right)
    end
 
@@ -215,7 +215,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       left_label.set_is_shaded()
       left_label.set_contents(\c.label_left)
       p_left.add(left_label)
-      
+
       use_left_icon := CheckBox()
       use_left_icon .connect(self, "on_use_left_icon", ACTION_EVENT)
       use_left_icon.set_pos(50, "50%")
@@ -234,7 +234,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       left_icon.set_img(self.img_left)
       p_left.add(left_icon)
 
-      browse_left := TextButton() 
+      browse_left := TextButton()
       browse_left .connect(self, "on_browse_left", ACTION_EVENT)
       browse_left.set_label("Browse...")
       browse_left.set_pos(250, "50%")
@@ -281,7 +281,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       right_label.set_is_shaded()
       right_label.set_contents(\c.label_right)
       p_right.add(right_label)
-      
+
       use_right_icon := CheckBox()
       use_right_icon .connect(self, "on_use_right_icon", ACTION_EVENT)
       use_right_icon.set_pos(50, "50%")
@@ -300,7 +300,7 @@ class CanvasMenuComponentDialog : MenuComponentEdit(
       right_icon.set_img(self.img_right)
       p_right.add(right_icon)
 
-      browse_right := TextButton() 
+      browse_right := TextButton()
       browse_right .connect(self, "on_browse_right", ACTION_EVENT)
       browse_right.set_label("Browse...")
       browse_right.set_pos(250, "50%")

--- a/uni/ide/ivib/canvasoverlayitem.icn
+++ b/uni/ide/ivib/canvasoverlayitem.icn
@@ -60,7 +60,7 @@ class CanvasOverlayItem : CanvasComponent : OverlayItem()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Children", "children"],
           ["Parent OverlaySet", "parent"]
          ]
@@ -94,7 +94,7 @@ class CanvasOverlayItem : CanvasComponent : OverlayItem()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local e, o

--- a/uni/ide/ivib/canvasoverlayset.icn
+++ b/uni/ide/ivib/canvasoverlayset.icn
@@ -64,12 +64,12 @@ class CanvasOverlaySet : CanvasComponent : OverlaySet()
       }
       return c
    end
-      
+
    #
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Children", "children"],
           ["Which One", "which_one"]
          ]
@@ -91,7 +91,7 @@ class CanvasOverlaySet : CanvasComponent : OverlaySet()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local o

--- a/uni/ide/ivib/canvasoverlaysetdialog.icn
+++ b/uni/ide/ivib/canvasoverlaysetdialog.icn
@@ -14,18 +14,18 @@ $include "guih.icn"
 #
 #
 class CanvasOverlaySetDialog : CanvasComponentDialog(
-   c,                       #         
-   add_col,                 #               
-   delete,                  #              
-   apply,                   #             
-   struct,                  #              
-   os,                      #          
-   os_on,                   #             
-   os_off,                  #              
+   c,                       #
+   add_col,                 #
+   delete,                  #
+   apply,                   #
+   struct,                  #
+   os,                      #
+   os_on,                   #
+   os_off,                  #
    item_var_category0,      # Checkboxes for item variable category
-   item_var_category1,           
-   item_var_category_cbg,        
-   col_name,                #                
+   item_var_category1,
+   item_var_category_cbg,
+   col_name,                #
    which_one                #
    )
 
@@ -63,12 +63,12 @@ class CanvasOverlaySetDialog : CanvasComponentDialog(
       if *l = 0 | nl > *c.children then {
          put(c.children, new)
          struct.set_contents(c.string_rep())
-         struct.goto_pos(*c.children)                             
+         struct.goto_pos(*c.children)
          struct.set_selections([*c.children])
          struct.set_cursor(*c.children)
       } else {
          c.children := c.children[1:nl] ||| [new] ||| c.children[nl:0]
-         struct.set_contents(c.string_rep())      
+         struct.set_contents(c.string_rep())
          line := struct.get_first_line()
          nlines := struct.get_curr_lines()
          if nl > line + nlines - 1 then
@@ -78,7 +78,7 @@ class CanvasOverlaySetDialog : CanvasComponentDialog(
          struct.goto_pos(line)
          struct.set_selections([nl])
          struct.set_cursor(nl)
-      }                              
+      }
       if \new.class_variable then
          item_var_category_cbg.set_which_one(item_var_category0)
       else
@@ -195,7 +195,7 @@ class CanvasOverlaySetDialog : CanvasComponentDialog(
       os_off := OverlayItem()
       os.add(os_off)
 
-      os_on := OverlayItem() 
+      os_on := OverlayItem()
       os.add(os_on)
 
       b := Border()

--- a/uni/ide/ivib/canvasoverlaysetui.icn
+++ b/uni/ide/ivib/canvasoverlaysetui.icn
@@ -21,7 +21,7 @@ class CanvasOverlaySetUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Containers", 
+      self.BasicCanvasComponentUI.initially("Containers",
                                             "OverlaySet",
                                             $include "icon/icn15.icon"
                                             )

--- a/uni/ide/ivib/canvaspanel.icn
+++ b/uni/ide/ivib/canvaspanel.icn
@@ -58,7 +58,7 @@ class CanvasPanel : CanvasComponent : Panel()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Children", "children"]
          ]
    end
@@ -85,7 +85,7 @@ class CanvasPanel : CanvasComponent : Panel()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local e, o

--- a/uni/ide/ivib/canvaspanelui.icn
+++ b/uni/ide/ivib/canvaspanelui.icn
@@ -17,7 +17,7 @@ class CanvasPanelUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Containers", 
+      self.BasicCanvasComponentUI.initially("Containers",
                                             "Panel",
                                             $include "icon/icn20.icon"
                                             )

--- a/uni/ide/ivib/canvasrangespin.icn
+++ b/uni/ide/ivib/canvasrangespin.icn
@@ -22,10 +22,10 @@ class CanvasRangeSpin : CanvasComponent : RangeSpin(value)
       self.CanvasComponent.gen_code(c)
       if \self.lo | \self.hi then {
          s := name || ".set_range(" || (\self.lo|"&null") || ", " ||
-            (\self.hi|"&null") || ")" 
+            (\self.hi|"&null") || ")"
          c.line(s)
       }
-      
+
       c.line(name || ".set_value(" || value || ")")
       c.line(name || ".set_increment_size(" || self.increment_size || ")")
    end
@@ -69,7 +69,7 @@ class CanvasRangeSpin : CanvasComponent : RangeSpin(value)
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [
           ["Hi", "hi"],
           ["Lo", "lo"],

--- a/uni/ide/ivib/canvasrangespindialog.icn
+++ b/uni/ide/ivib/canvasrangespindialog.icn
@@ -15,11 +15,11 @@ $include "guih.icn"
 #
 #
 class CanvasRangeSpinDialog : CanvasComponentDialog(
-   c,                       #         
-   hi, 
-   hi_flag, 
+   c,                       #
+   hi,
+   hi_flag,
    value,
-   lo, 
+   lo,
    lo_flag,
    increment_size
    )
@@ -27,10 +27,10 @@ class CanvasRangeSpinDialog : CanvasComponentDialog(
    method on_okay()
       local hi_val, lo_val, inc_val, init_val
 
-      if hi_flag.is_checked() then 
+      if hi_flag.is_checked() then
          hi_val := numeric(hi.get_contents()) | return alert_error("Hi is not numeric")
 
-      if lo_flag.is_checked() then 
+      if lo_flag.is_checked() then
          lo_val := numeric(lo.get_contents()) | return alert_error("Lo is not numeric")
 
       inc_val := numeric(increment_size.get_contents()) | return alert_error("Increment is not numeric")

--- a/uni/ide/ivib/canvasrangespinui.icn
+++ b/uni/ide/ivib/canvasrangespinui.icn
@@ -20,7 +20,7 @@ class CanvasRangeSpinUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Spin", 
+      self.BasicCanvasComponentUI.initially("Spin",
                                             "RangeSpin"
                                             )
 end

--- a/uni/ide/ivib/canvasscrollbar.icn
+++ b/uni/ide/ivib/canvasscrollbar.icn
@@ -8,7 +8,7 @@
 
 import gui
 
-      
+
 ############################################################################
 #
 # Class for representing a ScrollBar on the canvas.Class for a ScrollBar on the canvas.
@@ -71,7 +71,7 @@ class CanvasScrollBar : CanvasComponent : ScrollBar()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [
           ["Increment Size", "increment_size"],
           ["Value", "value"],
@@ -83,7 +83,7 @@ class CanvasScrollBar : CanvasComponent : ScrollBar()
           ["Total Size", "total_size"]
          ]
    end
-                                                      
+
    #
    # Open the configuration dialog box.
    #

--- a/uni/ide/ivib/canvasscrollbardialog.icn
+++ b/uni/ide/ivib/canvasscrollbardialog.icn
@@ -15,12 +15,12 @@ $include "guih.icn"
 #
 class CanvasScrollBarDialog : CanvasComponentDialog(
    c,                       # The object being configured
-   slider,                  #              
-   total_size,              #                  
-   page_size,               #                 
-   increment_size,          #                      
-   range_from,              #                  
-   range_to,                #                
+   slider,                  #
+   total_size,              #
+   page_size,               #
+   increment_size,          #
+   range_from,              #
+   range_to,                #
    initial_value            #
    )
 
@@ -86,7 +86,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(150, 50)
       l.set_align("l", "c")
       p.add(l)
-      
+
       increment_size := TextField()
       increment_size.set_pos(250, 50)
       increment_size.set_size(100)
@@ -99,7 +99,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(50, 100)
       l.set_align("l", "c")
       p.add(l)
-      
+
       page_size := TextField()
       page_size.set_pos(125, 100)
       page_size.set_size(100)
@@ -111,7 +111,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(250, 100)
       l.set_align("l", "c")
       p.add(l)
-      
+
       total_size := TextField()
       total_size.set_pos(325, 100)
       total_size.set_size(100)
@@ -123,7 +123,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(50, 150)
       l.set_align("l", "c")
       p.add(l)
-      
+
       range_from := TextField()
       range_from.set_pos(125, 150)
       range_from.set_size(100)
@@ -135,7 +135,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(250, 150)
       l.set_align("l", "c")
       p.add(l)
-      
+
       range_to := TextField()
       range_to.set_pos(325, 150)
       range_to.set_size(100)
@@ -160,7 +160,7 @@ class CanvasScrollBarDialog : CanvasComponentDialog(
       l.set_pos(50, 200)
       l.set_align("l", "c")
       p.add(l)
-      
+
       initial_value := TextField()
       initial_value.set_pos(125, 200)
       initial_value.set_size(100)

--- a/uni/ide/ivib/canvassizer.icn
+++ b/uni/ide/ivib/canvassizer.icn
@@ -36,7 +36,7 @@ class CanvasSizer : CanvasComponent : Sizer()
       self.CanvasComponent.gen_code(c)
       if \self.lo | \self.hi then {
          s := name || ".set_range(" || (\self.lo|"&null") || ", " ||
-            (\self.hi|"&null") || ")" 
+            (\self.hi|"&null") || ")"
          c.line(s)
       }
       if \self.is_horizontal_flag then
@@ -78,7 +78,7 @@ class CanvasSizer : CanvasComponent : Sizer()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [
           ["Lo", "lo"],
           ["Hi", "hi"],

--- a/uni/ide/ivib/canvasslider.icn
+++ b/uni/ide/ivib/canvasslider.icn
@@ -69,7 +69,7 @@ class CanvasSlider : CanvasComponent : Slider()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [
           ["Hi", "hi"],
           ["Lo", "lo"],

--- a/uni/ide/ivib/canvassliderdialog.icn
+++ b/uni/ide/ivib/canvassliderdialog.icn
@@ -15,16 +15,16 @@ $include "guih.icn"
 #
 #
 class CanvasSliderDialog : CanvasComponentDialog(
-   c,                       #         
-   hi, 
+   c,                       #
+   hi,
    value,
    increment_size,
-   lo, 
-   snaps, 
-   labels, 
+   lo,
+   snaps,
+   labels,
    snaps_flag,
    labels_flag,
-   ticks, 
+   ticks,
    ticks_flag
    )
 
@@ -36,13 +36,13 @@ class CanvasSliderDialog : CanvasComponentDialog(
       init_val := numeric(value.get_contents()) | return alert_error("Init value is not numeric")
       incr_val := numeric(increment_size.get_contents()) | return alert_error("Increment is not numeric")
 
-      if ticks_flag.is_checked() then 
+      if ticks_flag.is_checked() then
          ticks_val := numeric(ticks.get_contents()) | return alert_error("Ticks is not numeric")
 
-      if labels_flag.is_checked() then 
+      if labels_flag.is_checked() then
          labels_val := numeric(labels.get_contents()) | return alert_error("Labels is not numeric")
 
-      if snaps_flag.is_checked() then 
+      if snaps_flag.is_checked() then
          snaps_val := numeric(snaps.get_contents()) | return alert_error("Snaps is not numeric")
 
       if init_val < \lo_val | init_val > \hi_val then

--- a/uni/ide/ivib/canvastabitem.icn
+++ b/uni/ide/ivib/canvastabitem.icn
@@ -66,7 +66,7 @@ class CanvasTabItem : CanvasComponent : TabItem()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Label", "label"],
           ["Parent TabSet", "parent"],
           ["Children", "children"]
@@ -101,7 +101,7 @@ class CanvasTabItem : CanvasComponent : TabItem()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local e, o

--- a/uni/ide/ivib/canvastable.icn
+++ b/uni/ide/ivib/canvastable.icn
@@ -83,7 +83,7 @@ class CanvasTable : CanvasComponent : Table(select_one, select_many, columns)
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Select One", "select_one"],
           ["Select Many", "select_many"],
           ["Columns", "columns"]
@@ -136,8 +136,8 @@ class CanvasTable : CanvasComponent : Table(select_one, select_many, columns)
       local l, c
       l := []
       every c := !self.get_columns() do
-         put(l, [c.label, 
-                 if \c.auto_width_flag then "Auto" else c.column_width, 
+         put(l, [c.label,
+                 if \c.auto_width_flag then "Auto" else c.column_width,
                  c.internal_alignment])
       put(l, ["", "", ""])
       return l

--- a/uni/ide/ivib/canvastabledialog.icn
+++ b/uni/ide/ivib/canvastabledialog.icn
@@ -14,21 +14,21 @@ $include "guih.icn"
 #
 #
 class CanvasTableDialog : CanvasComponentDialog(
-   c,                       #         
-   add_col,                 #               
-   delete,                  #              
-   apply,                   #             
-   struct,                  #              
-   edit_label,              #                  
-   size,                    #            
-   internal_alignment,      #                          
-   os,                      #          
-   os_on,                   #             
-   os_off,                  #              
+   c,                       #
+   add_col,                 #
+   delete,                  #
+   apply,                   #
+   struct,                  #
+   edit_label,              #
+   size,                    #
+   internal_alignment,      #
+   os,                      #
+   os_on,                   #
+   os_off,                  #
    col_var_category0,       # Checkboxes for column variable category
-   col_var_category1,       #  
+   col_var_category1,       #
    col_var_category_cbg,    #
-   internal_alignment_list, #                               
+   internal_alignment_list, #
    col_name,                #
    auto_width_cb,
    select_group             #
@@ -81,12 +81,12 @@ class CanvasTableDialog : CanvasComponentDialog(
       if *l = 0 | nl > *c.table_header.children then {
          put(c.table_header.children, new)
          struct.set_contents(c.string_rep())
-         struct.goto_pos(*c.table_header.children)                             
+         struct.goto_pos(*c.table_header.children)
          struct.set_selections([*c.table_header.children])
          struct.set_cursor(*c.table_header.children)
       } else {
          c.table_header.children := c.table_header.children[1:nl] ||| [new] ||| c.table_header.children[nl:0]
-         struct.set_contents(c.string_rep())      
+         struct.set_contents(c.string_rep())
          line := struct.get_first_line()
          nlines := struct.get_curr_lines()
          if nl > line + nlines - 1 then
@@ -96,7 +96,7 @@ class CanvasTableDialog : CanvasComponentDialog(
          struct.goto_pos(line)
          struct.set_selections([nl])
          struct.set_cursor(nl)
-      }                              
+      }
       if \new.class_variable then
          col_var_category_cbg.set_which_one(col_var_category0)
       else
@@ -245,7 +245,7 @@ class CanvasTableDialog : CanvasComponentDialog(
       os_off := OverlayItem()
       os.add(os_off)
 
-      os_on := OverlayItem() 
+      os_on := OverlayItem()
       os.add(os_on)
 
       b := Border()
@@ -261,7 +261,7 @@ class CanvasTableDialog : CanvasComponentDialog(
       l.set_pos(20, 25)
       l.set_align("l", "c")
       b.add(l)
-      
+
       edit_label := TextField()
       edit_label.set_align("l", "c")
       edit_label.set_pos(70, 25)
@@ -273,7 +273,7 @@ class CanvasTableDialog : CanvasComponentDialog(
       l.set_pos(20, 60)
       l.set_align("l", "c")
       b.add(l)
-      
+
       size := TextField()
       size.set_align("l", "c")
       size.set_pos(70, 60)

--- a/uni/ide/ivib/canvastableui.icn
+++ b/uni/ide/ivib/canvastableui.icn
@@ -18,7 +18,7 @@ class CanvasTableUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Other", 
+      self.BasicCanvasComponentUI.initially("Other",
                                             "Table",
                                             $include "icon/icn12.icon"
                                             )

--- a/uni/ide/ivib/canvastabset.icn
+++ b/uni/ide/ivib/canvastabset.icn
@@ -64,12 +64,12 @@ class CanvasTabSet : CanvasComponent : TabSet()
       }
       return c
    end
-      
+
    #
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Children", "children"],
           ["Which One", "which_one"]
          ]
@@ -91,7 +91,7 @@ class CanvasTabSet : CanvasComponent : TabSet()
    end
 
    #
-   # Overrides CanvasComponent.which_cursor_over() 
+   # Overrides CanvasComponent.which_cursor_over()
    #
    method which_cursor_over()
       local o

--- a/uni/ide/ivib/canvastabsetdialog.icn
+++ b/uni/ide/ivib/canvastabsetdialog.icn
@@ -14,20 +14,20 @@ $include "guih.icn"
 #
 #
 class CanvasTabSetDialog : CanvasComponentDialog(
-   c,                       #         
-   add_col,                 #               
-   delete,                  #              
-   apply,                   #             
-   struct,                  #              
-   edit_label,              #                  
-   os,                      #          
-   os_on,                   #             
-   os_off,                  #              
+   c,                       #
+   add_col,                 #
+   delete,                  #
+   apply,                   #
+   struct,                  #
+   edit_label,              #
+   os,                      #
+   os_on,                   #
+   os_off,                  #
    item_var_category0,      # Checkboxes for item variable category
-   item_var_category1,             
-   item_var_category_cbg,        
-   col_name,                #                
-   item_shaded,                                
+   item_var_category1,
+   item_var_category_cbg,
+   col_name,                #
+   item_shaded,
    which_one                #
    )
 
@@ -62,7 +62,7 @@ class CanvasTabSetDialog : CanvasComponentDialog(
       local new, l, nl, line, nlines
       new := CanvasTabItem()
       new.set_name(c.parent_Canvas.get_new_name(new.name))
-      new.set_label("Edit me") 
+      new.set_label("Edit me")
       new.set_parent(c)
       new.init()
       new.set_parent_Canvas(c.parent_Canvas)
@@ -71,12 +71,12 @@ class CanvasTabSetDialog : CanvasComponentDialog(
       if *l = 0 | nl > *c.children then {
          put(c.children, new)
          struct.set_contents(c.string_rep())
-         struct.goto_pos(*c.children)                             
+         struct.goto_pos(*c.children)
          struct.set_selections([*c.children])
          struct.set_cursor(*c.children)
       } else {
          c.children := c.children[1:nl] ||| [new] ||| c.children[nl:0]
-         struct.set_contents(c.string_rep())      
+         struct.set_contents(c.string_rep())
          line := struct.get_first_line()
          nlines := struct.get_curr_lines()
          if nl > line + nlines - 1 then
@@ -86,7 +86,7 @@ class CanvasTabSetDialog : CanvasComponentDialog(
          struct.goto_pos(line)
          struct.set_selections([nl])
          struct.set_cursor(nl)
-      }                              
+      }
       if \new.class_variable then
          item_var_category_cbg.set_which_one(item_var_category0)
       else
@@ -208,7 +208,7 @@ class CanvasTabSetDialog : CanvasComponentDialog(
       os_off := OverlayItem()
       os.add(os_off)
 
-      os_on := OverlayItem() 
+      os_on := OverlayItem()
       os.add(os_on)
 
       b := Border()
@@ -224,7 +224,7 @@ class CanvasTabSetDialog : CanvasComponentDialog(
       l.set_pos(20, 30)
       l.set_align("l", "c")
       b.add(l)
-      
+
       edit_label := TextField()
       edit_label.set_align("l", "c")
       edit_label.set_pos(70, 30)

--- a/uni/ide/ivib/canvastabsetui.icn
+++ b/uni/ide/ivib/canvastabsetui.icn
@@ -22,7 +22,7 @@ class CanvasTabSetUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Containers", 
+      self.BasicCanvasComponentUI.initially("Containers",
                                             "TabSet",
                                             $include "icon/icn13.icon"
                                             )

--- a/uni/ide/ivib/canvastextbutton.icn
+++ b/uni/ide/ivib/canvastextbutton.icn
@@ -27,7 +27,7 @@ class CanvasTextButton : CanvasButton : TextButton()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasButton.get_template() ||| 
+      return self.CanvasButton.get_template() |||
          [["Internal Align", "internal_alignment"]]
    end
 
@@ -39,7 +39,7 @@ class CanvasTextButton : CanvasButton : TextButton()
       c.internal_alignment := self.internal_alignment
    end
 
-   # 
+   #
    # Duplicate object
    #
    method dup(pc)

--- a/uni/ide/ivib/canvastextbuttondialog.icn
+++ b/uni/ide/ivib/canvastextbuttondialog.icn
@@ -14,8 +14,8 @@ import gui
 #
 #
 class CanvasTextButtonDialog : CanvasButtonDialog(
-   c,                                                  
-   internal_alignment,      #                          
+   c,
+   internal_alignment,      #
    internal_alignment_list
    )
 

--- a/uni/ide/ivib/canvastextbuttonui.icn
+++ b/uni/ide/ivib/canvastextbuttonui.icn
@@ -18,7 +18,7 @@ class CanvasTextButtonUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Buttons", 
+      self.BasicCanvasComponentUI.initially("Buttons",
                                             "TextButton",
                                             $include "icon/icn1.icon"
                                             )

--- a/uni/ide/ivib/canvastextfield.icn
+++ b/uni/ide/ivib/canvastextfield.icn
@@ -14,7 +14,7 @@ import gui
 # Class for representing a TextField on the canvas.
 #
 class CanvasTextField : CanvasComponent : TextField(
-   filter_str       
+   filter_str
    )
 
    #
@@ -64,7 +64,7 @@ class CanvasTextField : CanvasComponent : TextField(
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Contents", "contents"],
           ["Filter String", "filter_str"]
          ]

--- a/uni/ide/ivib/canvastextfielddialog.icn
+++ b/uni/ide/ivib/canvastextfielddialog.icn
@@ -39,7 +39,7 @@ class CanvasTextFieldDialog : CanvasComponentDialog(c, contents, filter)
       l.set_pos(50, "33%")
       l.set_align("l", "c")
       p.add(l)
-      
+
       contents := TextField()
       contents.set_pos(170, "33%")
       contents.set_size(100)
@@ -52,7 +52,7 @@ class CanvasTextFieldDialog : CanvasComponentDialog(c, contents, filter)
       l.set_pos(50, "66%")
       l.set_align("l", "c")
       p.add(l)
-      
+
       filter := TextField()
       filter.set_pos(170, "66%")
       filter.set_size(100)

--- a/uni/ide/ivib/canvastextfieldui.icn
+++ b/uni/ide/ivib/canvastextfieldui.icn
@@ -19,7 +19,7 @@ class CanvasTextFieldUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Text", 
+      self.BasicCanvasComponentUI.initially("Text",
                                             "TextField",
                                             $include "icon/icn3.icon"
                                             )

--- a/uni/ide/ivib/canvastextlist.icn
+++ b/uni/ide/ivib/canvastextlist.icn
@@ -20,7 +20,7 @@ class CanvasTextList : CanvasComponent : TextList()
       # 14 + 8*2 + 22
       return 52
    end
- 
+
    method min_width()
       # need a smart calculation font height + borders + scrollbar
       # for now based on constants in gui.icn, guiconst.icn we go with
@@ -77,7 +77,7 @@ class CanvasTextList : CanvasComponent : TextList()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Select One", "select_one"],
           ["Select Many", "select_many"],
           ["Checked", "checked"],

--- a/uni/ide/ivib/canvastextlistdialog.icn
+++ b/uni/ide/ivib/canvastextlistdialog.icn
@@ -14,8 +14,8 @@ import gui
 #
 #
 class CanvasTextListDialog : CanvasComponentDialog(
-   c,                       #         
-   contents,                #                
+   c,                       #
+   contents,                #
    select_group             #
    )
 

--- a/uni/ide/ivib/canvastextlistui.icn
+++ b/uni/ide/ivib/canvastextlistui.icn
@@ -18,7 +18,7 @@ class CanvasTextListUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Text", 
+      self.BasicCanvasComponentUI.initially("Text",
                                             "TextList",
                                             $include "icon/icn16.icon"
                                             )

--- a/uni/ide/ivib/canvastoolbarui.icn
+++ b/uni/ide/ivib/canvastoolbarui.icn
@@ -18,7 +18,7 @@ class CanvasToolBarUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Containers", 
+      self.BasicCanvasComponentUI.initially("Containers",
                                             "ToolBar"
                                             )
 end

--- a/uni/ide/ivib/canvastree.icn
+++ b/uni/ide/ivib/canvastree.icn
@@ -84,7 +84,7 @@ class CanvasTree : CanvasComponent : Tree()
    # Return the I/O template.
    #
    method get_template()
-      return self.CanvasComponent.get_template() ||| 
+      return self.CanvasComponent.get_template() |||
          [["Select One", "select_one"],
           ["Select Many", "select_many"],
           ["Show Root Handles", "show_root_handles"],

--- a/uni/ide/ivib/canvastreedialog.icn
+++ b/uni/ide/ivib/canvastreedialog.icn
@@ -14,7 +14,7 @@ import gui
 #
 #
 class CanvasTreeDialog : CanvasComponentDialog(
-   c,                       #         
+   c,                       #
    show_root,
    show_root_handles,
    select_group             #

--- a/uni/ide/ivib/canvastreeui.icn
+++ b/uni/ide/ivib/canvastreeui.icn
@@ -15,6 +15,6 @@ class CanvasTreeUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Other", 
+      self.BasicCanvasComponentUI.initially("Other",
                                             "Tree")
 end

--- a/uni/ide/ivib/canvasvlineui.icn
+++ b/uni/ide/ivib/canvasvlineui.icn
@@ -19,7 +19,7 @@ class CanvasVLineUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Separators", 
+      self.BasicCanvasComponentUI.initially("Separators",
                                             "VLine"
                                             )
 end

--- a/uni/ide/ivib/canvasvscrollbarui.icn
+++ b/uni/ide/ivib/canvasvscrollbarui.icn
@@ -20,7 +20,7 @@ class CanvasVScrollBarUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("ScrollBar", 
+      self.BasicCanvasComponentUI.initially("ScrollBar",
                                             "VScrollBar",
                                             $include "icon/icn10.icon"
                                             )

--- a/uni/ide/ivib/canvasvsizerui.icn
+++ b/uni/ide/ivib/canvasvsizerui.icn
@@ -18,7 +18,7 @@ class CanvasVSizerUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Separators", 
+      self.BasicCanvasComponentUI.initially("Separators",
                                             "VSizer"
                                             )
 end

--- a/uni/ide/ivib/canvasvsliderui.icn
+++ b/uni/ide/ivib/canvasvsliderui.icn
@@ -20,7 +20,7 @@ class CanvasVSliderUI : BasicCanvasComponentUI()
    end
 
    initially()
-      self.BasicCanvasComponentUI.initially("Slider", 
+      self.BasicCanvasComponentUI.initially("Slider",
                                             "VSlider"
                                             )
 end

--- a/uni/ide/ivib/cdialog.icn
+++ b/uni/ide/ivib/cdialog.icn
@@ -14,8 +14,8 @@ import gui
 #
 class CDialog : Dialog : SelectiveClassCoding(ticker_rate)
    method get_template()
-      return [["Min Width", "min_width"], 
-              ["Min Height", "min_height"], 
+      return [["Min Width", "min_width"],
+              ["Min Height", "min_height"],
               ["Ticker Rate", "ticker_rate"],
               ["Attribs", "attribs"]
               ]

--- a/uni/ide/ivib/choicedialog.icn
+++ b/uni/ide/ivib/choicedialog.icn
@@ -12,7 +12,7 @@ $include "guih.icn"
 #############################################################################
 #
 # Dialog with string and two buttons
-#     
+#
 class ChoiceDialog : CommonDialog(str, okay_str, cancel_str, okay, cancel, res)
    method result()
       return \self.res

--- a/uni/ide/ivib/eventtab.icn
+++ b/uni/ide/ivib/eventtab.icn
@@ -13,9 +13,9 @@ $include "guih.icn"
 
 class EventTab : TabItem(
                          tbl,
-                         add,                 # Buttons              
-                         delete,              #                  
-                         apply,               #                 
+                         add,                 # Buttons
+                         delete,              #
+                         apply,               #
                          contents,            # Table contents
                          event,
                          handler,
@@ -77,7 +77,7 @@ class EventTab : TabItem(
    method on_apply()
       local i
       #
-      # Copy the edited item back to the table. 
+      # Copy the edited item back to the table.
       #
       i := tbl.get_selections()[1]
       contents[i] := [event.get_contents(), handler.get_contents()]

--- a/uni/ide/ivib/gridelement.icn
+++ b/uni/ide/ivib/gridelement.icn
@@ -13,7 +13,7 @@
 #
 class GridElement(
    c,                       # The original CanvasComponent
-   abs_x_spec,              # Its absolute position                 
+   abs_x_spec,              # Its absolute position
    abs_y_spec               #
    )
 

--- a/uni/ide/ivib/gridset.icn
+++ b/uni/ide/ivib/gridset.icn
@@ -20,7 +20,7 @@ $define GRID_TOLERANCE 15
 # A line of GridElements.
 #
 class GridLine(
-   avg,                     # The average of the x or y values 
+   avg,                     # The average of the x or y values
    elements                 # The elements
    )
    method enter(e)
@@ -59,7 +59,7 @@ class VGridLine : GridLine()
 
    #
    # Set all the elements' positions
-   # 
+   #
    method set_positions(spec, align, fix)
       local e
       every e := !elements do {
@@ -105,7 +105,7 @@ end
 # A set of GridLines
 #
 class GridSet : Comparator(
-   orientation,             # Either "h" or "v"                  
+   orientation,             # Either "h" or "v"
    lines                    # The lines - all HGridLines or all VGridLines.
    )
 

--- a/uni/ide/ivib/group.icn
+++ b/uni/ide/ivib/group.icn
@@ -14,7 +14,7 @@ import lang
 # Superclass for CanvasCheckBoxGroup and CanvasButtonGroup
 #
 class Group : SelectiveClassCoding(
-   name,                    # Object name           
+   name,                    # Object name
    class_name,              # Class name
    import_name,             # Name of import file
    number,                  # Group number
@@ -66,7 +66,7 @@ class Group : SelectiveClassCoding(
               ]
    end
 
-   # 
+   #
    # Generate code; will be called several times so only output
    # first time.
    #
@@ -77,7 +77,7 @@ class Group : SelectiveClassCoding(
          c.add_import(self.import_name)
          code_gen_flag := 1
       }
-   end      
+   end
 
    initially
 end

--- a/uni/ide/ivib/groupset.icn
+++ b/uni/ide/ivib/groupset.icn
@@ -14,7 +14,7 @@ import lang
 # Superclass for CheckBoxGroupSet and ButtonGroupSet
 #
 class GroupSet : SelectiveClassCoding(
-   parent_Canvas,           #                     
+   parent_Canvas,           #
    boxes                    # List of the objects.
    )
 
@@ -54,7 +54,7 @@ class GroupSet : SelectiveClassCoding(
       return l
    end
 
-   # 
+   #
    # Group i in boxes.
    #
    method group_number(i)

--- a/uni/ide/ivib/groupsetdialog.icn
+++ b/uni/ide/ivib/groupsetdialog.icn
@@ -15,18 +15,18 @@ $include "guih.icn"
 # Dialog box for configuring GroupSet
 #
 class GroupSetDialog : CommonDialog(
-   c,                       #         
-   okay,                    #            
-   cancel,                  #              
-   apply,                   #             
-   struct,                  #              
-   os,                      #          
-   os_on,                   #             
-   os_off,                  #              
+   c,                       #
+   okay,                    #
+   cancel,                  #
+   apply,                   #
+   struct,                  #
+   os,                      #
+   os_on,                   #
+   os_off,                  #
    var_category0,           # Checkboxes for variable category
-   var_category1,           #  
+   var_category1,           #
    var_category_cbg,        #
-   col_name,                #                
+   col_name,                #
    col_class_name,          #
    col_import_name,         #
    okay_result              #
@@ -126,7 +126,7 @@ class GroupSetDialog : CommonDialog(
       os_off := OverlayItem()
       os.add(os_off)
 
-      os_on := OverlayItem() 
+      os_on := OverlayItem()
       os.add(os_on)
 
       b := Border()

--- a/uni/ide/ivib/infodialog.icn
+++ b/uni/ide/ivib/infodialog.icn
@@ -12,8 +12,8 @@ $include "guih.icn"
 #############################################################################
 #
 # A simple dialog to output a multi-line message.
-#     
-class InfoDialog : CommonDialog(lines, 
+#
+class InfoDialog : CommonDialog(lines,
                                 title,
                                 width,
                                 button_text,
@@ -28,7 +28,7 @@ class InfoDialog : CommonDialog(lines,
       /alignment := "c"
       /button_text := "Close"
 
-      self.set_attribs("size=" || width || "," || 90 + *lines * spacing, 
+      self.set_attribs("size=" || width || "," || 90 + *lines * spacing,
                        "label=" || title)
       close_button := TextButton()
       close_button.set_pos("50%", "100%-30")

--- a/uni/ide/ivib/menucomponentedit.icn
+++ b/uni/ide/ivib/menucomponentedit.icn
@@ -15,16 +15,16 @@ $include "guih.icn"
 #
 #
 class MenuComponentEdit : CommonDialog(
-   name,                    #            
+   name,                    #
    class_name,              # Class name
    import_name,             # TextField - import name
-   okay,                    #            
-   cancel,                  #              
+   okay,                    #
+   cancel,                  #
    label,                   # Dialog title
    tabset,
    code_tab,
    var_category0,           # Checkboxes for variable category
-   var_category1,           #  
+   var_category1,           #
    var_category_cbg,        #
    event_flag,
    event_method
@@ -39,14 +39,14 @@ class MenuComponentEdit : CommonDialog(
    #
    # Add the tab to the TabSet
    #
-   method add_tab(t) 
+   method add_tab(t)
       tabset.add(t)
    end
 
    #
    # Add the tab to the TabSet, as the first item
    #
-   method add_tab_at_front(t) 
+   method add_tab_at_front(t)
       tabset.add(t, 1)
    end
 

--- a/uni/ide/ivib/menutree.icn
+++ b/uni/ide/ivib/menutree.icn
@@ -25,7 +25,7 @@ class MenuTree : SelectableScrollArea()
       lp := xp
       every 1 to s.depth do {
          DrawLine(dashed, lp + SPACING / 2, yp - line_height / 2, lp + SPACING / 2, yp + line_height / 2)
-         
+
          lp +:= SPACING
       }
       if \s.owner then {
@@ -40,7 +40,7 @@ class MenuTree : SelectableScrollArea()
       if \selection_cw then
          FillRectangle(selection_cw, self.view.x, yp - self.line_height / 2, self.view.w, self.line_height)
 
-      if \cursor_cw then 
+      if \cursor_cw then
          Rectangle(cursor_cw, self.view.x, yp - self.line_height / 2, self.view.w, self.line_height)
 
       Uncouple(dashed)

--- a/uni/ide/ivib/savechangesdialog.icn
+++ b/uni/ide/ivib/savechangesdialog.icn
@@ -13,7 +13,7 @@ $include "guih.icn"
 #
 # Dialog asking whether or not to save a file.  The actual saving is left up
 # to the creator of the dialog.
-#     
+#
 class SaveChangesDialog : CommonDialog(yes, no, cancel, res)
    method result()
       return self.res
@@ -76,6 +76,6 @@ class SaveChangesDialog : CommonDialog(yes, no, cancel, res)
       cancel.set_label("Cancel")
       cancel.set_accel("c")
       cancel.set_pos("75%", "100%-30")
-      cancel.set_align("c", "c")      
+      cancel.set_align("c", "c")
       self.add(cancel)
 end

--- a/uni/ide/ivib/utils.icn
+++ b/uni/ide/ivib/utils.icn
@@ -137,11 +137,11 @@ procedure read_string_icon(dialog, s)
    close(f)
 
    #
-   # Check for reasonably valid image 
+   # Check for reasonably valid image
    #
    if img_height(res) then
       return res
-   else   
+   else
       return dialog.alert_error("Not a valid image")
 end
 
@@ -154,13 +154,13 @@ procedure util_check_attribs(dialog, l)
    initial {
       test_win := WOpen("canvas=hidden") | stop("couldn't open window")
       attrib_table := table()
-      every attrib_table["label" | "posx" | "pos" | "posy" | "resize" | "size" | "height" | 
-                         "width" | "lines" | "columns" | "image" | "canvas" | "iconpos" | "iconlabel" | 
-                         "iconimage" | "echo" | "cursor" | "x" | "y" | "row" | "col" | "pointer" | 
-                         "pointerx" | "pointery" | "pointerrow" | "pointercol" | "display" | "depth" | 
-                         "displayheight" | "displaywidth" | "fg" | "bg" | "reverse" | "drawop" | "gamma" | 
-                         "font" | "fheight" | "fwidth" | "ascent" | "descent" | "leading" | "linewidth" | 
-                         "linestyle" | "fillstyle" | "pattern" | "clipx" | "clipy" | "clipw" | "cliph" | 
+      every attrib_table["label" | "posx" | "pos" | "posy" | "resize" | "size" | "height" |
+                         "width" | "lines" | "columns" | "image" | "canvas" | "iconpos" | "iconlabel" |
+                         "iconimage" | "echo" | "cursor" | "x" | "y" | "row" | "col" | "pointer" |
+                         "pointerx" | "pointery" | "pointerrow" | "pointercol" | "display" | "depth" |
+                         "displayheight" | "displaywidth" | "fg" | "bg" | "reverse" | "drawop" | "gamma" |
+                         "font" | "fheight" | "fwidth" | "ascent" | "descent" | "leading" | "linewidth" |
+                         "linestyle" | "fillstyle" | "pattern" | "clipx" | "clipy" | "clipw" | "cliph" |
                          "dx" | "dy"] := 1
    }
 

--- a/uni/lib/_table.icn
+++ b/uni/lib/_table.icn
@@ -244,7 +244,7 @@ class Table : Component(
          }
       }
    end
-   
+
    method handle_rpress(e)
       if \ (self.select_one | self.select_many) & (self.tx <= &x < self.tx + self.tw) & (self.ty  <= &y < self.ty + self.th) then {
          #
@@ -276,7 +276,7 @@ class Table : Component(
       }
    end
 
-   
+
 
    method end_state()
       if \self.is_held then {
@@ -715,12 +715,12 @@ class Table : Component(
       if *\highlight_lst > 0 then
          h_set := set(highlight_lst)
       else
-         h_set := set() 
+         h_set := set()
 
       if *\highlight_lst2 > 0 then
          h_set2 := set(highlight_lst2)
       else
-         h_set2 := set()  
+         h_set2 := set()
 
       line := self$get_line()
       left_pos := self$get_left_pos()
@@ -754,11 +754,11 @@ class Table : Component(
 
             Clip(self.cbwin, clip_x1, self.ty, clip_x2 - clip_x1, self.th)
 
-           
+
             case self.columns[j].internal_alignment of {
                "r" : right_string(self.cbwin, x1 + w1, yp, l[j])
                "c" : center_string(self.cbwin, x1 + w1 / 2, yp, l[j])
-               "l" : left_string(self.cbwin, x1, yp, l[j]) 
+               "l" : left_string(self.cbwin, x1, yp, l[j])
             }
             Clip(self.cbwin)
          }

--- a/uni/lib/editabletextlist.icn
+++ b/uni/lib/editabletextlist.icn
@@ -54,7 +54,7 @@ class EditableTextList : ScrollArea(
      return [self.cursor_x,self.cursor_y]
       }
    return []
- 
+
   end
 
    #
@@ -104,9 +104,9 @@ class EditableTextList : ScrollArea(
 
    Clip(self.cwin, self.tx, self.ty, self.tw, self.th)
    yp := self.ty + self.line_height / 2
-      
+
    j := cx
- 
+
    every l := self.contents[i := line to self.cursor_y  - 1] do {
        yp +:= self.line_height
    }
@@ -115,22 +115,22 @@ class EditableTextList : ScrollArea(
    l := self.contents[self.cursor_y]
 
    l := actual_line(l)
- 
-        
+
+
 #   every  k := 1 to *r1  do {
-#      if any(printable,r1[k]) then 
+#      if any(printable,r1[k]) then
 #          l := l || r1[k]
 #   }
-  
- 
+
+
    while  j <  *l do {
-      if l[j] == !c1 then { 
-           ex := j 
+      if l[j] == !c1 then {
+           ex := j
            ex := many(alnum,l,j)
            word := l[j:ex]
            if map(trim(word)) == map(trim(spword)) then {
-              self.cursor_x := ex 
-              i :=   self.cursor_y 
+              self.cursor_x := ex
+              i :=   self.cursor_y
               EraseRectangle(self.cwin, self.tx, self.ty, self.tw, self.th)
               self.constrain_line()
               self.display()
@@ -138,15 +138,15 @@ class EditableTextList : ScrollArea(
               draw23(l, left_pos, yp, i,j,ex,1)
               Clip(self.cwin, self.tx, self.ty, self.tw, self.th)
               return 1
-            }  # if map 
+            }  # if map
             j := ex
       } # if l[j]
       j := j + 1
    }  # while
-   
+
 
    return 0
-   
+
    end
 #____________________________________________________________________
   method text_area_to_high()
@@ -188,11 +188,11 @@ class EditableTextList : ScrollArea(
                 if j := find(map(wordlist[k][2:0]),map(l),j) then {
                    ex := j + *(wordlist[k][2:0])
                    draw23(l, left_pos, yp, i,j,ex)
-                   j := ex 
+                   j := ex
                 }
             }
             else {
-             if member(c2,l[j]) then { 
+             if member(c2,l[j]) then {
                ex := many(c2,l,j)
                word := l[j:ex]
                if map(trim(word)) == map(trim(wordlist[k])) then {
@@ -205,17 +205,17 @@ class EditableTextList : ScrollArea(
         } # every *wordlist
         yp +:= self.line_height
       }
- 
+
 #      Clip(self.cwin, self.tx, self.ty, self.tw, self.th)
        Clip(self.cwin)
-     
+
    return
-  
-  
+
+
    end
 #___________________________________________________________________
 method draw23(s, left_pos, yp, i,sx,ex,nc)
-local s1, s2, newp, fh, asc, desc, yp2 ,s3 
+local s1, s2, newp, fh, asc, desc, yp2 ,s3
    newp := 0
    s1 := ""
    s2 := ""
@@ -225,22 +225,22 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
    desc := WAttrib(self.cwin, "descent")
 
    s :=  actual_line(s)
- 
+
    s1 := s[1:sx]
    s2 := s[sx:ex]
-  
-   newp := left_pos + TextWidth(self.cwin, s1) 
-      
+
+   newp := left_pos + TextWidth(self.cwin, s1)
+
  #  Fg(self.cwin, "very light gray")
    Fg(self.cwin, "light violet")
    yp2 :=  yp + ((WAttrib(self.cwin,"ascent")-
                       WAttrib(self.cwin,"descent"))/2) - asc
    FillRectangle(self.cwin,newp, yp2, TextWidth(self.cwin, s2), fh)
    left_stringr(self.cwin, left_pos, yp, s)
- 
+
    if \nc then
       self.cursor_x :=  *s1 + *s2
-  
+
    end
 #_____________________________________________________________
 
@@ -260,14 +260,14 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       every j := 1 to *x do {
         s1 := ""
         every k := 1 to *x[j] do {
-            if x[j][k] == "\t" then 
+            if x[j][k] == "\t" then
                 s1 := s1 || x[j][k]
-            else if any(printable,x[j][k]) then 
+            else if any(printable,x[j][k]) then
                  s1 := s1 || x[j][k]
         }
-       
+
         put(new1,s1)
-      } 
+      }
 
       self.contents := new1
       if *self.contents = 0 then
@@ -285,7 +285,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
        return new1
    end
 
- 
+
    #
    # Move cursor y to line n, and constrain x within range of that line.
    #
@@ -492,7 +492,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
 
    method handle_start_of_line(e)
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -503,7 +503,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
    method handle_end_of_line(e)
    local s
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -605,11 +605,11 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
 
    method handle_delete_line(e)
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
-      if cursor_y < *self.contents then 
+      if cursor_y < *self.contents then
          self.contents := self.contents[1:self.cursor_y] ||| self.contents[self.cursor_y + 1 : 0]
       else
          self.contents := self.contents[1:self.cursor_y] ||| [""]
@@ -628,7 +628,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       # Delete backspace delete
       #
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -656,7 +656,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
          offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
          posn := self.cursor_x  - offset - 1
          if self.contents[self.cursor_y][self.cursor_x  - offset - 1] == "\t" then  {
-            put(cutlst, self.contents[self.cursor_y][self.cursor_x  - offset - 1]) 
+            put(cutlst, self.contents[self.cursor_y][self.cursor_x  - offset - 1])
 
             self.contents[self.cursor_y][self.cursor_x  - offset - 1] := ""
             offset := offset_pos(self.contents[self.cursor_y],posn,1)
@@ -667,11 +667,11 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
                undo_del := undo_rec("delete_list",cutlst,self.cursor_x,self.cursor_y,0,0,"insert",[],self.cursor_x,self.cursor_y,0,0)
                put(undolist,undo_del)
                }
-            } 
+            }
          else { # contents ~= "\t"
 
            if /undo then {
-              put(cutlst, self.contents[self.cursor_y][self.cursor_x  - offset - 1]) 
+              put(cutlst, self.contents[self.cursor_y][self.cursor_x  - offset - 1])
               undo_del := undo_rec("delete_list",cutlst,self.cursor_x-1,self.cursor_y,0,0,"insert",[],self.cursor_x-1,self.cursor_y,0,0)
               put(undolist,undo_del)
               }
@@ -690,13 +690,13 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       # Delete
       #
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
       offset := 0
 
-      if /no_offset then 
+      if /no_offset then
          offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
 
       newcursor_x := self.cursor_x - offset
@@ -720,7 +720,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
    method handle_return(e, undo)
    local offset, s, newcursor_x,j1, undo_info
      if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -729,13 +729,13 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       s := self.contents[self.cursor_y]
       newcursor_x := self.cursor_x - offset
 
-#undo 
+#undo
       if /undo then  {
          redolist := []
          undo_info := undo_rec("insert",[e],self.cursor_x,self.cursor_y,0,0,"delete_cr",[e],self.cursor_x,self.cursor_y,0,0)
             put(undolist,undo_info)
       }
-  
+
       self.contents[self.cursor_y] := s[1:newcursor_x]
       self.contents := self.contents[1:cursor_y + 1] ||| [s[newcursor_x:0]] |||
                          self.contents[cursor_y + 1:0]
@@ -756,7 +756,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
    method handle_tab_text(e, undo)
    local offset, undo_info
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -788,7 +788,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       # Add any printable character at cursor position
       #
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
          }
       reset_drag()
@@ -796,8 +796,8 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
       offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
 
       if /cntl &  type(e) == "string" & &control then
-         return 
-        
+         return
+
    #  if type(e) == "string" & not(&control | &meta) & any(printable, e) then {
       if type(e) == "string" & not(&meta) & any(printable, e) then {
 
@@ -806,7 +806,7 @@ local s1, s2, newp, fh, asc, desc, yp2 ,s3
             undo_info := undo_rec("insert",[e],self.cursor_x,self.cursor_y,0,0,"delete_list",[e],self.cursor_x,self.cursor_y,0,0)
             put(undolist,undo_info)
             }
-   
+
          if self.cursor_x = 1 then
             self.contents[self.cursor_y] := e || self.contents[self.cursor_y]
          else
@@ -822,23 +822,23 @@ end
 #
 # The undo list is built for each event. This method gets the last
 # item off the list and undos it using the same routines. A non-null
-# parameter is passed to cut_selection, set_selection, and handle_return 
-# so that these undo actions are not put back on the undo list. 
+# parameter is passed to cut_selection, set_selection, and handle_return
+# so that these undo actions are not put back on the undo list.
 #
    method handle_undo(e, no_redo)
       redolist := []
       if *undolist = 0 then
          return
-    
+
       if self.noedit = 1 then {
-         self.has_focus := &null 
+         self.has_focus := &null
          return
       }
- 
+
       self.has_focus := 1
       undo_info  := pull(undolist)
       case undo_info.undo_type of  {
-      "insert" : { 
+      "insert" : {
          reset_drag()
          self.cursor_x :=  undo_info.undo_x
          self.cursor_y :=  undo_info.undo_y
@@ -848,8 +848,8 @@ end
          }
       "delete_list" : {
          reset_drag() #
-         self.cursor_x := undo_info.undo_x 
-         self.cursor_y := undo_info.undo_y 
+         self.cursor_x := undo_info.undo_x
+         self.cursor_y := undo_info.undo_y
          if /no_redo then
             put(redolist,undo_info)
          set_selection(undo_info.undo_list,1)
@@ -864,14 +864,14 @@ end
          enddragy := undo_info.undoend_y
          if /no_redo then
             put(redolist,undo_info)
-         cut_selection(1) 
+         cut_selection(1)
          self.has_focus := &null
          return
          }
       "delete_cr" : {
          reset_drag()
-         self.cursor_x := undo_info.undo_x 
-         self.cursor_y := undo_info.undo_y 
+         self.cursor_x := undo_info.undo_x
+         self.cursor_y := undo_info.undo_y
          if /no_redo then
             put(redolist,undo_info)
          handle_return("\r",1)
@@ -881,7 +881,7 @@ end
 #         text_area_to_high()
          self.has_focus := &null
          return
-         }      
+         }
       }
 
    self.has_focus := &null
@@ -900,7 +900,7 @@ end
          return
 
       if self.noedit = 1 then {
-        self.has_focus := &null 
+        self.has_focus := &null
         return
       }
       rec1 :=  pull(redolist)
@@ -1001,7 +1001,7 @@ end
 
 #     create a mapping for the cursor to skip over the tabs
         sa := map_pos(self.contents[self.cursor_y] || " ")
-    
+
         self.cursor_x := 1
         l := self.get_left_pos()
         while (self.cursor_x < *s) & (TextWidth(self.cwin, s[1:self.cursor_x + 1]) < &x - l)
@@ -1016,7 +1016,7 @@ end
             }
           }  # while
 
-  
+
       if donedrag = 0 then {
          startdragx := self.cursor_x
          startdragy := self.cursor_y
@@ -1030,11 +1030,11 @@ end
    end
 
 #
-# added to prevent reset of drag positions when ^x,^c,^v 
+# added to prevent reset of drag positions when ^x,^c,^v
 #
 method handle_nodefault()
    if self.noedit = 1 then {
-      self.has_focus := &null 
+      self.has_focus := &null
       return
       }
    return
@@ -1045,7 +1045,7 @@ end
 #  parameter s is a list of strings
 #
 method set_selection(slst, undo)
-local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcursor_x,undo_info,s3 
+local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcursor_x,undo_info,s3
    self.has_focus := 1
    stng := ""
    slast := ""
@@ -1058,12 +1058,12 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
 
    offset := 0
    offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
-   
+
    if /undo then {
       redolist := []
       undo := 1 # do not build list in handle_default because built here
       if *slst > 1 then {
-         endy := self.cursor_y  + *slst - 1 
+         endy := self.cursor_y  + *slst - 1
          slast :=  actual_line(slst[*slst])  # size of last string in list
          endx := *slast + 1 # one more for drag
          }
@@ -1081,7 +1081,7 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
 
    stng := slst[1]
    if *slst = 1 & *stng = 1 then {
-      if stng == "\t" then 
+      if stng == "\t" then
          handle_tab_text(stng,undo)
        else
           handle_default(stng,1,undo)
@@ -1098,15 +1098,15 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
    oldcursor_x := self.cursor_x
    oldcursor_y := self.cursor_y
    newcursor_x := self.cursor_x - offset
-     
-   self.contents[self.cursor_y] := s[1:newcursor_x] || stng 
+
+   self.contents[self.cursor_y] := s[1:newcursor_x] || stng
    s2 :=  s[newcursor_x:0]
 
    self.contents := self.contents[1:cursor_y + 1] ||| self.contents[cursor_y + 1:0]
 
    self.cursor_y +:= 1
    self.cursor_x := 1
-      
+
    every j := 2 to *slst  do {
       stng := slst[j]
       s :=  self.contents[self.cursor_y]
@@ -1119,7 +1119,7 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
       self.cursor_y +:= 1
       self.cursor_x := 1
    }
-  
+
    self.cursor_y  := self.cursor_y -  1
    self.contents[self.cursor_y] :=  self.contents[self.cursor_y] || s2
 
@@ -1127,7 +1127,7 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
 
    reset_drag()
 
-   self.cursor_y :=  oldcursor_y 
+   self.cursor_y :=  oldcursor_y
    self.cursor_x :=  oldcursor_x
    self.set_internal_fields()
    self.constrain_line()
@@ -1138,7 +1138,7 @@ local stng,j,k,endx,endy,endpos,offset,slast,newcursor_x,s,s2,oldcursor_y,oldcur
    return _Event(e, self, 0)
   end
 
-#  method added to retieve a highlighted section swj 
+#  method added to retieve a highlighted section swj
 #  returns a list of strings for Copy
 ##
 method get_selection()
@@ -1147,7 +1147,7 @@ local st, lst, l, i, sx
    lst := []
    l := ""
     #  self.has_focus := &null
-   #  return just one character if nothing is highlighted  
+   #  return just one character if nothing is highlighted
    if (enddragx = startdragx ) & (enddragy = startdragy) then {
       offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
       sx := self.cursor_x - offset
@@ -1160,14 +1160,14 @@ local st, lst, l, i, sx
       st := get_region(i)
       if \st then
          put(lst,st)
-      } 
+      }
       return lst
    end
 
 #
 #  returns the string that is highlighted for each line of self.contents
 #  s is the line of self.contents and i is line number or y position
-# 
+#
 method get_region(i)
 local ex, sx, offset, s2
    s2 := ""
@@ -1179,7 +1179,7 @@ local ex, sx, offset, s2
    #  if no vertical drag just current line
    if (i = startdragy) & (startdragy = enddragy) then {
       if startdragx < enddragx then    # forward drag
-         return self.contents[i][sx:ex] 
+         return self.contents[i][sx:ex]
       if startdragx > enddragx then    # backward drag
          return self.contents[i][ex:sx]
       }
@@ -1201,17 +1201,17 @@ local ex, sx, offset, s2
       if i > startdragy then  # for forward drag
          return self.contents[i][1:ex]
       if i < startdragy then  # for reverse drag
-         if ex <=  *(self.contents[i]) then 
+         if ex <=  *(self.contents[i]) then
             return self.contents[i][ex:0]
       }
 
    #  fill in all the lines in between
-   #  for forward drag         
-   if i < enddragy & i > startdragy then  #  for forward drag     
+   #  for forward drag
+   if i < enddragy & i > startdragy then  #  for forward drag
       return self.contents[i]
    if i > enddragy & i < startdragy then  # reverse
       return self.contents[i]
-  
+
    return
    end
 
@@ -1219,10 +1219,10 @@ local ex, sx, offset, s2
 #  This method added to support Cut
 #  It removes the highlighted region from self.contents
 #  This cut was modeled after Emacs editor and therefore removes
-#  the carriage return at the end of lines so they are merged. 
+#  the carriage return at the end of lines so they are merged.
 #
 method cut_selection(undo,ev)
-local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x 
+local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
    l := ""
    lst := []
    flag1 := ["n"] # flags to indicate if A all or P partial cut of line
@@ -1233,23 +1233,23 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
       self.has_focus := &null
       return
       }
-  
+
    #
    #  keep starting and ending drag positions because they will be reset
    #  when handle_delete_2 and handle_delete_line etc are called.
    #
-   ex := enddragx 
+   ex := enddragx
    ey := enddragy
    sx := startdragx
    sy := startdragy
-   
+
    # No drag just delete character under the cursor
    if (enddragx = startdragx ) & (enddragy = startdragy) then {
       if /undo then {
          redolist := []
          offset := offset_pos(self.contents[self.cursor_y],self.cursor_x)
          newcursor_x := self.cursor_x-offset
-         put(cutlst,self.contents[self.cursor_y][newcursor_x]) 
+         put(cutlst,self.contents[self.cursor_y][newcursor_x])
          undo_info := undo_rec("delete_list",cutlst,self.cursor_x,self.cursor_y,0,0,"insert",[],newcursor_x,self.cursor_y,0,0)
          put(undolist,undo_info)
          }
@@ -1258,15 +1258,15 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
       self.set_internal_fields()
       self.display()
 #      text_area_to_high()
-      if /ev then 
+      if /ev then
         self.has_focus := &null
-      return 
+      return
       }
- 
+
    if /undo then {
       redolist := []
       cutlst :=  get_selection()
-      if sy = ey then 
+      if sy = ey then
          if ex > sx then {      # forward
             undo_info := undo_rec("delete_list",cutlst,sx,sy,0,0,"insert_list",[],sx,sy,ex,ey)
             put(undolist,undo_info)
@@ -1287,7 +1287,7 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
 
    undo := 1
    if sy = ey then {         # only horizontal drag
-      l := self.contents[sy] 
+      l := self.contents[sy]
       i := sy
       get_cutregion_1_line(i, sx, ex,undo,flag1)
       }
@@ -1296,9 +1296,9 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
          i := ey
          get_cutregion_last(i, ex, ey, sx, sy, flag2)
          # go through next loop bottom up because lines are deleted
-         i := ey - 1 
+         i := ey - 1
          while i > sy do {
-            l := self.contents[i] 
+            l := self.contents[i]
             get_cutregion_mid(l, i, ex, ey, sx, sy)
             i := i - 1
             }
@@ -1308,18 +1308,18 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
             get_cutregion_cr(i, ex, ey, sx, sy)
          if flag1[1] == "A" &  flag2[1] == "A"  then {# A All of lines cut add cr
             self.cursor_y := sy
-            self.cursor_x := 1 
+            self.cursor_x := 1
             handle_return("\r",undo)
             self.cursor_y := sy
-            self.cursor_x := 1 
-            } 
+            self.cursor_x := 1
+            }
          }
       else { # bottom to top drag
          i := sy  # cut line from start of drag
          get_cutregion_last(i, ex, ey, sx, sy, flag2)
          i := sy - 1
          while i > ey do {
-            l := self.contents[i] 
+            l := self.contents[i]
             get_cutregion_mid(l, i, ex, ey, sx, sy)
             self.max_width := get_max_width()
             i := i - 1
@@ -1330,27 +1330,27 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
             get_cutregion_cr(i, ex, ey, sx, sy)
          if flag1[1] == "A" &  flag2[1] == "A"  then {# A All of lines cut add cr
             self.cursor_y := ey
-            self.cursor_x := 1 
+            self.cursor_x := 1
             handle_return("\r",undo)
             self.cursor_y := ey
-            self.cursor_x := 1 
-            } 
+            self.cursor_x := 1
+            }
          } # bottom to top drag
       }# end else ey > sy
 
    if ey = sy then {
-      self.cursor_y := sy 
+      self.cursor_y := sy
       if sx > ex then         # reverse drag
          self.cursor_x := ex
-      else 
+      else
          self.cursor_x := sx
       }
    if ey > sy then {       # top to bottom drag
-      self.cursor_y := sy 
+      self.cursor_y := sy
       self.cursor_x := sx
       }
    if ey < sy then {        # bottom to top drag
-      self.cursor_y := ey 
+      self.cursor_y := ey
       self.cursor_x := ex
       }
 
@@ -1359,7 +1359,7 @@ local l, lst, ex, ey, sx, sy, i, flag1,flag2, undo_info, offset, newcursor_x
    self.constrain_line()
    self.display()
 #   text_area_to_high()
-   if /ev then 
+   if /ev then
      self.has_focus := &null
 
 end
@@ -1370,17 +1370,17 @@ end
 method get_cutregion_mid(s, i, ex, ey, sx, sy)
    s :=  actual_line(s)
    self.cursor_y := i
-   self.cursor_x := ex 
-     
-   if i < ey & i > sy then { # for forward drag     
+   self.cursor_x := ex
+
+   if i < ey & i > sy then { # for forward drag
       handle_delete_line("\^k")
       self.max_width := get_max_width()
-      return 
+      return
       }
    if i > ey & i < sy then {  # reverse drag
       handle_delete_line("\^k")
       self.max_width := get_max_width()
-      return 
+      return
       }
    end
 
@@ -1408,7 +1408,7 @@ local j, offset
       }
    if sx > ex then {    # backward drag
       every j := ex to sx - 1 do {
-          self.cursor_x := ex 
+          self.cursor_x := ex
           handle_delete_2("\d",1)
           self.max_width := get_max_width()
           }
@@ -1416,7 +1416,7 @@ local j, offset
    end
 
 #  method to cut the highlighted regions of the first and last lines
-#  when more than one line is highlighted 
+#  when more than one line is highlighted
 #  set flag1 if drag on last line does not include the entire line.
 #  This will indicate that the carriage return on the previous line
 #  must be deleted so the lines will be merged and will behave like
@@ -1424,10 +1424,10 @@ local j, offset
    method get_cutregion_first(i, ex, ey, sx, sy, flag2)
    local j
    j := 0
-   
+
    self.cursor_y := i
-   s  := self.contents[self.cursor_y] 
-  
+   s  := self.contents[self.cursor_y]
+
 #  if drag on current line and a vertical drag
 #  for forward drag need to get whole line for backward
 #  need to get line up to start of drag
@@ -1439,7 +1439,7 @@ local j, offset
          handle_delete_line("\^k")
          self.max_width := get_max_width()
          flag2[1] := "A"  # All of line cut
-         return 
+         return
          }
       every j := sx to *s do {
          self.cursor_x := sx
@@ -1447,7 +1447,7 @@ local j, offset
          self.max_width := get_max_width()
          }
       flag2[1] := "P"     # part of line cut
-      return 
+      return
       }
    if sy > ey then { # reverse drag get the 1st part to start x
       offset := offset_pos(self.contents[self.cursor_y],ex)
@@ -1456,15 +1456,15 @@ local j, offset
          handle_delete_line("\^k")
          self.max_width := get_max_width()
          flag2[1] := "A"  # all of line cut
-         return 
+         return
          }
       every j := ex to *s do {
-         self.cursor_x := ex 
+         self.cursor_x := ex
          handle_delete_2("\d",1)
          self.max_width := get_max_width()
          }
       flag2[1] := "P"   # part of line cut
-      return 
+      return
       }
    end
 
@@ -1472,10 +1472,10 @@ method get_cutregion_last(i,ex, ey, sx, sy, flag1)
 local j,offset
    j := 0
    offset := 0
- 
+
    self.cursor_y := i
    s  := self.contents[self.cursor_y]
- 
+
    if ey > sy then { # for forward drag
       offset := offset_pos(self.contents[self.cursor_y],ex)
       ex := ex - offset
@@ -1483,7 +1483,7 @@ local j,offset
          handle_delete_line("\^k")
          self.max_width := get_max_width()
          flag1[1] := "A"
-         return 
+         return
          }
       every j := 1 to ex - 1 do {
          self.cursor_x := 1
@@ -1501,7 +1501,7 @@ local j,offset
          handle_delete_line("\^k")
          self.max_width := get_max_width()
          flag1[1] := "A"
-         return 
+         return
          }
       every j := 1 to sx - 1 do {
          self.cursor_x := 1
@@ -1510,23 +1510,23 @@ local j,offset
          }
       flag1[1] := "P"
       }
-   return 
+   return
 end
 
 #
 #  method to remove carriage return on the line before(forward drag)
-#  or after(backward drag). This will merge the two lines. 
+#  or after(backward drag). This will merge the two lines.
 #
 method get_cutregion_cr(i, ex, ey, sx, sy)
 local s
 
    self.cursor_y := i
-   s  := self.contents[self.cursor_y]  
+   s  := self.contents[self.cursor_y]
    s :=  actual_line(s)
 
    if *s = 0 then
       return
-  
+
 # if drag on current line and a vertical drag
 # for forward drag need to get whole line for backward
 # need to get line up to start of drag
@@ -1536,17 +1536,17 @@ local s
          self.cursor_x := *s + 1
          handle_delete_2("\d")
          self.max_width := get_max_width()
-         return 
+         return
          }
       }
 
    if i = ey then {
       if i < sy then { # for reverse drag
-         self.cursor_x := *s + 1 
+         self.cursor_x := *s + 1
          handle_delete_2("\d")
          self.max_width := get_max_width()
          }
-      return 
+      return
       }
    end
 
@@ -1554,7 +1554,7 @@ local s
 #  Added Editable Textlist version of draw
 #
 method draw(s, left_pos, yp, i)
-local s1, s2, newp, fh, asc, desc, yp2  
+local s1, s2, newp, fh, asc, desc, yp2
    newp := 0
    s1 := ""
    s2 := ""
@@ -1596,7 +1596,7 @@ local s1, s2, newp, fh, asc, desc, yp2
          }
    if i > enddragy then { # reverse drag get the 1st part to start x
       if startdragx  >= *s then
-         s2 := s 
+         s2 := s
       else
          s2 := s[1:startdragx]
       newp := left_pos
@@ -1651,31 +1651,31 @@ local s1, s2, newp, fh, asc, desc, yp2
       }
 end
 
-# 
+#
 #
 #  This method returns the offset(or number of added blanks because
 #  of the tabs) up to the end position. If the use_selfcontents parameter is
 #  null then the number of blanks up to the position (endpos) in the
 #  actual line (the line with the blanks that is displayed) is returned.
-#  If  use_selfcontents is not null, then the number of blanks that would be  
-#  inserted up to the position (endpos) in self.contents is returned. 
-#  
-   method offset_pos(tab_line,endpos,use_selfcontents)  
+#  If  use_selfcontents is not null, then the number of blanks that would be
+#  inserted up to the position (endpos) in self.contents is returned.
+#
+   method offset_pos(tab_line,endpos,use_selfcontents)
    local posx, sblnks, linepos, numtabs, x12
    posx := 0
    sblnks := 0
    linepos := 0
    numtabs := 0
- 
+
    tab_line ? {
       while x12 := move(1) do {
          linepos := linepos + 1
          if /use_selfcontents then {
             if posx == endpos - 1  then # stop at the position in the line displayed
                return sblnks - numtabs
-            } 
+            }
          else {
-            if linepos == endpos  then  # stop where at endpos in self.contents 
+            if linepos == endpos  then  # stop where at endpos in self.contents
                return  sblnks - numtabs
              }
          if x12 == "\t" then {
@@ -1700,8 +1700,8 @@ end
 #  is a horizantal jump and needs to move an extra position. If the
 #  vertical_key is not null, then it is a vertical jump and it does
 #  not need to move forward an extra position just straight up or down.
-   
-method map_pos(pos_line, vertical_key) 
+
+method map_pos(pos_line, vertical_key)
 local posx, sblnks, pos_line2, x12, tabpos,printable
    printable := cset(&ascii[33:128])
    posx := 0
@@ -1710,7 +1710,7 @@ local posx, sblnks, pos_line2, x12, tabpos,printable
 
    pos_line ? {
       while x12 := move(1) do {
-     
+
          if x12 == "\t" then {
             posx +:= 1
 
@@ -1722,13 +1722,13 @@ local posx, sblnks, pos_line2, x12, tabpos,printable
          posx +:= (8 -  (posx-1)%8) - 1
          }
        else {
-        # if any(printable,x12) then { 
+        # if any(printable,x12) then {
             posx +:= 1
             pos_line2[posx] := posx
         # }
          }
       }
-      
+
    }
 
    return pos_line2

--- a/uni/lib/fastprime.icn
+++ b/uni/lib/fastprime.icn
@@ -22,7 +22,7 @@ end
 # <i>precision</i> is generally sufficient.
 # Google the <b>Miller-Rabin primality test</b> for details on the
 # algorithm.
-# <[param n integer value to test for primality.]> 
+# <[param n integer value to test for primality.]>
 # <[param precision degree of confidence to use (defaults to 16).]>
 # <[return n if n is prime, fails otherwise.]>
 #</p>
@@ -34,7 +34,7 @@ procedure is_prime(n, precision)
       k_primes_set := set(known_primes)
       }
     /precision := 16
-      
+
     if n <= 1 then fail
     # Fast check for small n
     if member(k_primes_set, n) then return n

--- a/uni/lib/logger.icn
+++ b/uni/lib/logger.icn
@@ -321,7 +321,7 @@ class Logger(
    method debug_level_kind(lvl, kind, msgs[])
       self._debug(lvl+8, kind, msgs)
    end
-   
+
    method set_log_level(newLevel)
       current_log_level := newLevel
    end

--- a/uni/lib/mailbox.icn
+++ b/uni/lib/mailbox.icn
@@ -11,7 +11,7 @@ import util
 # may be parsed in accordance with RFC822.
 #
 class Mailbox : Address : Error(local_part, domain, phrase, route)
-   method get_local_part() 
+   method get_local_part()
       return local_part
    end
 
@@ -22,12 +22,12 @@ class Mailbox : Address : Error(local_part, domain, phrase, route)
    method get_domain()
       return domain
    end
-   
+
    method set_domain(x)
       domain := x
    end
 
-   method get_phrase() 
+   method get_phrase()
       return phrase
    end
 
@@ -35,7 +35,7 @@ class Mailbox : Address : Error(local_part, domain, phrase, route)
       phrase := x
    end
 
-   method get_route() 
+   method get_route()
       return route
    end
 
@@ -70,7 +70,7 @@ class Mailbox : Address : Error(local_part, domain, phrase, route)
       local p
       p := mail::RFC822Parser()
       return p.parse_mailbox(s, self) | error(p)
-   end   
+   end
 
    method generate_mailboxes()
       return self

--- a/uni/lib/textlist.icn
+++ b/uni/lib/textlist.icn
@@ -57,7 +57,7 @@ class TextList : ScrollArea()
    local fd, longstring, format_list
    longstring := ""
    format_list := []
-   
+
    if /no_open then
    if not (fd := open(printfile, mode)) then
       fail
@@ -69,7 +69,7 @@ class TextList : ScrollArea()
    nlines :=  *self.contents
 
    if \heading then {
-      write(fd) 
+      write(fd)
       write(fd, heading)
       write(fd)
       }
@@ -78,7 +78,7 @@ class TextList : ScrollArea()
    # Write the lines
    #
    every l := self.contents[i := line to line + nlines - 1] do {
-      write(fd,self.contents[i]) 
+      write(fd,self.contents[i])
    }
 
    writes(fd, "\^L") # emit a page break

--- a/uni/progs/csv.icn
+++ b/uni/progs/csv.icn
@@ -37,7 +37,7 @@ procedure helpMesg()
     write(&errout,"\t     Normally, fields are separated by exactly one")
     write(&errout,"\t     separator, so \"a,,b\" has three fields.")
     write(&errout,"\t--span -- fields separated by one or more SEPARATORS")
-    write(&errout,"\t     So \"a,,b\" has two fields.")  
+    write(&errout,"\t     So \"a,,b\" has two fields.")
     stop()
 end
 

--- a/uni/progs/exception_demo.icn
+++ b/uni/progs/exception_demo.icn
@@ -27,13 +27,13 @@
 #        g [ExceptionDemo.icn:96]
 #        f [ExceptionDemo.icn:80]
 #        main [ExceptionDemo.icn:56]
-#    
+#
 #    x is '4'.
 #    NumException: 'a' is not a number:
 #        g [ExceptionDemo.icn:93]
 #        f [ExceptionDemo.icn:80]
 #        main [ExceptionDemo.icn:56]
-#    
+#
 #    x is '6'.
 #</pre>
 #<p>
@@ -69,7 +69,7 @@ procedure main(args)
             }
 
         }
-        
+
 end
 
 #<p>

--- a/uni/progs/heap_demo.icn
+++ b/uni/progs/heap_demo.icn
@@ -61,10 +61,10 @@ class HeapDemo()
 
         header("Heap of reals, sorted by inverse order.")
         processReals(Heap(, Closure("*",-1)))
-     
+
         header("Heap of reals, sorted by reverse order.")
         processReals(Heap(,,">"))
-     
+
         header("Heap of reals, minimal are those closest to 1/2.")
         processReals(Heap(, heap_demo2 ))
 

--- a/uni/progs/mapStrings.icn
+++ b/uni/progs/mapStrings.icn
@@ -24,13 +24,13 @@ import util
 #</p>
 procedure main(args)
 
-     if (*args = 0) | ("--help" == !args) then 
+     if (*args = 0) | ("--help" == !args) then
          stop("Usage: mapStrings [oldString=newString]... <infile >outfile")
 
      sr := StringReplacer(buildMap(args))
      bRead := BlockRead(&input,4096)
      while writes(sr.replace(bRead.readBlock()))
-     
+
 end
 
 #<p>

--- a/uni/progs/rankvote.icn
+++ b/uni/progs/rankvote.icn
@@ -102,7 +102,7 @@ end
 #</p>
 procedure removeWorst()
    worst := results[1]
-   worst2 := results[2]  # Needed to check for ties...		
+   worst2 := results[2]  # Needed to check for ties...
    if percentVote(worst) < percentVote(worst2) then removeCandidate(worst)
    else tieBreak(worst1,worst2)
 end
@@ -113,7 +113,7 @@ end
 #</p>
 procedure removeCandidate(worst)
    write("\tRemoving '",worst[1],"' with ",percentVote(worst),"% of votes")
-   every b := !ballots do 
+   every b := !ballots do
       every i := 1 to *b do if worst[1] == b[i] then delete(b,i)
 end
 

--- a/uni/progs/splitmail.icn
+++ b/uni/progs/splitmail.icn
@@ -156,7 +156,7 @@ procedure readMessages(mailFileName)
     mailFile := PushBack(open(mailFileName)) | fail
     while line := mailFile.read() do {
         if match("From ",line) then {
-            suspend getMessage(line, mailFile) 
+            suspend getMessage(line, mailFile)
             }
         }
 end
@@ -203,7 +203,7 @@ procedure routeMessage(message, file1, file2)
         if \verbose then showHeader(&errout, "---",message)
         if /dryrun then every write(file2, !message.text)
         }
-        
+
 end
 
 #<p>

--- a/uni/shell/dist/Stream.icn
+++ b/uni/shell/dist/Stream.icn
@@ -16,7 +16,7 @@
 #   The freedom of its content is protected by the Lesser GNU public
 #     license, version 2.1, February 1999,
 #     http://www.gnu.org/licenses/lgpl.html
-#   which means you are granted permission to use this in any way that 
+#   which means you are granted permission to use this in any way that
 #   does not limit others' freedom to use it.
 #
 ############################################################################
@@ -25,7 +25,7 @@
 #  with lists, files, and coexpressions.
 #   - Stream( L ) produces an instance of StreamL
 #   - Stream( f ) and Stream(args[ ]) produce an instance of Streamf
-#      where args are the arguments to the open( ) function 
+#      where args are the arguments to the open( ) function
 #   - Stream( C, "r" | "w" ) produces an instance of C
 #   - Stream( StreamL ) produces StreamL
 #
@@ -44,8 +44,8 @@
 #   Select  *      *      *      Produces &null if Get will produce a value
 #   Type    *      *      *      Produces "list" | "file" | "co-expression"
 #
-#   When a producer coexpression uses StreamC to transmit values to a 
-#   consumer coexpression that receives them using StreamC, the values 
+#   When a producer coexpression uses StreamC to transmit values to a
+#   consumer coexpression that receives them using StreamC, the values
 #   transmitted will be the same regardless of whether the producer or
 #   the consumer was activated first.
 #
@@ -57,7 +57,7 @@
 
 # set tracking which coexpression-streams' coexpressions have been activated
 # friend: shell.icn - variable is manipulated by shell.icn
-global StreamC_activated 
+global StreamC_activated
 
 # set StreamC_trace to a non-null value to enable tracing of StreamC methods
 global StreamC_trace
@@ -74,7 +74,7 @@ global trace
 #   invokes shell.icn recursively, the child shell's children
 #   are may be "1.1", "1.2", etc.
 # friend: shell.icn - variable is manipulated by shell.icn
-global trace_task_id 
+global trace_task_id
 
 # trace_task_symbol is a table where:
 #   the key is a co-expression
@@ -161,18 +161,18 @@ class Streamf : Stream_Abstract ( file, mode, readfunc )
     local arglist
     readfunc := read
     /ushpath := [""]
-    if 
+    if
       ( /p_argv[2], \p_argv[3] )
     then # args are filename and filemode, only
       file := p_argv[1]
     else {
       # flilemode defaults to "r" to be like open
       mode := \p_argv[2] | "r"
-      if 
+      if
         p_argv[1] == "-"
       then {
         # user requested either stdin or stdout
-        if 
+        if
           find( mode, "r t u " )
         then
           file := &input
@@ -180,9 +180,9 @@ class Streamf : Stream_Abstract ( file, mode, readfunc )
           file := &output
       }
       else {
-        if 
+        if
           mode ? ="n" || ( ="a" | "" ) || ="u"
-        then 
+        then
           readfunc := receive
         # user requested a file by name; search the ushpath
         ( arglist <- [ !ushpath || p_argv[1] ] ||| p_argv[2:0]
@@ -260,7 +260,7 @@ class StreamC : Stream_Abstract( queue, coexp, hasFailed, write_mode, tracing_pr
     # first activation, with optional tracing
     if
       \tracing_prefix
-    then 
+    then
       if   put( queue, coactrace( pop(p_item)\1, coexp, tracing_prefix )\1 )
       then {
              hasFailed := &null
@@ -328,8 +328,8 @@ class StreamC : Stream_Abstract( queue, coexp, hasFailed, write_mode, tracing_pr
            ": _____ StreamC.Close cofailing stream opened for " ||
            ( if \write_mode then "w" else "r")
          )
-    if 
-      \write_mode 
+    if
+      \write_mode
     then {
       write_mode := &null
       return cofail( coexp )\1 | &null
@@ -343,12 +343,12 @@ class StreamC : Stream_Abstract( queue, coexp, hasFailed, write_mode, tracing_pr
   if
     \StreamC_trace
   then
-    ( tracing_prefix := 
+    ( tracing_prefix :=
       ( trace_task_id := ( \trace_task_id | "0" )\1
       , " ______ (" || trace_task_id || ") " || StreamC_trace
-      ) | 
+      ) |
       " ______ " || StreamC_trace
-    , trace := \trace | write 
+    , trace := \trace | write
     )
 
   # default mode is read
@@ -385,13 +385,13 @@ end # class StreamC
 # coactrace acts like "value @ coexpr", but traces info to &output
 procedure coactrace( value, coexpr, label )
   local result, cnt
-  
+
   cnt := 1
 
   (\trace) ( " ... coactrace: " || label || " is transmitting: " ||
          ( image(\value) | "&null" )
        )
-  
+
   every  result := value @ coexpr  do {
     (\trace) ( " ... coactrace: " || label ||
            ( " received result "||cnt||": "||image(\result) |
@@ -417,10 +417,10 @@ procedure cofailtrace( coexpr, label )
     cnt +:= 1
     suspend result
   }
-  (\trace)(" XXX cofailtrace [ " || label || " ]: " || 
-           trace_task_symbol[ &current ] || 
+  (\trace)(" XXX cofailtrace [ " || label || " ]: " ||
+           trace_task_symbol[ &current ] ||
            " received failure from " || trace_task_symbol[&source] )
-  &current ~=== &source  &  fail 
+  &current ~=== &source  &  fail
   stop( "fatal error: infinite failure - task "||label||" failing to self")
 end # procedure cofailtrace
 
@@ -430,12 +430,12 @@ procedure service( callback, moreargs, source )
 
   # sanity check
   \callback | fail
-  
+
   ( # calculate the tracing prefix if applicable
     tracing_prefix := " ______ " || \StreamC_trace
     # and set the tracing procedure identifier
     #   if applicable and not yet set
-  , /trace := write 
+  , /trace := write
   )
 
   # save the &source if it was not supplied as an argument
@@ -443,32 +443,32 @@ procedure service( callback, moreargs, source )
 
   # repeat endlessly
   repeat {
-    
+
     # transmit result to source, and get next operand from source
     #   1. if source transmits failure, abort
-    (\trace)( (\tracing_prefix | \trace_task_id | "unknown") || 
-              ": about to activate or cofail source" ) 
-    if 
-      not ( 
-        result := if   /failed 
-                  then (result @ source)\1 
+    (\trace)( (\tracing_prefix | \trace_task_id | "unknown") ||
+              ": about to activate or cofail source" )
+    if
+      not (
+        result := if   /failed
+                  then (result @ source)\1
                   else cofail( source )\1
       )
-    then 
-      stop( ) # terminate task and yield control of execution 
+    then
+      stop( ) # terminate task and yield control of execution
               #   back to parent (main) task
-    
+
     #  2. save the &source for the current resumption before invoking
-    #     the callback (in case the callback needs to resume other 
+    #     the callback (in case the callback needs to resume other
     #     services or co-expressions before returning)
     source := &source
-    
+
     #  3. invoke callback to produce next result (or failure)
-    ((/failed,\trace))( (\tracing_prefix | \trace_task_id | "unknown") || 
-                        ": about to invoke callback" ) 
-    if 
+    ((/failed,\trace))( (\tracing_prefix | \trace_task_id | "unknown") ||
+                        ": about to invoke callback" )
+    if
       result := callback( result, moreargs )\1
-    then 
+    then
       failed := &null
     else
       failed := 1

--- a/uni/shell/dist/client.icn
+++ b/uni/shell/dist/client.icn
@@ -1,8 +1,8 @@
 # client.icn
 #   Model a client as a producer relative to the service (i.e.,
-#     open the service Stream with a filemode of "w") so that 
-#     the client will not write a value that cannot be read 
-#     by the service and the client will not be attempting 
+#     open the service Stream with a filemode of "w") so that
+#     the client will not write a value that cannot be read
+#     by the service and the client will not be attempting
 #     to read data that the service has not yet written.
 #   Note that either Get or Put can be used with a service
 #     Stream opened with a "w" filemode.  Get is more convenient
@@ -30,8 +30,8 @@ procedure main( argv )
     stop( usage )
   S_out.Put( "I am the client.")
   while ( data_in := &null, data_in :=  S_in.Get( ) ) do {
-    if 
-      data_service := S_service.Get( \data_in ) 
+    if
+      data_service := S_service.Get( \data_in )
     then
       S_out.Put( data_service )
   }

--- a/uni/shell/dist/queue_get.icn
+++ b/uni/shell/dist/queue_get.icn
@@ -10,7 +10,7 @@ procedure main( argv )
     StreamC_trace := "queue_get.icn"
     pop( argv )
   }
-  
+
   ( S_file := Stream( argv[2], "w" )
   , S_file.Type( ) == ("file" | "co-expression")
   ) | stop( usage || "\nfailure opening output Stream" )
@@ -21,9 +21,9 @@ procedure main( argv )
 
   S_file.Put( "I am queue_get.icn" )
 
-  if 
-    not S_list.Select( ) 
-  then 
+  if
+    not S_list.Select( )
+  then
     stop( "queue_get: global list is empty" )
   while ( S_file.Put( S_list.Get( ) ) )
   S_file.Put( "queue_get: S_list.Get has no more input" )

--- a/uni/shell/dist/s_file.icn
+++ b/uni/shell/dist/s_file.icn
@@ -41,7 +41,7 @@ procedure S_in_func( )
 end
 
 procedure S_out_func( value )
-  if 
+  if
     S_f.Put( value )
   then
     return "ready for input"

--- a/uni/shell/dist/service.icn
+++ b/uni/shell/dist/service.icn
@@ -1,10 +1,10 @@
 # service.icn
-#   Model a service as a consumer relative to the client because 
+#   Model a service as a consumer relative to the client because
 #     the service should not be permitted to miss the first value transmitted
 #     by the client, i.e., the client should open a Stream for the service
 #     using the filemode "w".
-#   Note that the first required argument must supply the name of 
-#     one of the provided functions. 
+#   Note that the first required argument must supply the name of
+#     one of the provided functions.
 
 link Stream
 
@@ -18,7 +18,7 @@ procedure main( argv )
   local routine, source
 
   source := &source # save the first source
-  
+
   # enable tracing if applicable (if so, must be argv[1])
   if
     ( type(argv[1]) == "string", argv[1] == "-t" )
@@ -26,18 +26,18 @@ procedure main( argv )
     StreamC_trace := "service.icn"
     pop( argv )
   }
-  
-  # enable logging if applicable (if so, the -o logstream 
-  #   argument must appear after tracing and 
+
+  # enable logging if applicable (if so, the -o logstream
+  #   argument must appear after tracing and
   #   before the string naming function to be executed)
   if
     ( type(argv[1]) == "string", argv[1] == "-o" )
   then {
     pop( argv )
-    logstream := Stream( pop( argv ), "w" ) | 
+    logstream := Stream( pop( argv ), "w" ) |
       stop( "service.icn: could not open log Stream" )
   }
-  
+
   # get the callback routine
   if
     type( argv[1] ) == "string"
@@ -45,10 +45,10 @@ procedure main( argv )
     routine := argv[1]
   else
     stop( "service.icn: fatal error - argv[1] is " || image(argv[1]) )
-  
+
   # start the service (never returns)
   service( routine, argv[2:0] | &null, source )
-  
+
   # next line never is reached
   stop( "FATAL ERROR: ... service stops" )
 end

--- a/uni/shell/dist/shell.icn
+++ b/uni/shell/dist/shell.icn
@@ -16,7 +16,7 @@
 #   The freedom of its content is protected by the Lesser GNU public
 #     license, version 2.1, February 1999,
 #     http://www.gnu.org/licenses/lgpl.html
-#   which means you are granted permission to use this in any way that 
+#   which means you are granted permission to use this in any way that
 #   does not limit others' freedom to use it.
 #
 ##########################################################################
@@ -26,7 +26,7 @@
 #   option -s path: search path for icode and shell files
 #   option -i file: take input from file instead of standard input
 #   option -p prog: invoke prog as preprocessor, passing arguments to it
-#                   prog will be invoked with a task that is a recursive 
+#                   prog will be invoked with a task that is a recursive
 #                   instance of shell.icn as the first argument and a list
 #                   for enqueueing results as the second argument; any
 #                   arguments appearing afterward will be passed through
@@ -43,10 +43,10 @@
 #   monitor the execution of the tasks' co-expressions and intervene to
 #   prevent "infinite loops of failure".  Tasks co-operatively yield control
 #   by activating co-expressions and gain control, receiving results of the
-#   activation.  
+#   activation.
 #
-# Although tasks may directly exchange results with other tasks, the 
-#   StreamC.Get and StreamC.Put methods defined in Stream.icn provide a 
+# Although tasks may directly exchange results with other tasks, the
+#   StreamC.Get and StreamC.Put methods defined in Stream.icn provide a
 #   convenient interface that ensures that producers will transmit the same
 #   result sequences to the consumers regardless of whether the producer or
 #   the consumer is activated first.
@@ -72,11 +72,11 @@
 #
 # Grammar for input file lines:
 #
-#   input_file_line         ::= task_declaration | 
-#                               list_symbol_declaration | 
+#   input_file_line         ::= task_declaration |
+#                               list_symbol_declaration |
 #                               task_activation |
 #                               comment
-# 
+#
 #   task_declaration        ::= lvalue ":=" <program_name> arguments
 #
 #   list_symbol_declaration ::= "list" lvalues
@@ -86,22 +86,22 @@
 #   comment                 ::= "#" many(<&cset>)
 #
 #   arguments               ::= arguments argument | argument | <nothing>
-# 
+#
 #   argument                ::= lvalue | "$" many(<&digits>) | alphanum
 #
 #   lvalues                 ::= lvalues lvalue | lvalue
 #
 #   lvalue                  ::= alphanum
-#   
+#
 #   alphanum                ::= many(<&letters> ++ <&digits>)
 #
 #   many(c)                 ::= c many(c) | c
 #
 # The following further rules apply to scripts:
-# 
-#   Names of programs that are not in the current working directory must 
-#     include relative or absolute path information suitable for the 
-#     platform; the program name supplied is passed directly to the 
+#
+#   Names of programs that are not in the current working directory must
+#     include relative or absolute path information suitable for the
+#     platform; the program name supplied is passed directly to the
 #     load( ) function.
 #
 #   List symbols must be declared before they are used.
@@ -109,13 +109,13 @@
 #   Task declarations may include forward references to other tasks.
 #
 #   Task activations must be deferred until all referenced tasks
-#     have been declared. The convert_tasks( ) procedure loads the tasks, 
+#     have been declared. The convert_tasks( ) procedure loads the tasks,
 #     wraps them with a monitoring co-expression (which is created by via
 #     the monitor_task( ) procedure), and activates them.
 #
-#   Once a task has terminated, it must be redeclared before it can be 
-#     reactivated.  Once one task has been redeclared, all must be 
-#     redeclared before they are activated.  List symbols need not be 
+#   Once a task has terminated, it must be redeclared before it can be
+#     reactivated.  Once one task has been redeclared, all must be
+#     redeclared before they are activated.  List symbols need not be
 #     redeclared, however, but the lists that they represent
 #     are replaced with empty lists when convert_tasks( ) is executed.
 #
@@ -123,7 +123,7 @@
 #     way permitted by the balq(s) procedure (from the scan.icn file in
 #     the Icon Program Library), where balq(s) is invoked with a single
 #     argument.
-# 
+#
 ############################################################################
 #
 #  Links:  Stream, scan
@@ -170,7 +170,7 @@ global task_table        # key: task-symbols
 global invalid_task      # a co-expression representing an invalid task
 global t_task_symbol     # table mapping tasks to task symbols
 global task_counter      # increment by one for each task created; start at 1
-global ushpath           # [ "", "./" ] ||| parsed -s option ||| 
+global ushpath           # [ "", "./" ] ||| parsed -s option |||
                          #    parsed USHPATH envar (shared with Stream)
 
 # main program - parser that consumes tokens and dispatches the tasks
@@ -240,13 +240,13 @@ procedure main( argv )
 
   # fetch each token generated by token( ) and feed it to parsing logic
   input_files := [ ]
-  if type(\opt_tab["i"]) == "string" 
+  if type(\opt_tab["i"]) == "string"
     then every put( input_files, !path_list( opt_tab["i"] ) )
     else put( input_files, \opt_tab["i"] | "-" )
 
   every
     file := !input_files
-  do every 
+  do every
     tok := token( Stream( file, "r" ) )
   do {
     # (\trace)("token = "||tok) # uncomment to observe tokens in trace
@@ -426,8 +426,8 @@ procedure main( argv )
                  ( integer(tok) |
                      stop(" argument index " || tok || " is not an integer")
                  )\1
-               ] | 
-               stop(" arglist[ " || tok || " ] '" || 
+               ] |
+               stop(" arglist[ " || tok || " ] '" ||
                  arglist[integer(tok)] || "'does not exist")
              )
 
@@ -459,7 +459,7 @@ procedure put_ushpath( s )
     then put( ushpath, s )
 end
 
-# options extracter - different from options( ) routine 
+# options extracter - different from options( ) routine
 #   in the Icon Program Library
 procedure shell_options( argv )
   local topt, argc, i, arg, result_list
@@ -498,14 +498,14 @@ procedure shell_options( argv )
                                         , &null
                                         , invalid_task
                                         , &progname
-                                        , [ "-i", "_SCRIPT_", "_LIST_" ] 
+                                        , [ "-i", "_SCRIPT_", "_LIST_" ]
                                         )
           task_table["_SCRIPT_"] := task( "_SCRIPT_"
                                         , &null
                                         , invalid_task
                                         , arglist[1]
                                         , [ "_SHELL_", "_LIST_" ] |||
-                                          arglist[2:0] 
+                                          arglist[2:0]
                                         )
           arglist := argv := [ ]
           topt["i"] := [ "@ _SHELL_" ]
@@ -529,7 +529,7 @@ procedure shell_options( argv )
           every trace("argv["||(i := 1 to argc) ||"] = "||image(argv[i]))
           pop( argv )
         }
-      default : 
+      default :
         break # once options end, the arguments follow
     }
   every put_ushpath( !path_list( getenv( USHPATH ) ) || "/" )
@@ -547,7 +547,7 @@ procedure token( S_in )
 
   lineno := 0
   # get a line
-  # prepend a space so the "while tab( many( ws ) )" 
+  # prepend a space so the "while tab( many( ws ) )"
   #   will always succeed at the beginning of a line
   # append " EOL" to line because "s ? balq( ws )" fails if s has no spaces
   while
@@ -631,20 +631,20 @@ procedure convert_tasks( )
   t_task_symbol := table("TASK_SYMBOL_UNDIFINED")
   t_task_symbol[ &main ] := "SHELL_MAIN"
   every task_key := key( task_table ) do {
-    task_record := task_table[task_key] 
+    task_record := task_table[task_key]
     \task_record | stop("no task record exists for key: " || task_key)
     if task_record.monitor ~=== invalid_task then {
       (\trace)("task "||task_key||" may still be active")
       next
     }
     \task_record.argv    | stop("task_table[ " || task_key || " ].argv IS NULL")
-    if /task_record.program 
+    if /task_record.program
       then write(&errout, "warning - task_table[ " || task_key || " ].program IS NULL")
       else {
-        task_record.coexp := 
-          load( !ushpath || task_record.program, task_record.argv ) | 
+        task_record.coexp :=
+          load( !ushpath || task_record.program, task_record.argv ) |
             {
-              write( &progname || ": Could not find task " || 
+              write( &progname || ": Could not find task " ||
                      task_record.program || " on path" )
               every write( "  " || !ushpath )
               stop( )
@@ -682,12 +682,12 @@ procedure path_list( s )
         tab(many(' '))
         if pos(0) then
            break
-        put(pathList, 
+        put(pathList,
           {
             dir := &null
-            ="'" || (dir := tab( upto('\'') | break ) ) || move(1) | 
-              (dir := tab(upto(' '))) ||move(1) | 
-              (dir := tab(0)) | 
+            ="'" || (dir := tab( upto('\'') | break ) ) || move(1) |
+              (dir := tab(upto(' '))) ||move(1) |
+              (dir := tab(0)) |
               break
             \dir
           }
@@ -701,27 +701,27 @@ end
 #
 # To avoid "infinite failure" scenarios, shell.icn invokes each
 #   task via a separate co-expression that the monitor_task procedure
-#   creates.  This co-expression refuses to resume a task that has 
-#   "cofailed to it" (i.e., the task either (1) explicitly transmitted 
+#   creates.  This co-expression refuses to resume a task that has
+#   "cofailed to it" (i.e., the task either (1) explicitly transmitted
 #   failure to the monitoring co-expression using the cofail( ) function
-#   or (2) implicitly failed by either (a) by falling off the end of the 
+#   or (2) implicitly failed by either (a) by falling off the end of the
 #   main( ) procedure, or (b) by executing fail in the main( ) procedure,
-#   or (c) by invoking the stop( ) function in any procedure 
+#   or (c) by invoking the stop( ) function in any procedure
 #   or co-expression).
-# 
-# The specific logic implemented by the co-expression that the 
-# monitor_task procedure creates is as follows:
-# 
-# (1) The monitoring co-expression repeatedly transmits values to
-# other tasks the values that were transmitted to it.  
 #
-# (2) (a) USUALLY the task to which the monitoring co-expression transmits 
+# The specific logic implemented by the co-expression that the
+# monitor_task procedure creates is as follows:
+#
+# (1) The monitoring co-expression repeatedly transmits values to
+# other tasks the values that were transmitted to it.
+#
+# (2) (a) USUALLY the task to which the monitoring co-expression transmits
 #         a value is the monitored task.
 #     (b) However, if the monitoring co-expression transmits a value
 #         to the monitored task and the monitored task either transmits a
 #         value back to (or cofails back to) &current (the task's &source),
-#         then the monitoring co-expression should transmit the value  
-#         received back to (or cofail back to) the task that formerly 
+#         then the monitoring co-expression should transmit the value
+#         received back to (or cofail back to) the task that formerly
 #         activated it before it transmitted a value to the monitored task.
 #         If there are no such previous activations, or if the monitoring
 #         co-expression was activated by &main, then iteration should stop.
@@ -729,10 +729,10 @@ end
 # Thus:
 #
 # If the monitoring co-expression receives a value (or failure) from a task
-#   other than the monitored task, it pushes a reference to the transmitting 
+#   other than the monitored task, it pushes a reference to the transmitting
 #   task to a stack and transmits the value (or failure) to the monitored task.
 #
-# If the monitoring co-expression receives a value (or failure) from the 
+# If the monitoring co-expression receives a value (or failure) from the
 #   monitored task, and if it cannot pop a reference to a task from the stack,
 #   it ceases cofails to &main; otherwise it transmits the value (or failure)
 #   to the task referenced by the value popped from the stack.
@@ -755,7 +755,7 @@ procedure monitor_task( task, task_key )
   /task     & write("monitor_task: null task argument") & fail
   /task_key & stop("monitor_task: null task_key argument")
 
-  # friends share the activation table 
+  # friends share the activation table
   variable( "StreamC_activated", task ) := StreamC_act_shell
   # friends share the task/script/file search path
   variable( "ushpath", task ) := ushpath
@@ -822,14 +822,14 @@ procedure monitor_task( task, task_key )
 
     repeat {
       # The monitoring co-expression transmits to other tasks
-      #    those values that were transmitted to it.  
+      #    those values that were transmitted to it.
 
       # 1. Trace results if applicable.
       if
         \trace
       then {
         next_rslt :=
-          
+
           if
             /failed # failed is not null when activation failed
           then { # did not fail
@@ -841,11 +841,11 @@ procedure monitor_task( task, task_key )
             # reset failed flag
             failed := &null
             # preceding activation/resumption failed
-            cofailtrace( next_task, task_symbol || " (to next_task)" )\1 | 
+            cofailtrace( next_task, task_symbol || " (to next_task)" )\1 |
               break
           }
         if
-          \failed 
+          \failed
         then { # did fail
           ( &source === task , \trace )
             ( " ... monitor_task: " || trace_task_symbol[task] ||
@@ -879,8 +879,8 @@ procedure monitor_task( task, task_key )
             # reset failed flag
             failed := &null
             # preceding activation/resumption failed
-            cofail( next_task )\1 | 
-            break 
+            cofail( next_task )\1 |
+            break
           }
       }
 
@@ -891,7 +891,7 @@ procedure monitor_task( task, task_key )
       then
         break
 
-      # 3. Test for each of the following cases in the following order: 
+      # 3. Test for each of the following cases in the following order:
       #   * another task succeeded and produced a value
       #   * own task succeeded and produced a value
       #   * another task cofailed
@@ -904,7 +904,7 @@ procedure monitor_task( task, task_key )
           ( &source ~=== task )
         then {
           # If the monitoring co-expression receives a value from a task
-          # other than the monitored task, it continues iterating, transmiting 
+          # other than the monitored task, it continues iterating, transmiting
           # that value to the monitored task.
           last_rslt := next_rslt
           next_task := task
@@ -912,9 +912,9 @@ procedure monitor_task( task, task_key )
           next
         }
         else { # therefore &source === task
-          # If the monitoring co-expression receives a value from the 
+          # If the monitoring co-expression receives a value from the
           # monitored task, it transmits that value
-          # to the last task that activated it before it activated 
+          # to the last task that activated it before it activated
           # the monitored task and received a value from that task.
           last_rslt := next_rslt
           next_task := last_task
@@ -927,7 +927,7 @@ procedure monitor_task( task, task_key )
           ( &source ~=== task )
         then {
           # If the monitoring co-expression receives failure from a task
-          # other than the monitored task, it continues iterating, transmiting 
+          # other than the monitored task, it continues iterating, transmiting
           # failure to the monitored task.
           last_rslt := &null
           next_task := task
@@ -935,8 +935,8 @@ procedure monitor_task( task, task_key )
           next
         }
         else { # therefore &source === task
-          # If the monitoring co-expression receives failure from the 
-          # monitored task, and if it cannot transmit failure to 
+          # If the monitoring co-expression receives failure from the
+          # monitored task, and if it cannot transmit failure to
           # the last task that activated it before it activated the monitored
           # task and received failure from that task, it ceases iterating.
           last_rslt := &null
@@ -969,7 +969,7 @@ procedure monitor_task( task, task_key )
       \trace
     then {
       cofailtrace( \last_task, task_symbol || " (to last_task)" )\1 |
-        cofailtrace( monitor, task_symbol || " (to monitor)" )\1 
+        cofailtrace( monitor, task_symbol || " (to monitor)" )\1
     }
     else  {
       cofail( \last_task )\1 |

--- a/uni/shell/dist/t_cat.icn
+++ b/uni/shell/dist/t_cat.icn
@@ -10,16 +10,16 @@ procedure main( argv )
   # handle tracing option
   if ( type(argv[1]) == "string", argv[1] == "-t" )
   then { StreamC_trace := "t_cat.icn" ; pop( argv ) }
-  
+
   # pull the output task or file off the end of the arg list
   outp := pull( argv )
   0 == *argv & stop( usage )
-  S_out := Stream( outp, "w" ) | 
+  S_out := Stream( outp, "w" ) |
     stop( "could not open output " || image(outp) || "\n" || usage )
-    
+
   # send each input task or file (left to right) to output
   while inp := pop( argv ) do {
-    S_in  := Stream(inp,"r") | 
+    S_in  := Stream(inp,"r") |
       stop( "could not open input " || image(inp) || "\n" || usage )
     while S_out.Put( S_in.Get( ) )
   }

--- a/uni/shell/dist/test.shell
+++ b/uni/shell/dist/test.shell
@@ -3,4 +3,4 @@
 # declare tasks
 CONS   := consumer PROD -
 PROD   := producer CONS
-@ PROD 
+@ PROD

--- a/uni/shell/dist/test_queue.shell
+++ b/uni/shell/dist/test_queue.shell
@@ -1,6 +1,6 @@
 # test_queue.shell
-list LIST 
-PUT  := queue_put LIST 
+list LIST
+PUT  := queue_put LIST
 GET  := queue_get LIST -
 @ PUT
 @ GET

--- a/uni/shell/dist/ush.icn
+++ b/uni/shell/dist/ush.icn
@@ -16,15 +16,15 @@
 #   The freedom of its content is protected by the Lesser GNU public
 #     license, version 2.1, February 1999,
 #     http://www.gnu.org/licenses/lgpl.html
-#   which means you are granted permission to use this in any way that 
+#   which means you are granted permission to use this in any way that
 #   does not limit others' freedom to use it.
 #
 ##########################################################################
 # links: Stream, scan
 ##########################################################################
 # This file is a very rudimentary command line interpreter interface
-# for the Unicon shell, shell.icn.  
-# It demonstrates a "preprocessor" program that can be invoked with the -p 
+# for the Unicon shell, shell.icn.
+# It demonstrates a "preprocessor" program that can be invoked with the -p
 # option of shell.icn.
 # Note that the first argument for a preprocessor must be -o and that
 # the second must be a consumer task.
@@ -46,7 +46,7 @@ procedure main( argv )
   then
     argv[3] | put( argv, "-" )
   else {
-    while 
+    while
       "string" == type(argv[1]) & "-s" == argv[1]
     do {
       # write( &errout, "argv[2]: ", image(argv[2]) )
@@ -63,16 +63,16 @@ procedure main( argv )
     # if arg_ushpath is not null, put "-s" and then put arg_ushpath
     put( shell_arglist, "-s", \arg_ushpath )
     # every write( &errout, "shell_arg: ", image(!shell_arglist) )
-    push( argv, load( "shell", shell_arglist ) ) | 
+    push( argv, load( "shell", shell_arglist ) ) |
       stop( "ush: load shell failed" )
     argv[3] | put( argv, "-" )
   }
 
   # open the consumer of input-script strings
   outp := pop( argv )
-  type( outp ) == "co-expression" | 
+  type( outp ) == "co-expression" |
     stop( "ush: error - type of outp is " || type( outp ) )
-  S_out := Stream( outp, "w" ) | 
+  S_out := Stream( outp, "w" ) |
     stop( usage || "\nush: error opening S_out" )
 
   ushpath := variable( "ushpath", outp )
@@ -80,29 +80,29 @@ procedure main( argv )
   # Note that ush.icn does not (yet) do anything else
   #   with the next argument once the Stream has been opened.
   result_list := pop( argv ) | stop( "failed to get result list" )
-  S_result := Stream( result_list, "r" ) | 
+  S_result := Stream( result_list, "r" ) |
     stop( usage || "\nush: error opening S_result; image of arg is " || image( result_list ) )
-  
+
   while inp := pop( argv ) do {
     S_in  := Stream(inp,"r") | stop( usage || "\nush: error opening S_in" )
     S_in.Data( ) === &input & writes( "ush: ")
-    # prepend a space so the "tab(many(ws))" 
+    # prepend a space so the "tab(many(ws))"
     #   will always succeed at the beginning of a line
     # append " EOL" to line because "s ? balq( ws )" fails if s has no spaces
     while line := S_in.Get( ) do {
       \ushpath | stop( "ush: fatal error - ushpath is not set" )
       # every write( &errout, "ushpath: ", !ushpath )
-      " " || line || " EOL" ? 
+      " " || line || " EOL" ?
         if
           (
-            ( tab(many(ws)) 
+            ( tab(many(ws))
             , ="."
             , tab(many(ws))
             , quoted := tab( balq( ws ) )
-            , quoted := ( quoted[1:2] == quoted[-1:0] == "\"", quoted[2:0] ) | 
+            , quoted := ( quoted[1:2] == quoted[-1:0] == "\"", quoted[2:0] ) |
                         quoted
             )\1
-          , S_src := Stream( !ushpath || quoted, "r" )\1 | 
+          , S_src := Stream( !ushpath || quoted, "r" )\1 |
               stop( "ush: could not load task '" || quoted || "'" )
           )
         then

--- a/uni/udb/adapter.icn
+++ b/uni/udb/adapter.icn
@@ -754,9 +754,9 @@ $endif
             writes(sock, response)
             return
          }
-         
+
          ref := addStructuredVar(res["result"])
-         
+
          body := [
             "value": replace(image(res["result"]), "\"", "\\\"")
             "type": type(res["result"])
@@ -764,8 +764,8 @@ $endif
          ]
          response := build_response(currentRequestBody["seq"], "__true__", currentRequestBody["command"], body)
          writes(sock, response)
-      }  
-      
+      }
+
    end
 
    method processEvaluateResult(res, noBody)

--- a/uni/udb/agent.icn
+++ b/uni/udb/agent.icn
@@ -74,7 +74,7 @@ end
 #
 method cmdInfo(name)
    local i:=0, msg:="", obj
-    
+
    ## what if there is more than one monitor loaded with the same name??
    if \name then {
       if \Clients[name] then {
@@ -118,7 +118,7 @@ method cmdInfo(name)
 end
 
 #
-# it constructs/re-constucts the eventMask from all active monitors  
+# it constructs/re-constucts the eventMask from all active monitors
 #
 method build_Mask()
    local obj
@@ -128,11 +128,11 @@ method build_Mask()
 
    DState.eventMask ++:= eventMask
    if mtype == "internal" then {
-      DState.internalMask := eventMask 
+      DState.internalMask := eventMask
       #DState.Update()
       }
    else if mtype == ("external"|"semi-internal") then {
-      DState.externalMask := eventMask 
+      DState.externalMask := eventMask
       #DState.Update()
       }
 end

--- a/uni/udb/auto.y
+++ b/uni/udb/auto.y
@@ -14,7 +14,7 @@ $include "evdefs.icn"
 $define UNINIT 0
 $define INIT 1
 
-global convCount 
+global convCount
 global gcStart
 global gcEnd
 global programStart
@@ -56,7 +56,7 @@ events : event {
 event : conv_attempt |
         garbage_start |
         garbage_end |
-        initialize_var { 
+        initialize_var {
    $$ := node( "event", "", $1 )
    };
 
@@ -70,7 +70,7 @@ event : var_read {
 
    if uninitState == ON & varState[ $1.varName ] == UNINIT then {
       write( "Target program reads from uninitialized variable: " ||
-             $1.varName[1: upto('-', $1.varName )] || " at " || 
+             $1.varName[1: upto('-', $1.varName )] || " at " ||
              keyword( "line", Monitored ) || ":" ||
              keyword( "file", Monitored ) )
       }

--- a/uni/udb/coexp.icn
+++ b/uni/udb/coexp.icn
@@ -1,6 +1,6 @@
 #
-# Author: Gigi Young 
-# Date:   5-31-2018 
+# Author: Gigi Young
+# Date:   5-31-2018
 # e-mail: kzyoung93@gmail.com
 #
 
@@ -8,8 +8,8 @@
 # class for an individual co-expression
 #
 class Coexp(
-   id,         # string with the number N in "co-expression_N()" 
-   tag,        # a string used "pretty printing" 
+   id,         # string with the number N in "co-expression_N()"
+   tag,        # a string used "pretty printing"
    val,        # the value of the co-expression
    src_val,    # the value of the calling co-expression (optional?)
    file,       # optional?
@@ -17,10 +17,10 @@ class Coexp(
    stk_info,   # string containing file:line info for current execution
    curr_frame  # int containing current frame within stack for frame cmd
    )
- 
-   # 
+
+   #
    # updates the stack frame status
-   # 
+   #
    method update_stk_info()
       local pname, levels_up := 0 , s := "", paren := "(", temp
 
@@ -29,7 +29,7 @@ class Coexp(
       if \pname then {
          pname := pname[find(" ",pname)+1:0]
 #         write("currently in procedure ",pname)
-         s ||:= pname  
+         s ||:= pname
 
          # get proc parameter info
          every x := paramnames(val,levels_up) do {
@@ -42,7 +42,7 @@ class Coexp(
             s ||:= paren || " at "
             }
          else if *paren = 1 then {
-            s ||:= "() at " 
+            s ||:= "() at "
             }
          }
 
@@ -105,14 +105,14 @@ class CoexpState(
    #
    # Returns a coexp id (integer string representation of coexp number)
    # given a coexp value
-   # 
+   #
    method get_id(C)
       local s
       image(C) ? { tab(upto(&digits)\1) & s := tab(find("(")\1) }
       return s
       #return image(C) ? tab(find("(")\1)
    end
-   
+
    #
    # Returns a "pretty printing" tag given a coexp value
    #
@@ -122,25 +122,25 @@ class CoexpState(
       #return "Co-expression " || s
       return "Coexp #" || s
    end
- 
+
    #
    # Returns an instance of class Coexp given that it is an active coexp,
    # otherwise returns null
    #
    method get_coexp(x)
-      local i, c_id 
-      
+      local i, c_id
+
       #write("get_coexp() - type of C is: ",type(x))
-      case type(x) of {  
+      case type(x) of {
          "co-expression": { c_id := get_id(x) }
          #"integer": { c_id := "co-expression_" || image(x) }
          "integer": { c_id := image(x) }
-         #"string": { c_id := "co-expression_" || x } 
-         "string": { c_id := x } 
+         #"string": { c_id := "co-expression_" || x }
+         "string": { c_id := x }
          default: {  return &null }
          }
 
-      every i := 1 to *active_list do 
+      every i := 1 to *active_list do
          if c_id == active_list[i].id then {
             #write("found coexp ",c_id)
             return active_list[i]
@@ -155,7 +155,7 @@ class CoexpState(
       if \C then {
          # go to next state
          prev := curr
-         if /(curr := get_coexp(C)) then 
+         if /(curr := get_coexp(C)) then
             curr := Coexp(get_id(C),get_tag(C),C,keyword("source",C))
          target := curr
 
@@ -173,22 +173,22 @@ class CoexpState(
 #      else write("failed to change coexp target")
    end
 
-   # 
+   #
    # Adds a coexp to the list of active coexps
-   # 
+   #
    method add_coexp(val,src_val)
       local coexp
       if \val then {
          coexp := Coexp(get_id(val),get_tag(val),val,src_val)
-         put(active_list,coexp) 
+         put(active_list,coexp)
          write("[New co-expression ",coexp.id,"]")
          #return put(active_list,Coexp(get_id(val),val,keyword("source",val)))
          }
    end
 
-   # 
+   #
    # Removes a coexp from the list of active coexps
-   # 
+   #
    method remove_coexp(C)
       local i, c_id := get_id(C)
 
@@ -196,7 +196,7 @@ class CoexpState(
          if c_id == active_list[i].id then {
             # found, move to end of list and pull off
             active_list[i] :=: active_list[-1]
-            return pull(active_list) 
+            return pull(active_list)
             }
          }
    end
@@ -211,7 +211,7 @@ class CoexpState(
          if c_id == active_list[i].id then {
             # found, move to end of list and pull off
             active_list[i] :=: active_list[-1]
-            return pull(active_list) 
+            return pull(active_list)
             }
          }
    end
@@ -227,7 +227,7 @@ class CoexpState(
                "\n   in order to view activated co-expressions.")
          return
          }
-      
+
       every coexp := !active_list do {
          if \target & target.id == coexp.id then writes(" *  ")
          else writes("    ")

--- a/uni/udb/console.icn
+++ b/uni/udb/console.icn
@@ -2,7 +2,7 @@
 # console.icn
 # Handles the main console based command interpreter
 # Author : Ziad Al-Sharif
-# Date   : Feb 24, 2008 
+# Date   : Feb 24, 2008
 # e-mail : zsharif@gmail.com
 #
 
@@ -120,7 +120,7 @@ method get_Line()
       case ch of{
          DOWN:{
             left := &null
-            if i > 1 then  
+            if i > 1 then
                i-:=1
             else if i = (1|0) then
                i := *DState.cmdHistory
@@ -142,14 +142,14 @@ method get_Line()
             if /left then
                line := line[1:-1]
             else{
-               if left > 1 then left-:=1  
+               if left > 1 then left-:=1
                line := line[1:left]||line[left+1:0]
-               }   
+               }
             }
          LEFT:{
             if /left then
                left := *line
-            else if left > 1 then left-:=1  
+            else if left > 1 then left-:=1
             }
          RIGHT:{
             if \left & left <= *line then left+:=1
@@ -177,15 +177,15 @@ method get_Line()
 $ifndef _UNIX
             write()
 $endif
-            if *line = 0 then{ 
+            if *line = 0 then{
                line := DState.cmdHistory[1]
                writes(line)
                }
-            break 
+            break
             }
          default:{
             if not member(badKeys, ch) then{
-               if /left then  
+               if /left then
                   line ||:=ch
                else{
                   line := line[1:left]||ch||line[left:0]
@@ -203,7 +203,7 @@ $endif
       if \left then {
          writes("\r")
          writes(PROMPT || line[1:left])
-         } 
+         }
       }#end of while
    write() # new line after the prompt
    return line
@@ -256,7 +256,7 @@ method get_CommandLine()
    local tok, op, cmd, line := get_Line()
 
    # analyze that cmd line
-   if *line > 0 then{  
+   if *line > 0 then{
       DState.update_cmdHistory(line)
       return argparse(line)
       }
@@ -277,10 +277,10 @@ method startConsole(argv)
       close(funame)
       }
    if argv[1] == "--line" then { mode := pop(argv); udb_no_more_flag := 1 }
-   else if argv[1] == "--adapter" then { 
-      mode := pop(argv) 
+   else if argv[1] == "--adapter" then {
+      mode := pop(argv)
       DState.udap := Adapter(pop(argv))
-      udb_no_more_flag := 1 
+      udb_no_more_flag := 1
    }
    else if argv[1] == "--noline" then { mode := &null; pop(argv) }
 
@@ -329,53 +329,53 @@ $endif
                if \DState.mode == "--adapter" then {
                   if \&errornumber then {
                      errorTable := table("type", "crash", "errornumber", &errornumber)
-                     errorTable["errortext"] := \&errortext 
+                     errorTable["errortext"] := \&errortext
                      errorTable["errorvalue"] := \&errorvalue
                      DState.Write(errorTable)
                   }
                }
                case DState.State of {
                  RELOAD |
-                 END | 
-                 QUIT:    { 
+                 END |
+                 QUIT:    {
                             # refresh coexp at debug session end
-                            DState.coState.reinit() 
+                            DState.coState.reinit()
 $ifndef TEST
                             break break next
-$else 
+$else
                             #-- Automated TEST: to get the Time right
-                            break break break 
+                            break break break
 $endif
                           }
-                 CONTINUE:{ 
+                 CONTINUE:{
                             if DState.RunCode == ERROR then {
-                               DState.runtimeErrorMsg() 
+                               DState.runtimeErrorMsg()
                                next
-                               } 
+                               }
                             DState.State   := RUN
-                            DState.RunCode := CONTINUE    
+                            DState.RunCode := CONTINUE
                             next                       }
-                 STEP:    { 
+                 STEP:    {
                             if DState.RunCode == ERROR then {
-                               DState.runtimeErrorMsg() 
+                               DState.runtimeErrorMsg()
                                next
-                               } 
+                               }
                             DState.State   := RUN
                             DState.RunCode := STEP
                             next                       }
-                 PSTEP:   { 
+                 PSTEP:   {
                             if DState.RunCode == ERROR then {
-                               DState.runtimeErrorMsg() 
+                               DState.runtimeErrorMsg()
                                next
-                               } 
+                               }
                             DState.State   := RUN
-                            DState.RunCode := PSTEP    
+                            DState.RunCode := PSTEP
                             next                       }
-                 NEXT:    { 
+                 NEXT:    {
                             if DState.RunCode == ERROR then {
-                               DState.runtimeErrorMsg() 
+                               DState.runtimeErrorMsg()
                                next
-                               } 
+                               }
                             DState.State   := RUN
                             DState.RunCode := NEXT
                             next                       }
@@ -387,7 +387,7 @@ $endif
                             Write(Message)             }
                }# end of case
 
-               # update current symbol table before user input       
+               # update current symbol table before user input
                DState.srcFile.updateCurrSymtab(DState.coState)
 
                if cmd := get_CommandLine() then {
@@ -406,9 +406,9 @@ $endif
           DState.State := LOAD #important for re-run
           }
        ERROR:{
-          # if there is a Console Error, handle it, 
+          # if there is a Console Error, handle it,
           # and go back to the old state
-          DState.State := old_State 
+          DState.State := old_State
           }
        SKIP:{
           DState.State := old_State
@@ -434,7 +434,7 @@ method otherControls()
    local F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12
    local PgUp, PgDn, Ins, Del, End, Home
 
-$ifdef _UNIX 
+$ifdef _UNIX
    F1 := "\eOP";  F2 := "\eOQ";  F3 := "\eOR";  F4 := "\eOS"
    F5 := "\e[1";  F6 := "\e[1";  F7 := "\e[1";  F8 := "\e[1"
    F9 := "\e[20"; F10:= "\e[21"; F11:= "\e[23"; F12:= "??"
@@ -454,14 +454,14 @@ end
 #  Initialization
 #
 initially()
-   
+
    self.Session.initially()
 
    #cmdHistory := [""]
    #wchar := CHARACTER ++ cset('\'\\/-+.*:=,\_n&?[]\"!<>~')
 
    # Constant Keys used with the command history
-$ifdef _UNIX 
+$ifdef _UNIX
    UP    := "\e[A"
    DOWN  := "\e[B"
    RIGHT := "\e[C"
@@ -473,7 +473,7 @@ $ifdef _UNIX
 $else
    UP    := "\xe0H"
    DOWN  := "\xe0P"
-   RIGHT := "\xe0M" 
+   RIGHT := "\xe0M"
    LEFT  := "\xe0K"
    ENTER := "\r"
    TAB   := "\t"

--- a/uni/udb/data.icn
+++ b/uni/udb/data.icn
@@ -614,7 +614,7 @@ method cmdEval(cmd)
          outputTable["consoleMsg"] := "\n   Invalid expression (probably)"
          outputTable["result"] := "Invalid expression"
       }
-         
+
       DState.Write(outputTable)
       fail
    }
@@ -741,7 +741,7 @@ method cmdPrint(cmd)
          if *(cmd[1]) = 1 then action := pop(cmd[1])
          else {
             action := cmd[1][1]
-            cmd[1] := cmd[1][2:0] 
+            cmd[1] := cmd[1][2:0]
          }
       }
       every j := 1 to *cmd do {

--- a/uni/udb/defaults.icn
+++ b/uni/udb/defaults.icn
@@ -37,7 +37,7 @@ $define DELETED         18 # to indicate that feature (breakpoint) is deleted
 $define WASSIGN         19 # Watch a variable every time gets assigned
 $define WVALUE          20 # Watch a variable every time it changes its value
 $define WTYPE           21 # Watch a variable every time it changes its type
-$define WREAD           22 # Watch a variable every time is read 
+$define WREAD           22 # Watch a variable every time is read
 $define WSCAN           23 # Watch both of &subject and &pos
 $define WANY            24 # all of the above type of watches
 
@@ -107,12 +107,12 @@ $define WhiteSpace  cset(' \t\n\^m')
 #
 $define OPERATOR    set("=",":=","<","<=",">",">=","*","!","?","~=","!=","~==","!==", "||","&&", "==>", "=>", "-->", "->")
 $define SEPARATOR   set(",",":","::")
-$define OPCHAR      cset('*!?:=<>~|&^,') 
+$define OPCHAR      cset('*!?:=<>~|&^,')
 $define TOKEN       &letters ++ &digits ++ cset('\'\\/.\_n+-\"')
 $define BRACKETS    cset('[]')
 $define PARENTHESES cset('()')
 $define BRACES      cset('{}')
-        
+
 $ifdef _UNIX
    $define PS  "/"
 $else

--- a/uni/udb/dta/atomic_agent.icn
+++ b/uni/udb/dta/atomic_agent.icn
@@ -10,7 +10,7 @@ $include "evdefs.icn"
 $include "../defaults.icn"
 
 #
-# This class represents the operands in the assertion body. 
+# This class represents the operands in the assertion body.
 # Each operand is either a 1) LITERAL, 2) VARIABLE, or 3) MACRO
 #
 class AtomicAgent(
@@ -21,7 +21,7 @@ class AtomicAgent(
    line,        # The operand's line number
    kind,        # The operand type (LITERAL | VARIABLE | MACRO)
    name,        # The string name as seen by the programmer
-   pname,       # The variable's procedure name (scope)  
+   pname,       # The variable's procedure name (scope)
    iNames,      # A set with all potential internal names (foo^x, foo-x,foo:x)
 
    values,      # A stack list with all encountered values
@@ -30,7 +30,7 @@ class AtomicAgent(
 
    eventMask,   # a cset with the operand's monitored events
    #valueMask,  # a table with the operands monitored event values
-   msg          # a string with the latest message from this class   
+   msg          # a string with the latest message from this class
    )
 
 #
@@ -38,7 +38,7 @@ class AtomicAgent(
 #
 method currentProcName(val)
    local pimage, pname, i
-   
+
    if type(val) == "procedure" then{
       pimage := image(val)
       i := find(" ", pimage)+1
@@ -56,7 +56,7 @@ method currentProcName(val)
 end
 
 #
-# receives a list of var info, i.e. [x], [foo,::,x], [class,::,foo,::,x] 
+# receives a list of var info, i.e. [x], [foo,::,x], [class,::,foo,::,x]
 # it sets the variable name, pname, and inames
 #
 method analyzeVarInfo(Var)
@@ -123,7 +123,7 @@ method analyzeVarInfo(Var)
             }
          }
       }
-   else fail 
+   else fail
    ready  := FALSE
 end
 
@@ -180,7 +180,7 @@ method currentVarValue(var)
 end
 
 #
-# returns the list of values found by the agent 
+# returns the list of values found by the agent
 #
 method getValue()
    #write("-getValue->"||image(values))
@@ -191,7 +191,7 @@ method getValue()
 end
 
 #
-# returns the list of values found by the agent 
+# returns the list of values found by the agent
 #
 method refreshData()
    #write("-getValue->"||image(values))
@@ -209,7 +209,7 @@ method getName()
 end
 
 #
-# returns the agent's ID 
+# returns the agent's ID
 #
 method getID()
    return id
@@ -260,7 +260,7 @@ method handle_event()
 end
 
 #
-# receives a list of var info, i.e. [foo], [class,::,foo] 
+# receives a list of var info, i.e. [foo], [class,::,foo]
 # it sets the variable name, pname, and inames
 #
 method analyzeProcInfo(Var)
@@ -284,10 +284,10 @@ method analyzeProcInfo(Var)
          values := 0
       insert(iNames, x)
       }
-   else fail 
+   else fail
    ready  := FALSE
 end
- 
+
 #
 # The class Constructor
 #
@@ -296,7 +296,7 @@ initially(DebugState, Fname, Line, Var)
    self.AtomicAgent.initially(DebugState, Fname, Line, AGENT)#, Var)
 
    analyzeProcInfo(Var)
-   id         := "the calling counter of procedure "||name 
+   id         := "the calling counter of procedure "||name
    eventMask  := cset(E_Pcall)
 end
 
@@ -323,7 +323,7 @@ method handle_event()
 end
 
 #
-# receives a list of var info, i.e. [foo], [class,::,foo] 
+# receives a list of var info, i.e. [foo], [class,::,foo]
 # it sets the variable name, pname, and inames
 #
 method analyzeProcInfo(Var)
@@ -342,7 +342,7 @@ method analyzeProcInfo(Var)
             fail
       insert(iNames, x)
       }
-   else fail 
+   else fail
    ready  := FALSE
 end
 
@@ -457,7 +457,7 @@ end
 class _Max : AtomicAgent()
 
 #
-# returns the agent's value 
+# returns the agent's value
 #
 method getValue()
    local maximum
@@ -486,7 +486,7 @@ end
 # This class handles the maximum variable value
 #
 class _NewMax : AtomicAgent(
-   new_max # a flag that becomes a non-null value when a new max is encountered 
+   new_max # a flag that becomes a non-null value when a new max is encountered
    )
 
 method handle_event()
@@ -519,7 +519,7 @@ method handle_event()
 end
 
 #
-# returns the agent's value 
+# returns the agent's value
 #
 method getValue()
    if \new_max then{
@@ -553,7 +553,7 @@ end
 class _Min : AtomicAgent()
 
 #
-# returns the agent's value 
+# returns the agent's value
 #
 method getValue()
    local minimum
@@ -580,10 +580,10 @@ end
 
 #
 # This class handles the new minimum of a variable value
-# 
+#
 class _NewMin : AtomicAgent(
    id,     # the string name of this agent
-   new_min # a flag that becomes a non-null value when new min is encountered 
+   new_min # a flag that becomes a non-null value when new min is encountered
    )
 
 method handle_event()
@@ -597,7 +597,7 @@ method handle_event()
 #      }
 #   else{
     if &eventcode == E_Assign & member(iNames, &eventvalue) then
-       var := 1 
+       var := 1
     else if &eventcode == E_Value & \var then{
        if /values then{
           values := &eventvalue
@@ -650,7 +650,7 @@ end
 class _Initial : AtomicAgent()
 
 #
-# returns the agent's value 
+# returns the agent's value
 #
 method getValue()
    return values[1]
@@ -705,7 +705,7 @@ method getValue()
       return values[-2]
    #else if *values = 1 then
    #   return values[1]
-   else 
+   else
       fail
 end
 
@@ -770,7 +770,7 @@ method handle_event()
 end
 
 #
-# returns the agent's value 
+# returns the agent's value
 #
 method getValue()
    if \flag then{
@@ -918,15 +918,15 @@ method handle_event()
    if &eventcode == E_Syntax then{
       #write("----->",evnames(&eventcode), ": ", syntname(&eventvalue))
       if name == (syntax := syntname(&eventvalue)) then{
-         if line  =  keyword("&line", Monitored) & 
+         if line  =  keyword("&line", Monitored) &
             fname == keyword("&file", Monitored) then
             values +:= 1
          }
       else if syntax == endLoop then
          values -:= 1
       }
-   else if &eventcode == E_Line & &eventvalue = line & 
-      fname == keyword("&file", Monitored)           & 
+   else if &eventcode == E_Line & &eventvalue = line &
+      fname == keyword("&file", Monitored)           &
       name  == syntname(keyword("syntax", Monitored)) then
       values +:= 1
 end

--- a/uni/udb/externals.icn
+++ b/uni/udb/externals.icn
@@ -1,6 +1,6 @@
 #
 # externals.icn
-# handles the external monitores that can be loaded 
+# handles the external monitores that can be loaded
 # to run in-conjunction with UDB
 # Author  : Ziad Al-Sharif
 # Date    : Feb 24, 2008
@@ -32,13 +32,13 @@ class Externals : Agent()
 #
 method cmdLoad(Name)
    local prog, mproc, name, param, mask := &cset, client, old, x, flag
- 
+
    #write(ximage(Name))
 
    if *Name = 1 then{
       name  := Name[1]
       param := [] #name[2:0]
-      } 
+      }
    else if *Name >= 2 then{
          flag := Name[1]
          name := Name[2]
@@ -61,7 +61,7 @@ method cmdLoad(Name)
       enabled +:= 1
       client := ExternalClient(name, count, ENABLED, prog, mproc, mask)
       insert(activeClients, client)
-   
+
       # debug the agent mask
       #every x := !mask do
       #   write("-->",evnames(x))
@@ -71,14 +71,14 @@ method cmdLoad(Name)
       if /Clients[name] then{
          Clients[name] := client
          build_Mask()
-         } 
+         }
       else{
          if type(Clients[name]) == "list" then
             put(Clients[name], client)
          else if type(Clients[name]) == "record" then{
             old := Clients[name]
             Clients[name] := [old]
-            } 
+            }
          }
       return
       }

--- a/uni/udb/internals.icn
+++ b/uni/udb/internals.icn
@@ -1,6 +1,6 @@
 #
 # internals.icn
-# handles the internals (built-in) monitores that can be used 
+# handles the internals (built-in) monitores that can be used
 # during the debugging session with UDB
 # Author  : Ziad Al-Sharif
 # Date    : Feb 24, 2008
@@ -51,7 +51,7 @@ end
 
 #
 # Registers an internal monitor: i.e.
-# register("test", obj,  
+# register("test", obj,
 #          [handle_event1, handle_event2], [analyze_events], [write1, write2])
 method register(name, client, handler, analyzer, writer, mask)
    local methodName
@@ -60,23 +60,23 @@ method register(name, client, handler, analyzer, writer, mask)
    Clients[name] := client
    insert(disabledClients, name)
    client.AutoRegister(name, count, DISABLED)
-   
-   #handler: is a list of method names from the internal monitor 
+
+   #handler: is a list of method names from the internal monitor
    if \handler then
       every methodName := !handler do
          client.RegisterHandler(methodName)
 
-   #analyzer: is a list of method names from the internal monitor 
+   #analyzer: is a list of method names from the internal monitor
    if \analyzer then
       every methodName := !analyzer do
          client.RegisterAnalyzer(methodName)
 
-   #writer: is a list of method names from the internal monitor 
+   #writer: is a list of method names from the internal monitor
    if \writer then
       every methodName := !writer do
          client.RegisterHandler(methodName)
 
-   #mask: is the set of events needed by the internal monitor 
+   #mask: is the set of events needed by the internal monitor
    if \mask then
       client.RegisterEventMask(mask)
 end
@@ -86,7 +86,7 @@ end
 # to be used under UDB
 #
 method Init()
-   
+
    register("counter_syntax",EventCounterSyntax())   ##  TEST
    register("counter_line",EventCounterLine())       ##  TEST
    register("counter_pcall",EventCounterPcall())     ##  TEST
@@ -122,7 +122,7 @@ method Init()
            cset(E_Exit || E_Error || E_Line || E_Syntax || E_Pcall))
 
    register("deadvar", DeadVar(),
-            ["handle_Events"], ,["write_Info"], 
+            ["handle_Events"], ,["write_Info"],
             cset(E_Exit || E_Error || E_Pcall || E_Assign || E_Deref))
 
    register("typechange", TypeChange(),
@@ -131,7 +131,7 @@ method Init()
 
    register("structusage", StructUsage(),
             ["handle_Events"], ,["write_Info"],
-            cset(E_Exit || E_Error) ++ 
+            cset(E_Exit || E_Error) ++
             cset(ListMask ++ TableMask ++ SetMask ++ RecordMask))
 end
 
@@ -142,5 +142,5 @@ initially()
 
    self.Agent.initially("internal")
    Init()
-   
+
 end

--- a/uni/udb/lib/deadvar.icn
+++ b/uni/udb/lib/deadvar.icn
@@ -1,7 +1,7 @@
 #
 # varprofile.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 #
@@ -25,7 +25,7 @@ $else
 class DeadVar (
 $endif
 
-   eventMask,         # A cset of the Monitored events 
+   eventMask,         # A cset of the Monitored events
 
    procCallCount,     # Tracks all procedures number of calls
 
@@ -38,12 +38,12 @@ $endif
    referencedVarSet,  # Set Tracks all referenced variables
 
    DeadVars,          # A set of the dead variable names
-   DeadVarInfo        # A list with all of the 
+   DeadVarInfo        # A list with all of the
    )
 
 #
 # Checks for Dead Variables
-# The monitored events are E_Pcall, E_Deref 
+# The monitored events are E_Pcall, E_Deref
 #
 method handle_Events()
    static pname
@@ -61,12 +61,12 @@ method handle_Events()
          varLastAssigned[&eventvalue] := keyword("file",Monitored)||
                                          "-"||
                                          keyword("line",Monitored)
-         } 
+         }
       }
     else if &eventcode == E_Deref & type(&eventvalue) == "string" then{
       if (find("+",&eventvalue) & \GlobalVar[&eventvalue]) |
                                        find("-",&eventvalue) then {
-         referencedVarCount[&eventvalue] +:= 1 
+         referencedVarCount[&eventvalue] +:= 1
          insert(referencedVarSet,&eventvalue)
          varLastReferenced[&eventvalue] := keyword("file",Monitored)||
                                            "-"||
@@ -77,7 +77,7 @@ end
 
 #
 # Updates the Dead Variabls info,
-# it receives the param j which is the most important j Variables 
+# it receives the param j which is the most important j Variables
 #
 method update_Info(j)
    local i:=1, k, var, vname, scope, info
@@ -86,10 +86,10 @@ method update_Info(j)
    if \DeadVars & *DeadVars > 0 then {
       if /j then j := *DeadVars + 1
       else  j >=:= *DeadVars + 1
-  
+
       DeadVarInfo := sort(DeadVars)[1:j]
       # 1-"Num"      | # 2-"File Name" | # 3-"Line #"
-      # 4-"Var Name" | # 5-"Scope"     | # 6-"#Call"  | # 7-"#Assigned" 
+      # 4-"Var Name" | # 5-"Scope"     | # 6-"#Call"  | # 7-"#Assigned"
       while i <= j  & \DeadVarInfo & \DeadVarInfo[i] do {
          var := DeadVarInfo[i]
          k := find("-"|"+",var)
@@ -100,7 +100,7 @@ method update_Info(j)
          DeadVarInfo[i] := [i,
                             info[1: k:=find("-",info)],
                             info[k+1 : 0],
-                            vname, 
+                            vname,
                             scope,
                             procCallCount[scope],
                             assignedVarCount[var]
@@ -111,7 +111,7 @@ method update_Info(j)
 end
 
 #
-# Prints out the dead vars info 
+# Prints out the dead vars info
 # It is to be used in a console based application such as UDB
 #
 method write_Info( num )
@@ -146,7 +146,7 @@ end
 # Initialize the global variables count,
 # This way will eliminate the built ins and the user defined procedures:)
 # This technique is not needed for the local variables.
-# 
+#
 method init_GlobalVar()
    local x
 
@@ -166,14 +166,14 @@ $ifndef StandAlone
    self.Listener.initially(name, state)
 $endif
 
-   eventMask  := cset(E_Exit || E_Error) ++ 
+   eventMask  := cset(E_Exit || E_Error) ++
                  cset(E_Pcall || E_Assign || E_Deref)
 
    procCallCount  := table(0)
 
    init_GlobalVar()
    assignedVarCount   := table(0)
-   varLastAssigned    := table("??") 
+   varLastAssigned    := table("??")
    assignedVarSet     := set()
    referencedVarCount := table(0)
    varLastReferenced  := table("??")
@@ -181,13 +181,13 @@ $endif
 
   #DeadVars    := set()
    DeadVarInfo := []
-   
+
 end
 
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -199,7 +199,7 @@ link evinit
 #
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := DeadVar()
 
@@ -207,24 +207,24 @@ procedure main(arg)
       if &eventcode == (E_Exit | E_Error) then
          obj.write_Info(10)
       else
-         obj.handle_Events() 
+         obj.handle_Events()
       }
    #obj.write_Info(10)
    handle_Events()
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := DeadVar()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value
@@ -232,7 +232,7 @@ procedure handle_Events(code, value)
    if &eventcode == (E_Exit | E_Error) then
       obj.write_Info(10)
    else
-      obj.handle_Events() 
+      obj.handle_Events()
 end
 
 $endif

--- a/uni/udb/lib/failedloop.icn
+++ b/uni/udb/lib/failedloop.icn
@@ -1,7 +1,7 @@
 #
 # failedloop.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 $include "evdefs.icn"
@@ -18,10 +18,10 @@ class FailedLoop (
 $endif
 
    eventMask,     # Monitored events for this detection
-   
+
    procCallCount, # Table counts the number of times each procedure is called
    loopFailCount, # Table counts the number of time a loop has been iterated
-   
+
    FailedLoopInfo # a list with the failed loop information
    )
 
@@ -39,7 +39,7 @@ method handle_Events()
       pname := pname[find(" ", pname)+1: 0]
       procCallCount[pname] +:= 1
       }
-   else if &eventcode == E_Syntax then{ 
+   else if &eventcode == E_Syntax then{
       loop := syntname(&eventvalue)
       if find(loop, loopStart) then{
          line := keyword("line", Monitored)
@@ -55,34 +55,34 @@ method handle_Events()
    else if &eventcode == E_Line then{
       loop := syntname(keyword("syntax",Monitored))
       if find(loop, loopStart) then{
-         line := &eventvalue 
+         line := &eventvalue
          fname := keyword("file", Monitored)
          pname := image(proc(Monitored,0))
          pname := pname[find(" ", pname)+1: 0]
          k := fname||"("||line||"){"||pname||
               #"-"||procCallCount[pname]||
               "}"||loop
-         loopFailCount[k] +:=1 
+         loopFailCount[k] +:=1
          }
       }
 end
 
 #
 # updates the failed loop info,
-# it receives the param j which is the most elapsed j loops 
+# it receives the param j which is the most elapsed j loops
 #
 method update_Info(j)
    local i:=1, loop, fname, pname, line, p
-   
+
    if \loopFailCount & *loopFailCount > 0 then{
       if /j then j := *loopFailCount + 1
       else  j >=:= *loopFailCount + 1
-      
+
       FailedLoopInfo := sort(loopFailCount,2)[1:j]
-      # 1-"Seq Num"          | 
+      # 1-"Seq Num"          |
       # 2-"File Name"        | # 3-"Line #" |
       # 4-"Proc Name"        | # 5-"#call"  |
-      # 6-"Loop Name"        |  
+      # 6-"Loop Name"        |
       # 7-"Avg(Iter/Call)"   |
       # 8-"Total Iterations" |
       while i <= j  & \FailedLoopInfo do{
@@ -101,12 +101,12 @@ method update_Info(j)
               i
               )
          i +:= 1
-         } 
+         }
       }
 end
 
 #
-# Prints out the total elapsed of a loop in ms 
+# Prints out the total elapsed of a loop in ms
 # It is to be used in a console based application such as UDB
 #
 method write_Info( num )
@@ -118,7 +118,7 @@ method write_Info( num )
    write("\n-------------------------------------------------------------")
    write("\n---- Loop's info [The Least Iterated (",num,") Loops] ----")
    write(left("Num",3),            " | ",
-         left("File Name",10),     " : ",        
+         left("File Name",10),     " : ",
          left("Line #",6),         " : ",
          left("proc Name",10),     " : ",
          left("#Calls",6),         " : ",
@@ -149,7 +149,7 @@ $ifndef StandAlone
    self.Listener.initially(name, state)
 $endif
 
-   eventMask     := cset(E_Exit || E_Error) ++ 
+   eventMask     := cset(E_Exit || E_Error) ++
                     cset(E_Pcall || E_Syntax || E_Line)
 
    procCallCount := table(0)
@@ -161,7 +161,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -170,35 +170,35 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
-   EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+
+   EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := FailedLoop()
 
    while EvGet(obj.eventMask) do{
       if &eventcode == (E_Exit | E_Error) then
          obj.write_Info()
       else
-         obj.handle_Events() 
+         obj.handle_Events()
       }
    #obj.write_Info()
    handle_Events() #fake call
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
-      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := FailedLoop()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value
@@ -206,7 +206,7 @@ procedure handle_Events(code, value)
    if &eventcode == (E_Exit | E_Error) then
       obj.write_Info()
    else
-      obj.handle_Events() 
+      obj.handle_Events()
 end
 
 $endif

--- a/uni/udb/lib/failedsubscript.icn
+++ b/uni/udb/lib/failedsubscript.icn
@@ -1,7 +1,7 @@
 #
 # failedsubscript.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 $include "evdefs.icn"
@@ -16,12 +16,12 @@ class FailedSubscript (
 $endif
 
    eventMask,      # Cset of the monitored events
-   
+
    failedSubNames, # Table maps each failed list Serial into its used aliases
    failedSubCount, # Table maps each failed list Serial into its num of fails
    failedSubInfo,  # Table maps each failed list Serial into a list of locations
-   
-   FailedSubscriptInfo # A list with the Failed information 
+
+   FailedSubscriptInfo # A list with the Failed information
    )
 
 #
@@ -44,28 +44,28 @@ method handle_Events()
    # keep track of the index of the last referenced list
    else if &eventcode == E_Lsub then{
       index := &eventvalue
-      } 
+      }
    # Suspicious [] subscript fail
    else if &eventcode  == E_Ofail & find("[]",image(&eventvalue)) then{
-      failedSubNames[Serial] ||:= lname ||", " 
+      failedSubNames[Serial] ||:= lname ||", "
       failedSubCount[Serial] +:= 1
 
       fname := keyword("file", Monitored)
       line  := keyword("line", Monitored)
-      if i := find("-", lname) then lname := lname[1:i] 
-      else                          lname := lname[1:-1] 
+      if i := find("-", lname) then lname := lname[1:i]
+      else                          lname := lname[1:-1]
       #info  := fname||"("||line||") "||lname||"["||index||
-      /failedSubInfo[Serial] := [] 
-      push(failedSubInfo[Serial], 
+      /failedSubInfo[Serial] := []
+      push(failedSubInfo[Serial],
            fname||"("||line||"): "||lname||"["||index||"], index off by "||
            abs(*lref-index)
-           ) 
+           )
       }
 end
 
 #
 # Updates the Failed Subscript info,
-# It receives the param j which is the most elapsed j loops 
+# It receives the param j which is the most elapsed j loops
 #
 method update_Info(j)
    local i:=1, Serial
@@ -73,19 +73,19 @@ method update_Info(j)
    if \failedSubCount & *failedSubCount > 0 then{
       if /j then j := *failedSubCount + 1
       else  j >=:= *failedSubCount + 1
-  
+
       FailedSubscriptInfo := reverse(sort(failedSubCount,2))[1:j]
-      # 1-"Used Names"    | 
+      # 1-"Used Names"    |
       # 2-"Serial"        |
       # 3-"Num of Fail"   |
-      # 4-"Last Fail Info"|  
+      # 4-"Last Fail Info"|
       while i <= j  & \FailedSubscriptInfo do{
           Serial := FailedSubscriptInfo[i][1]
           push(FailedSubscriptInfo[i],failedSubNames[Serial])
           put(FailedSubscriptInfo[i],failedSubInfo[Serial][1])
           i +:= 1
           }
-      } 
+      }
 end
 
 #
@@ -101,7 +101,7 @@ method write_Info( num )
    write("\n-------------------------------------------------------------")
    write("\n---- Subscript's info [The Most (",num,") Subscripts] ----")
    write(left("Used Names",15), " : ",
-         left("Serial",6),      " : ",        
+         left("Serial",6),      " : ",
          left("#Fail",5),       " : ",
          left("Last Fail Info",40)
          )
@@ -124,7 +124,7 @@ $ifndef StandAlone
    self.Listener.initially(name, state)
 $endif
 
-   eventMask      := cset(E_Exit || E_Error) ++ 
+   eventMask      := cset(E_Exit || E_Error) ++
                      cset(E_Deref || E_Lref || E_Lsub || E_Ofail)
 
    failedSubNames := table("")
@@ -137,7 +137,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -146,10 +146,10 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := FailedSubscript()
 
@@ -157,24 +157,24 @@ procedure main(arg)
       if &eventcode == (E_Exit | E_Error) then
          obj.write_Info()
       else
-         obj.handle_Events() 
+         obj.handle_Events()
       }
    #obj.write_Info()
    handle_Events() #fake call
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := FailedSubscript()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value
@@ -182,7 +182,7 @@ procedure handle_Events(code, value)
    if &eventcode == (E_Exit | E_Error) then
       obj.write_Info()
    else
-      obj.handle_Events() 
+      obj.handle_Events()
 end
 
 $endif

--- a/uni/udb/lib/listener.icn
+++ b/uni/udb/lib/listener.icn
@@ -1,5 +1,5 @@
 #
-# This class is used to find out the methods in the 
+# This class is used to find out the methods in the
 # internal monitor and its event mask
 # Author : Dr. Jeffery, modified by Ziad Al-Sharif
 #
@@ -32,7 +32,7 @@ method Forward()
 end
 
 #
-# performas an on-demand analysis in the listener monitor 
+# performas an on-demand analysis in the listener monitor
 #
 method AnalyzeInof(tag)
    local foo, foolist
@@ -44,7 +44,7 @@ method AnalyzeInof(tag)
 end
 
 #
-# performas an on-demand output from the listener monitor 
+# performas an on-demand output from the listener monitor
 #
 method WriteInfo(tag)
    local foo, foolist
@@ -56,11 +56,11 @@ method WriteInfo(tag)
 end
 
 #
-# reads the derived class and finds out which methods start with 
+# reads the derived class and finds out which methods start with
 # on of the prefixes (handle_, update, or write)
 # It is used to automatically register the internal monitors
 # based on the assumptions:
-# event handler starts with the prefix "handle_" 
+# event handler starts with the prefix "handle_"
 # method analazer starts withe the prefix: "analyze" | "update"
 # method writer starts withe the prefix  : "write"   | "print"
 #
@@ -70,7 +70,7 @@ method AutoRegister(name, id, state)
    Name  := name
    Id    := id
    State := state
-   
+
    every (methodName := key(self.__m)) & not match("__",methodName) do {
        if (eventcode := symtab[methodName ? (="handle_" & tab(0))]) &
           eventcode ~== "E_????" then {
@@ -83,7 +83,7 @@ method AutoRegister(name, id, state)
           RegisterAnalyzer(methodName)
        else if find("write"|"print", methodName) then
           RegisterWriter(methodName)
-       }  
+       }
    if *mask > 0 then eventMask := cset(mask)
 end
 
@@ -91,7 +91,7 @@ end
 # Registers the event handler of the monitoring tool
 #
 method RegisterHandler(methodname, mask)
-   local eventcode 
+   local eventcode
 
    if \mask then{
       every eventcode := !mask do
@@ -99,16 +99,16 @@ method RegisterHandler(methodname, mask)
       eventMask := mask
       }
    else{
-      /methtab["handler"] := [ ] 
+      /methtab["handler"] := [ ]
       put(methtab["handler"], get_Method(methodname))
-      }  
+      }
 end
 
 #
 # Registers the analyzer handler of the monitoring tool
 #
 method RegisterAnalyzer(methodname)
-   /methtab["analyzer"] := [ ] 
+   /methtab["analyzer"] := [ ]
    put(methtab["analyzer"], get_Method(methodname))
 end
 
@@ -116,7 +116,7 @@ end
 # Registers the analyzer handler of the monitoring tool
 #
 method RegisterWriter(methodname)
-   /methtab["writer"] := [ ] 
+   /methtab["writer"] := [ ]
    put(methtab["writer"], get_Method(methodname))
 end
 
@@ -124,7 +124,7 @@ end
 # Registers the analyzer handler of the monitoring tool
 #
 method RegisterEventMask(mask)
-   /eventMask := cset() 
+   /eventMask := cset()
    eventMask ++:= mask
 end
 
@@ -133,18 +133,18 @@ end
 #
 method get_Method(name)
    local methodname
-   
+
    every (methodname := key(self.__m)) & not match("__",methodname) do
        if find(name, methodname) then
           return self.__m[methodname]
-   fail 
+   fail
 end
 #
-# reads the derived class and finds out which methods start with 
+# reads the derived class and finds out which methods start with
 # on of the prefixes (handle, update, or write)
 #
 initially(name, id,state)
-   
+
    Name  := name
    Id    := id
    State := state

--- a/uni/udb/lib/looptime.icn
+++ b/uni/udb/lib/looptime.icn
@@ -1,6 +1,6 @@
 
 #
-# looptime.icn 
+# looptime.icn
 # Ziad Al-Sharif
 # June 1, 2008
 #
@@ -10,7 +10,7 @@ link syntname
 
 #
 # This class handles loops times,
-# It finds the most n loops took time during the execution 
+# It finds the most n loops took time during the execution
 #
 $ifndef StandAlone
 class LoopTime : Listener(
@@ -19,14 +19,14 @@ class LoopTime (
 $endif
 
    eventMask,         # The monitored events for this detection
-    
+
    procCallCount,     # Table maps each proc name into its number of calls
    loopCount,         # Table maps each used loop into its number of use
 
    loopLastIteration, # Table tracks each loop last num of iterations
    loopIteration,     # Table maps each loop name into its number of iterations
 
-   loopLastTime,      # Table tracks each loop last elapsed time 
+   loopLastTime,      # Table tracks each loop last elapsed time
    loopTime,          # Table maps each loop name into its elapsed time
 
    LoopTimeInfo       # A list with loop times information
@@ -39,8 +39,8 @@ method handle_Events()
    static loopStart := "while every repeat until"
    static loopEnd   := "endwhile endevery endrepeat enduntil"
    static fname, line, pname, k
-   local  loop 
-   
+   local  loop
+
    if &eventcode == E_Pcall then{
       pname := image(&eventvalue)
       pname := pname[find(" ", pname)+1: 0]
@@ -76,9 +76,9 @@ method handle_Events()
          # Here is where the loop ends
          loopLastTime[k] := keyword("time",Monitored) - loopLastTime[k]
          loopTime[k] +:= loopLastTime[k]
-         loopIteration[k] +:= loopLastIteration[k] 
+         loopIteration[k] +:= loopLastIteration[k]
          }
-      } 
+      }
    else if &eventcode == E_Line then{
       loop := syntname(keyword("syntax",Monitored))
       if find(loop,loopStart) then{
@@ -90,30 +90,30 @@ method handle_Events()
               #procCallCount[pname]||"): "||
               loop
          # Here is where the loop iterates
-         loopLastIteration[k] +:=1 
+         loopLastIteration[k] +:=1
          }
       }
 end
 
 #
 # updates the loop time info,
-# it receives the param j which is the most elapsed j loops 
+# it receives the param j which is the most elapsed j loops
 #
 method update_Info(j)
    local i:=1, loop
-   
+
    if /j then j := *loopTime + 1
    else  j >=:= *loopTime + 1
-  
+
    LoopTimeInfo := reverse(sort(loopTime,2))[1:j]
-   # 1-"Seq Num"    | 
+   # 1-"Seq Num"    |
    # 2-"Loop Name"  | # 3-"Total Time" |
    # 4-"loop Count" |
    # 5-"Total Iterations" | # 6-"Avg Time/Iteration" |
    # 7-"Last elapsed Time"| # 8-"Last # Iterations"
    while i <= j  do{
       loop := LoopTimeInfo[i][1]
-      push(LoopTimeInfo[i],i)                     
+      push(LoopTimeInfo[i],i)
       put(LoopTimeInfo[i],
           loopCount[loop],
           procCallCount[loop[find("{",loop)+1:find("}",loop)]],
@@ -127,7 +127,7 @@ method update_Info(j)
 end
 
 #
-# Prints out the total elapsed of a loop in ms 
+# Prints out the total elapsed of a loop in ms
 # It is to be used in a console based application such as UDB
 #
 method write_Info( num )
@@ -139,7 +139,7 @@ method write_Info( num )
    write("\n-------------------------------------------------------------")
    write("\n---- Loop's Time info [The Most (",num,") Loops] ----")
    write(left("Num",3)," | ",
-         left("fname(line){Proc}-Loop Name",30)," : ",        
+         left("fname(line){Proc}-Loop Name",30)," : ",
          left("Total Time",10)," : ",
          left("Loop Count",10)," : ",
          left("Proc Calls",10)," : ",
@@ -187,7 +187,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -196,11 +196,11 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
-   EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+
+   EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := LoopTime()
 
    while EvGet(obj.eventMask) do{
@@ -214,17 +214,17 @@ procedure main(arg)
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
-      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := LoopTime()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value

--- a/uni/udb/lib/memory.icn
+++ b/uni/udb/lib/memory.icn
@@ -1,5 +1,5 @@
 #
-# memory.icn 
+# memory.icn
 # Ziad Al-Sharif
 # June 1, 2008
 #
@@ -8,7 +8,7 @@ $include "evdefs.icn"
 
 #
 # The main Memeory Monitoring class:
-# It Handles the memory managment of an Icon/Unicon perogram 
+# It Handles the memory managment of an Icon/Unicon perogram
 #
 $ifndef StandAlone
 class Memory : Listener(
@@ -19,7 +19,7 @@ $endif
    eventMask,      # The monitored events
    collectMask,    # The garbage collection mask
    allocMask,      # The heap memory allcation mask
- 
+
    BlockRegion,    # Total memory allocated for the block region
    StringRegion,   # Total memory allocated for the String Region
 
@@ -91,7 +91,7 @@ method update_AllocStateInfo()
   # 1- *** | 2-Lists | 3-Tables | 4-Sets | 5-Csets | 6-Records |
   # 7-Large Int | 8-Real
 
-  #AllocStateInfo[1][1] := "Total" 
+  #AllocStateInfo[1][1] := "Total"
    AllocStateInfo[1][2] := Talloc_total[E_List]
    AllocStateInfo[1][3] := Talloc_total[E_Table]
    AllocStateInfo[1][4] := Talloc_total[E_Set]
@@ -149,14 +149,14 @@ method write_AllocStateInfo()
 end
 
 #
-# update the current memory state whenever it is needed 
+# update the current memory state whenever it is needed
 #
 method update_MemoryStateInfo()
 
   # Fields description:
   # 1-Region | 2-Total Memory | 3-Allocated |  4-Allocated % |
   # 5-# Allocation | 6-Avg Allocation | 7-# of GC
-   
+
   #MemoryStateInfo[1][1] := "String Region"
   #MemoryStateInfo[1][2] := StringRegion / 1000000
    MemoryStateInfo[1][3] := AllocStrTotal
@@ -210,9 +210,9 @@ method get_AllocPercentage(k)
     if k == E_String then{
        return AllocStrTotal * 100 / StringRegion
        }
-    else{ # anything other than strings 
+    else{ # anything other than strings
        return Talloc_total[k] * 100 / AllocBlkTotal
-       } 
+       }
 end
 
 #
@@ -223,9 +223,9 @@ method get_AllocAvg(k)
     if k == E_String then{
        return AllocStrTotal / ((0 < Talloc_count[E_String]) | 1)
        }
-    else{ # any thing other than strings 
+    else{ # any thing other than strings
        return Talloc_total[k] / ((0 < Talloc_count[k]) | 1)
-       } 
+       }
 end
 
 # takes a table that maps events to their total allocations
@@ -251,7 +251,7 @@ method get_Total(T)
    local k, total := 0
 
    every k := key(T) do total +:= T[k]
-   return total  
+   return total
 end
 
 #
@@ -296,7 +296,7 @@ $endif
    # Fields description:
    # 1-Region       | 2-Total Memory   | 3-Allocated |  4-Allocated % |
    # 5-# Allocation | 6-Avg Allocation | 7-# of GC
-   MemoryStateInfo := 
+   MemoryStateInfo :=
            [["String Region",StringRegion / 1000000||" MB",0,0,0,0,0],
             ["Block Region" ,BlockRegion  / 1000000||" MB",0,0,0,0,0]]
 
@@ -314,7 +314,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -323,10 +323,10 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := Memory()
 
@@ -347,17 +347,17 @@ end
 #global obj
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
-      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := Memory()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value

--- a/uni/udb/lib/memory_alloc.icn
+++ b/uni/udb/lib/memory_alloc.icn
@@ -1,4 +1,4 @@
-# 
+#
 # Ziad AL-Sharif
 # Data Structure Visualization
 #
@@ -37,11 +37,11 @@ class Display(
 method layout()
 
    &window := open(title,"g", "bg=very light blue","size="||xmax||","||ymax)
-   createColorContext()   
+   createColorContext()
    drawLegend()
    DrawLine(wColor["gray"],0,160,xmax,160)
    DrawRectangle(wColor["default"],0,0,xmax-1,ypos-15)
-end 
+end
 
 method drawMemoryBar(which, T, RegionSize)
    static p1:=0, p2:=0, old_p1:=-1,old_p2:=-1
@@ -66,7 +66,7 @@ method drawMemoryBar(which, T, RegionSize)
          }
      "string":{ # update the string region bar
          every k:= key(T) do total +:= T[k]
-         p1 := ceil(total *100.0/RegionSize)        
+         p1 := ceil(total *100.0/RegionSize)
          if p1 ~= old_p1 then{
             old_p1 := p1
             s1 := "%"||left(p1,3)||" of "||left(RegionSize,2)||" MB, String Region"
@@ -77,7 +77,7 @@ method drawMemoryBar(which, T, RegionSize)
                ww := T[k] *  available /total
                FillRectangle(wColor[k],  x1, y1+1, ww, h-1)
                x1 +:= ww
-               } 
+               }
             DrawString(wColor["default"],   w/2.5,y1+15, s1)
             }
          }
@@ -95,7 +95,7 @@ method drawMemoryBar(which, T, RegionSize)
                ww := T[k] *  available /total
                FillRectangle(wColor[k],  x2, y2+1, ww, h-1)
                x2 +:= ww
-               } 
+               }
             DrawString(wColor["default"],   w/2.5,y2+15, s2)
             }
          }
@@ -109,16 +109,16 @@ method drawPie(T, num, label, label2)
    local w:=100, h:=100
    local x:=0 , y := 16
 
-   if t := getPercentage(T) then{   
+   if t := getPercentage(T) then{
       if num > 5 then{
          y := 180
          num -:= 5
-         } 
+         }
       x := (num-1) * w + (num * 16)
       DrawRectangle(wColor["gray"], x-8,y-8,w+16,h+16)
       EraseArea(x-8,y+h+10,w+15,30)
       DrawString(wColor["Text"],x,y+h+24,(\label|"?"))
-      if \label2 then 
+      if \label2 then
          DrawString(wColor["Text"],x,y+h+34,label2)
       start := 0
       every k := key(t) do {
@@ -186,7 +186,7 @@ end
 #
 method Labels()
    local code, result, labels := table()
-   
+
    every code := !AllocMask do{
       result := evnames(code)
       result ?:= tab(find(" allocation"))
@@ -206,7 +206,7 @@ end
 method createColorContext()
    local ecode, color := colormap("standard")
 
-   wColor := table()   
+   wColor := table()
    wColor["default"] := Clone(&window, "fg=black")
    wColor["white"]   := Clone(&window, "fg=very light blue")
    wColor["Title"]   := Clone(&window, "fg=black", "font=serif,bold,16")
@@ -233,7 +233,7 @@ initially(av)
    xlimit:= xmax / 2
    ylimit:= 150
    ypos  := ymax - ylimit
- 
+
 end
 
 
@@ -243,9 +243,9 @@ end
 class MMM(
    tp      ,    # target program name
    eventMask,   # the monitor events
-            
+
    Tstruct_usage,# counts the number of times a struct is used
-   Tstruct_count,# counts the number of created structures 
+   Tstruct_count,# counts the number of created structures
    Talloc_string,# counts string allocations
    Talloc_block, # counts block allocations
    Talloc_count, # counts of allocations
@@ -255,7 +255,7 @@ class MMM(
    Tables,       # counts the usage of tables
    Sets,         # counts the usage of sets
    Records,      # counts the usage of records
-   
+
    BlockRegion,  # the total memory in the block region
    StringRegion, # the total memory in the String Region
    display      # An object of the class Display()
@@ -278,17 +278,17 @@ method Monitor()
          Talloc_string := table(0)   # re-initialize : count string allocations
          Talloc_block  := table(0)   # re-initialize : count block allocations
          #write("=-====== start collecting")
-         }  
+         }
       else if &eventcode === E_EndCollect then{
          collect_flag := &null
          #write("=-====== end collecting")
-         }  
-      if member(AllocMask,&eventcode) then{ 
+         }
+      if member(AllocMask,&eventcode) then{
          if /collect_flag then{
             if &eventcode === (E_String | E_Tvsubs) then
                  Talloc_string[&eventcode] +:= &eventvalue
             else Talloc_block[&eventcode]  +:= &eventvalue
-            
+
             Talloc_count[&eventcode] +:= 1
             Talloc_total[&eventcode] +:= &eventvalue
             }
@@ -299,8 +299,8 @@ method Monitor()
             #Talloc_count[&eventcode] +:= 1
             Talloc_total[&eventcode] +:= &eventvalue
             }
-         }  
-      else{ 
+         }
+      else{
          if member(ListMask,&eventcode) then{
             if &eventcode == E_Lcreate then{
                insert(num_list,serial(&eventvalue))
@@ -308,7 +308,7 @@ method Monitor()
             Tstruct_usage[E_List] +:= 1
             if member(ListChange,&eventcode) then Lists["change"] +:= 1
             else                                  Lists["access"] +:= 1
-            } 
+            }
          else if member(TableMask,&eventcode) then{
             if &eventcode == E_Tcreate then{
                insert(num_table,serial(&eventvalue))
@@ -316,7 +316,7 @@ method Monitor()
             Tstruct_usage[E_Table] +:= 1
             if member(TableChange,&eventcode) then Tables["change"] +:= 1
             else                                   Tables["access"] +:= 1
-            }  
+            }
          else if member(SetMask,&eventcode) then{
             if &eventcode == E_Screate then{
                insert(num_set,serial(&eventvalue))
@@ -324,7 +324,7 @@ method Monitor()
             Tstruct_usage[E_Set] +:= 1
             if member(SetChange,&eventcode) then Sets["change"] +:= 1
             else                                 Sets["access"] +:= 1
-            }  
+            }
          else if member(RecordMask,&eventcode) then{
             if &eventcode == E_Rcreate then{
                insert(num_record,serial(&eventvalue))
@@ -333,7 +333,7 @@ method Monitor()
             if member(RecordChange,&eventcode) then Records["change"] +:= 1
             else                                    Records["access"] +:= 1
             }
-         }  
+         }
       #------------------------------
       if /collect_flag then{
          if i > 20 then{
@@ -349,23 +349,23 @@ method Monitor()
                display.drawMemoryBar("string",Talloc_string, StringRegion)
                }
 
-            if *Talloc_block > 0 then{ 
+            if *Talloc_block > 0 then{
                display.drawPie(Talloc_block, num+:=1, "% Block Alloc")
                display.drawMemoryBar("block", Talloc_block,  BlockRegion)
                }
 
-            if *Tstruct_count > 0 then 
+            if *Tstruct_count > 0 then
                display.drawPie(Tstruct_count, num+:=1, "% # Created Struct")
 
-            if *Lists > 0 then   
+            if *Lists > 0 then
                display.drawPie(Lists,num+:=1, "% Lists Usage"," #"||Tstruct_count[E_List])
-            if *Tables > 0 then  
+            if *Tables > 0 then
                display.drawPie(Tables,num+:=1,"% Tables Usage"," #"||Tstruct_count[E_Table])
-            if *Sets > 0 then 
+            if *Sets > 0 then
                display.drawPie(Sets,num+:=1, "% Sets Usage"," #"||Tstruct_count[E_Set])
             if *Records > 0 then
                display.drawPie(Records,num+:=1, "% Records Usage"," #"||Tstruct_count[E_Record])
-            if *Tstruct_usage > 0 then 
+            if *Tstruct_usage > 0 then
                display.drawPie(Tstruct_usage, num+:=1, "% All Struct Usage")
 
             #delay(10)
@@ -386,7 +386,7 @@ method Init(args)
    local Regions := []
 
    tp := args
-   Tstruct_usage := table(0) 
+   Tstruct_usage := table(0)
    Tstruct_count := table(0)
    Talloc_string := table(0)
    Talloc_block  := table(0)
@@ -401,7 +401,7 @@ method Init(args)
    #Initialize all allocation types even if there is no allocation for them.
    every Talloc_count[!AllocMask] := 0
    every Talloc_total[!AllocMask] := 0
-   
+
    BlockRegion  := 0
    StringRegion := 0
 
@@ -409,10 +409,10 @@ method Init(args)
    StringRegion:= Regions[2]
    BlockRegion := Regions[3]
 
-   ListChange := cset() 
-   eventMask := AllocMask ++ 
-                cset(E_Collect||E_EndCollect) ++ 
-                ListChange   ++ ListAccess    ++ 
+   ListChange := cset()
+   eventMask := AllocMask ++
+                cset(E_Collect||E_EndCollect) ++
+                ListChange   ++ ListAccess    ++
                 TableChange  ++ TableAccess   ++
                 SetChange    ++ SetAccess     ++
                 RecordChange ++ RecordAccess

--- a/uni/udb/lib/procprofile.icn
+++ b/uni/udb/lib/procprofile.icn
@@ -1,5 +1,5 @@
 #
-# procprofile.icn 
+# procprofile.icn
 # Ziad Al-Sharif
 # June 1, 2008
 #
@@ -42,7 +42,7 @@ $endif
    procMostName,    # a record tracks the name of the most used proc activity
 
    totalCall,       # acumulates the total calls + resumes
-   totalRet,        # acumulates the total returns+fails+suspends+removes  
+   totalRet,        # acumulates the total returns+fails+suspends+removes
 
    ProcProfileInfo  # A list with the procedure's profile info
    )
@@ -65,13 +65,13 @@ method handle_Events()
           }
       E_Pfail:{
           totalRet  +:= 1
-          procTotal.Fail +:= 1 
+          procTotal.Fail +:= 1
           if procMostNum.Fail <:= procFailCount[pname] +:= 1 then
              procMostName.Fail := pname
           }
       E_Pret:{
           totalRet  +:= 1
-          procTotal.Return +:= 1 
+          procTotal.Return +:= 1
           if procMostNum.Return <:= procReturnCount[pname] +:= 1 then
              procMostName.Return := pname
           }
@@ -83,17 +83,17 @@ method handle_Events()
           }
       E_Psusp:{
           totalRet  +:= 1
-          procTotal.Suspend +:= 1 
+          procTotal.Suspend +:= 1
           if procMostNum.Suspend <:= procSuspendCount[pname] +:= 1 then
-             procMostName.Suspend := pname 
+             procMostName.Suspend := pname
           }
       E_Prem:{
           totalRet  +:= 1
-          procTotal.Remove +:= 1 
+          procTotal.Remove +:= 1
           if procMostNum.Remove <:= procRemoveCount[pname] +:= 1 then
              procMostName.Remove := pname
           }
-      } 
+      }
 end
 
 #
@@ -104,7 +104,7 @@ method update_Info()
   # Fields description for procedure profiles:
   # 1-Action | 2-Total | 3-Total % | 4-Most Used
 
-  #procProfileInfo[1][1] := "Call" 
+  #procProfileInfo[1][1] := "Call"
    ProcProfileInfo[1][2] := procTotal.Call
    ProcProfileInfo[1][3] := procTotal.Call * 100 / totalCall
    ProcProfileInfo[1][4] := procMostName.Call||"-"||procMostNum.Call
@@ -119,12 +119,12 @@ method update_Info()
    ProcProfileInfo[3][3] := procTotal.Suspend * 100 / totalRet
    ProcProfileInfo[3][4] := procMostName.Suspend||"-"||procMostNum.Suspend
 
-  #ProcProfileInfo[4][1] := "Return" 
+  #ProcProfileInfo[4][1] := "Return"
    ProcProfileInfo[4][2] := procTotal.Return
-   ProcProfileInfo[4][3] := procTotal.Return * 100 / totalRet 
+   ProcProfileInfo[4][3] := procTotal.Return * 100 / totalRet
    ProcProfileInfo[4][4] := procMostName.Return||"-"||procMostNum.Return
 
-  #ProcProfileInfo[5][1] := "Fail" 
+  #ProcProfileInfo[5][1] := "Fail"
    ProcProfileInfo[5][2] := procTotal.Fail
    ProcProfileInfo[5][3] := procTotal.Fail * 100 / totalRet
    ProcProfileInfo[5][4] := procMostName.Fail||"-"||procMostNum.Fail
@@ -220,7 +220,7 @@ $ifndef StandAlone
 $endif
 
    eventMask := cset(E_Exit || E_Error) ++ ProcMask
- 
+
    procCallCount    := table(0)
    procResumeCount  := table(0)
    procSuspendCount := table(0)
@@ -236,7 +236,7 @@ $endif
    totalRet     := 1
 
    # Fields description for procedure profiles:
-   # 1-Action | 2-Total | 3-Total % | 4-Most Used 
+   # 1-Action | 2-Total | 3-Total % | 4-Most Used
    ProcProfileInfo := [["Call"   ,0,0,0],
                        ["Resume" ,0,0,0],
                        ["Suspend",0,0,0],
@@ -248,7 +248,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -257,11 +257,11 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
-   EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+
+   EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := ProcProfile()
 
    while EvGet(obj.eventMask) do{
@@ -275,17 +275,17 @@ procedure main(arg)
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
-      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")   
+      #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := ProcProfile()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value

--- a/uni/udb/lib/proctime.icn
+++ b/uni/udb/lib/proctime.icn
@@ -1,6 +1,6 @@
 
 #
-# proctime.icn 
+# proctime.icn
 # Ziad Al-Sharif
 # June 1, 2008
 #
@@ -8,9 +8,9 @@
 $include "evdefs.icn"
 
 #
-# This class handles the procedure calling time, 
+# This class handles the procedure calling time,
 # it associates all names fo called procedures with
-# their acumulated elapsed time from all calls. 
+# their acumulated elapsed time from all calls.
 #
 $ifndef StandAlone
 class ProcTime : Listener(
@@ -23,7 +23,7 @@ $endif
    callMask,         # The monitored events for the calls + resumes
    retMask,          # The monitored events for the ret+rem+susp+fail
 
-   procCallCount,    # Table maps each proc name into its number of calls 
+   procCallCount,    # Table maps each proc name into its number of calls
    procLastCallTime, # Table maps each procedure name into its last call time
    procTime,         # Table maps each proc+call sequence into its elapsed time
 
@@ -31,7 +31,7 @@ $endif
    )
 
 #
-# Counts the total time spent during the execution of procedures 
+# Counts the total time spent during the execution of procedures
 #
 method handle_Events()
    local pname
@@ -43,18 +43,18 @@ method handle_Events()
       procCallCount[pname] +:= 1
       procLastCallTime[pname] := keyword("time",Monitored)
       }
-   # == (E_Pret | E_Pfail | E_Psusp | E_Prem) 
+   # == (E_Pret | E_Pfail | E_Psusp | E_Prem)
    else if member(retMask,&eventcode) then{
       pname := image(proc(Monitored,0))
       pname := pname[find(" ", pname)+1: 0]
-      procTime[pname] +:= (procLastCallTime[pname] := 
+      procTime[pname] +:= (procLastCallTime[pname] :=
                            keyword("time",Monitored) - procLastCallTime[pname])
       }
 end
 
 #
 # updates the procedure time info,
-# it receives the param j which is the most important j procedures 
+# it receives the param j which is the most important j procedures
 #
 method update_Info(j)
    local i:=1, pname
@@ -62,13 +62,13 @@ method update_Info(j)
    if \procTime & *procTime > 0 then{
       if /j then j := *procTime + 1
       else  j >=:= *procTime + 1
-  
+
       ProcTimeInfo := reverse(sort(procTime,2))[1:j]
       # 1-"Seq Num"      | # 2-"Procedure Name"    | # 3-"Total Time"
       # 4-"Num of Calls" | # 5-"Avg Time/Num-Call" | # 6-"Last Call Time"
       while i <= j  & \ProcTimeInfo do{
          pname := ProcTimeInfo[i][1]
-         push(ProcTimeInfo[i],i)                     
+         push(ProcTimeInfo[i],i)
          put(ProcTimeInfo[i],
              procCallCount[pname],
              ProcTimeInfo[i][3] / procCallCount[pname],
@@ -80,7 +80,7 @@ method update_Info(j)
 end
 
 #
-# Prints out the total time of a procedure call in ms 
+# Prints out the total time of a procedure call in ms
 # It is to be used in a console based application such as UDB
 #
 method write_Info( num )
@@ -133,7 +133,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -142,12 +142,12 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
-   obj := ProcTime()   
+   obj := ProcTime()
 
    while EvGet(obj.eventMask) do{
       if &eventcode == (E_Exit | E_Error) then
@@ -159,17 +159,17 @@ procedure main(arg)
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
-      obj := ProcTime()   
+      obj := ProcTime()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value

--- a/uni/udb/lib/structaliases.icn
+++ b/uni/udb/lib/structaliases.icn
@@ -2,7 +2,7 @@
 #
 # structaliases.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 $include "evdefs.icn"
@@ -59,7 +59,7 @@ method handle_Events()
               insert(tRalias[i],x||"^"||pname)
               }
            }# end case
-         } 
+         }
       }
    else if &eventcode == E_Assign then{
       assigned_var := &eventvalue
@@ -103,7 +103,7 @@ method get_Info(k,i)
      E_Table: { t := tTalias  }
      E_Record:{ t := tRalias  }
      E_Set:   { t := tSalias  }
-     } 
+     }
 
    if \t[i] then{
       every x := !t[i] do result ||:= x||", "
@@ -123,16 +123,16 @@ $endif
 
    eventMask := cset(E_Exit || E_Error) ++ cset(E_Pcall || E_Assign || E_Value)
 
-   tLalias := table() 
-   tTalias := table() 
-   tSalias := table() 
+   tLalias := table()
+   tTalias := table()
+   tSalias := table()
    tRalias := table()
 end
 
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -141,10 +141,10 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := StructAliases()
 
@@ -152,23 +152,23 @@ procedure main(arg)
       if &eventcode == (E_Exit | E_Error) then
          obj.write_Info()
       else
-         obj.handle_Events() 
+         obj.handle_Events()
       }
    handle_Events() #fake call
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := StructAliases()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value
@@ -176,7 +176,7 @@ procedure handle_Events(code, value)
    if &eventcode == (E_Exit | E_Error) then
       obj.write_Info()
    else
-      obj.handle_Events() 
+      obj.handle_Events()
 end
 
 $endif

--- a/uni/udb/lib/structusage.icn
+++ b/uni/udb/lib/structusage.icn
@@ -35,14 +35,14 @@ $endif
    TableChange,    # Table events that indicate a change in the table
    RecordChange,   # Record events that indicate a change in the record
    SetChange,      # Set events that indicate a change in the set
-   
+
    structCountAll, # an int tracks all of the referenced structs (L+T+R+S)
    structCount,    # A record counts number of each created struct (L,T,R,S)
    structSize,     # A record counts the max size of each struct (L,T,R,S)
    structMostRef,  # A record tracks num of most referenced serial of a struct
    structMostSer,  # A record tracks the most referenced serial of a struct
    structUsage,    # A record counts references of each created struct (L,T,R,S)
-   structChange,   # A record counts each struct changes (create + modify) 
+   structChange,   # A record counts each struct changes (create + modify)
    structRead,     # A record counts each struct read (reference without change)
 
    Tlists,         # counts each list number of references
@@ -59,7 +59,7 @@ $endif
 method handle_Events()
    static Serial
 
-   Serial := serial(&eventvalue) 
+   Serial := serial(&eventvalue)
    if member(ListMask,&eventcode) then{
       structUsage.List +:= 1
       if structMostRef.List <:= Tlists[Serial] +:= 1 then
@@ -69,7 +69,7 @@ method handle_Events()
       if type(&eventvalue) == "list" then structSize.List <:= *&eventvalue
       if member(ListChange,&eventcode) then structChange.List +:= 1
       else                                  structRead.List   +:= 1
-      } 
+      }
    else if member(TableMask,&eventcode) then{
       structUsage.Table +:= 1
       if structMostRef.Table <:= Ttables[Serial] +:= 1 then
@@ -79,7 +79,7 @@ method handle_Events()
       if type(&eventvalue) == "table" then structSize.Table <:= *&eventvalue+1
       if member(TableChange,&eventcode) then structChange.Table +:= 1
       else                                   structRead.Table   +:= 1
-      }  
+      }
    else if member(SetMask,&eventcode) then{
       structUsage.Set +:= 1
       if structMostRef.Set <:= Tsets[Serial] +:= 1 then
@@ -89,7 +89,7 @@ method handle_Events()
       if type(&eventvalue) == "set" then structSize.Set <:= *&eventvalue
       if member(SetChange,&eventcode) then structChange.Set +:= 1
       else                                 structRead.Set   +:= 1
-      }  
+      }
    else if member(RecordMask,&eventcode) then{
       structUsage.Record +:= 1
       if structMostRef.Record <:= Trecords[Serial] +:= 1 then
@@ -108,11 +108,11 @@ end
 method update_Info()
 
   # Fields description:
-  # 1-Struct | 2-Number | 3-Num % | 4-Change % | 5-Read % | 6-Max 
+  # 1-Struct | 2-Number | 3-Num % | 4-Change % | 5-Read % | 6-Max
 
-  structCountAll := structCount.List   + structCount.Table + 
+  structCountAll := structCount.List   + structCount.Table +
                     structCount.Record + structCount.Set + 1
-   
+
   #StructUsageInfo[1][1] := "Lists"
    StructUsageInfo[1][2] := structCount.List
    StructUsageInfo[1][3] := structCount.List  * 100 / structCountAll
@@ -160,7 +160,7 @@ method write_Info()
    update_Info()
 
    write("\n-------------------------------------------------------------")
-   # 1-Struct   | 2-Number | 3-Num %    | 4-Max 
+   # 1-Struct   | 2-Number | 3-Num %    | 4-Max
    # 5-Change % | 6-Read % | 7-Most Used
    write("\n---- Structure Usage Info ----")
    write(left("Struct",10),  " : ",left("Number",10), " : ",
@@ -232,7 +232,7 @@ $ifndef StandAlone
    self.Listener.initially(name, state)
 $endif
 
-   eventMask   := cset(E_Exit || E_Error) ++ 
+   eventMask   := cset(E_Exit || E_Error) ++
                   cset(ListMask ++ TableMask ++ SetMask ++ RecordMask)
    ListChange  := cset(E_Lcreate||E_Lpop||E_Lpull||E_Lpush||E_Lput||E_Lget)
   #ListAccess  := cset(E_Lrand||E_Lsub||E_Lref||E_Lbang)
@@ -260,8 +260,8 @@ $endif
 
    # Fields description:
    # 1-Struct | 2-Number | 3-Num %    | 4-Change % |
-   # 5-Read % | 6-Max    | 7-MostUsed | 8-num of use 
-   StructUsageInfo := [["Lists"  ,0,0,0,0,0,0,0], 
+   # 5-Read % | 6-Max    | 7-MostUsed | 8-num of use
+   StructUsageInfo := [["Lists"  ,0,0,0,0,0,0,0],
                        ["Tables" ,0,0,0,0,0,0,0],
                        ["Records",0,0,0,0,0,0,0],
                        ["Sets"   ,0,0,0,0,0,0,0]]
@@ -270,7 +270,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -282,7 +282,7 @@ link evinit
 #
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
    obj := StructUsage()
 
@@ -290,23 +290,23 @@ procedure main(arg)
       if &eventcode == (E_Exit | E_Error) then
          obj.write_Info()
       else
-         obj.handle_Events() 
+         obj.handle_Events()
       }
    handle_Events() #fake call
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := StructUsage()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value
@@ -314,7 +314,7 @@ procedure handle_Events(code, value)
    if &eventcode == (E_Exit | E_Error) then
       obj.write_Info()
    else
-      obj.handle_Events() 
+      obj.handle_Events()
 end
 
 $endif

--- a/uni/udb/lib/typechange.icn
+++ b/uni/udb/lib/typechange.icn
@@ -1,14 +1,14 @@
 #
 # typechange.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 $include "evdefs.icn"
 
 #
 # This class Monitors the Variable type change that may occur during
-# the programs execution. It is considered a pad programming paractice 
+# the programs execution. It is considered a pad programming paractice
 #
 $ifndef StandAlone
 class TypeChange : Listener(
@@ -18,19 +18,19 @@ $endif
 
    eventMask,          # Cset with the monitored events
 
-   varTypeChangeCount, # A table maps variables into their num of type change 
+   varTypeChangeCount, # A table maps variables into their num of type change
    varLastTypeChange,  # A table maps variables into their actual type change
    TypeChangeInfo,     # A list the the updated type change info
    i, var, vname, oldtype
    )
 
 #
-# Suspicious change of a variable type 
+# Suspicious change of a variable type
 #
 method handle_Events()
    static var, vname, oldtype, i
    local  fname, line, pname, newtype
-   
+
    if &eventcode == E_Assign then{
       var := image(&eventvalue)[2:-1]
       if i := find("-"|"^"|"+",var) then{
@@ -53,15 +53,15 @@ end
 
 #
 # Updates the type changes info,
-# It receives the param j which is the most elapsed j loops 
+# It receives the param j which is the most elapsed j loops
 #
 method update_Info(j)
    local i:=1, k, var, vname, scope, fname, line, type_change, attrib
-   
+
    if \varTypeChangeCount & *varTypeChangeCount > 0 then{
       if /j then j := *varTypeChangeCount + 1
       else  j >=:= *varTypeChangeCount + 1
-   
+
       TypeChangeInfo := reverse(sort(varTypeChangeCount,2))[1:j]
       # 1-"Num"              |
       # 2-"File Name"        |
@@ -88,7 +88,7 @@ method update_Info(j)
               line,
               fname,
               i
-              )    
+              )
          i +:= 1
          }
       }
@@ -107,12 +107,12 @@ method write_Info( num )
    write("\n-------------------------------------------------------------")
    write("\n---- Type change's info [The Most (",num,") Thape change] ----")
    write(left("Num",3),              " : ",
-         left("File Name",10),       " : ",        
+         left("File Name",10),       " : ",
          left("Line #",6),           " : ",
          left("Var Name",10),        " : ",
          left("Scope",10),           " : ",
          left("Last Type Change",15)," : ",
-         left("Total Change",12) 
+         left("Total Change",12)
          )
    while i <= num &  \TypeChangeInfo do{
       write(left(TypeChangeInfo[i][1],3), " : ",
@@ -137,17 +137,17 @@ $ifndef StandAlone
 $endif
 
    eventMask          := cset(E_Exit || E_Error) ++ cset(E_Assign || E_Value)
-  
+
    varTypeChangeCount := table(0)
-   varLastTypeChange  := table("??") 
-   
+   varLastTypeChange  := table("??")
+
    TypeChangeInfo      := []
 end
 
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -156,12 +156,12 @@ link evinit
 #
 # This main procedure is only used in the standalone mode
 # or udb's external co-expression mode
-# 
+#
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
-   obj := TypeChange()   
+   obj := TypeChange()
 
    while EvGet(obj.eventMask) do{
       if &eventcode == (E_Exit | E_Error) then
@@ -173,17 +173,17 @@ procedure main(arg)
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
-   
+
    initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
-      obj := TypeChange()   
+      obj := TypeChange()
       return obj.eventMask
-      } 
+      }
 
    &eventcode  := code
    &eventvalue := value

--- a/uni/udb/lib/varprofile.icn
+++ b/uni/udb/lib/varprofile.icn
@@ -1,7 +1,7 @@
 #
 # varprofile.icn
 # Ziad Al-Sharif
-# June 1, 2008 
+# June 1, 2008
 #
 
 $include "evdefs.icn"
@@ -16,7 +16,7 @@ $else
 class VarProfile(
 $endif
 
-   eventMask,      # A cset of the Monitored events 
+   eventMask,      # A cset of the Monitored events
 
    procCallCount,  # Table maps procedur names to their number of calls
 
@@ -25,7 +25,7 @@ $endif
    GlobalVarType,  # Table maps local var names into their last type change
    GlobalVarTCount,# Table maps local var names into their number type change
 
-   LocalVar,       # A table with all of the local variables info 
+   LocalVar,       # A table with all of the local variables info
    LocalVarCount,  # Table maps local var names into their number of Deref
    LocalVarType,   # Table maps local var names into their last type change
    LocalVarTCount, # Table maps local var names into their number type change
@@ -36,12 +36,12 @@ $endif
 
 #
 # Checks for Dead Variables
-# The monitored events are E_Pcall, E_Deref 
+# The monitored events are E_Pcall, E_Deref
 #
 method handle_Events()
    static fname, pname
    local i,x, vtype
-   
+
    if &eventcode == E_Pcall then{
       pname := image(&eventvalue)
       pname := pname[find(" ", pname)+1: 0]
@@ -64,30 +64,30 @@ method handle_Events()
       else if i := find("-",&eventvalue) then{
          x := &eventvalue[1: i]
          if vtype := type(variable(x,Monitored,0)) then{
-            /LocalVarType[&eventvalue] := vtype 
+            /LocalVarType[&eventvalue] := vtype
             if LocalVarType[&eventvalue] ~==:= vtype then
                LocalVarTCount[&eventvalue] +:= 1
             LocalVarCount[&eventvalue] +:= 1
             fname := keyword("file",Monitored)
             LocalVar[&eventvalue] := fname||":"||&eventvalue
-            } 
-         } 
+            }
+         }
       }
 end
 
 #
 # Updates the Local variabls info,
-# it receives the param j which is the most important j Variables 
+# it receives the param j which is the most important j Variables
 #
 method update_LocalVarInfo(j)
    local i:=1, k,name, var, pname, fname, last_type
-   
+
    if \LocalVarCount & *LocalVarCount > 0 then {
       if /j then j := *LocalVarCount + 1
       else  j >=:= *LocalVarCount + 1
-  
+
       LocalVarInfo := reverse(sort(LocalVarCount,2))[1:j]
-      # 1-"File Name" | # 2-"Proc Name"   | # 3-"#Call"  | # 4-"Var Name" 
+      # 1-"File Name" | # 2-"Proc Name"   | # 3-"#Call"  | # 4-"Var Name"
       # 5-"Last Type" | # 6-"Change Type" | # 7-"#Deref" | # 8-"Avg(Deref/Call)"
       while i <= j  & \LocalVarInfo & LocalVarInfo[i][2] > 1 do{
          name := LocalVar[LocalVarInfo[i][1]]
@@ -108,12 +108,12 @@ method update_LocalVarInfo(j)
               fname
               )
          i +:= 1
-         } 
+         }
       }
 end
 
 #
-# Prints out the total time of a procedure call in ms 
+# Prints out the total time of a procedure call in ms
 # It is to be used in a console based application such as UDB
 #
 method write_LocalVarInfo( num )
@@ -121,7 +121,7 @@ method write_LocalVarInfo( num )
 
    update_LocalVarInfo(num)
    num := *LocalVarInfo + 1
-  
+
    write("\n-------------------------------------------------------------")
    write("\n---- [The Most (",num,") Local Variables] ----")
    write(left("File Name",10),  " : ",
@@ -149,17 +149,17 @@ end
 
 #
 # updates the Global variabls info,
-# it receives the param j which is the most important j Variables 
+# it receives the param j which is the most important j Variables
 #
 method update_GlobalVarInfo(j)
    local i:=1, k,name, var, pname, fname
-   
+
    if \GlobalVarCount & *GlobalVarCount > 0 then{
       if /j then j := *GlobalVarCount + 1
       else  j >=:= *GlobalVarCount + 1
-  
+
       GlobalVarInfo := reverse(sort(GlobalVarCount,2))[1:j]
-      # 1-"File Name" | # 2-"Proc Name"   | # 3-"#Call"  | # 4-"Var Name" 
+      # 1-"File Name" | # 2-"Proc Name"   | # 3-"#Call"  | # 4-"Var Name"
       # 5-"Last Type" | # 6-"Change Type" | # 7-"#Deref" | # 8-"Avg(Deref/Call)"
       while i <= j  & \GlobalVarInfo & GlobalVarInfo[i][2] > 1 do{
          name := GlobalVar[GlobalVarInfo[i][1]]
@@ -180,12 +180,12 @@ method update_GlobalVarInfo(j)
               fname
               )
          i +:= 1
-         } 
+         }
       }
 end
 
 #
-# Prints out the total time of a procedure call in ms 
+# Prints out the total time of a procedure call in ms
 # It is to be used in a console based application such as UDB
 #
 method write_GlobalVarInfo( num )
@@ -223,7 +223,7 @@ end
 # Initialize the global variables count,
 # This way will eliminate the built ins and the user defined procedures:)
 # This technique is not needed for the local variables.
-# 
+#
 method init_GlobalVarCount()
    local x
 
@@ -264,7 +264,7 @@ end
 #
 # StandAlone is defined when this tool is used as a stand-alone monitor.
 #  Otherwise, this tool can be statically linked into the main utop/udb
-#  source code 
+#  source code
 #
 $ifdef StandAlone
 
@@ -276,9 +276,9 @@ link evinit
 #
 procedure main(arg)
    local obj
-   
+
    EvInit(arg) | stop(" **** can not initialize Monitor !!!")
-   obj := VarProfile()   
+   obj := VarProfile()
 
    while EvGet(obj.eventMask) do{
       if &eventcode == (E_Exit | E_Error) then{
@@ -292,13 +292,13 @@ procedure main(arg)
 end
 
 #
-# This handle_Events procedure is only used udb's external 
+# This handle_Events procedure is only used udb's external
 # inter-program procedure calls
 #
 procedure handle_Events(code, value)
    static obj
 
-   initial{   
+   initial{
       #EvInit(arg) | stop(" **** can not initialize Monitor !!!")
       obj := VarProfile()
       return obj.eventMask
@@ -306,7 +306,7 @@ procedure handle_Events(code, value)
 
    &eventcode  := code
    &eventvalue := value
- 
+
    if &eventcode == (E_Exit | E_Error) then{
       obj.write_LocalVarInfo(10)
       obj.write_GlobalVarInfo(10)

--- a/uni/udb/srcfile.icn
+++ b/uni/udb/srcfile.icn
@@ -1,8 +1,8 @@
-#  
+#
 #  srcfile.icn: Handles the collected Source Files from the Icode
 #  Author:      Ziad Al-Sharif, zsharif@gmail.com
 #  Contributor: Gigi Young
-# 
+#
 
 $include "defaults.icn"
 
@@ -13,14 +13,14 @@ link basename
 
 #
 # It is used to index the loaded source files in the srcText list
-# 
+#
 record fileIndex(
    fbegin, # where the source file index starts in srcText
    fend    # where the source file index ends in srcText
    )
 
 #
-# Contains all of the source files issues such as found files and so  
+# Contains all of the source files issues such as found files and so
 #
 class SourceFile(
    procMainFile, # The Source File that has the procedure main
@@ -32,7 +32,7 @@ class SourceFile(
    libFiles,     # a set of the loaded library files
    incFiles,     # a set of the loaded included files
    foundFiles,   # Set with all file names that were found - loaded
-   missingFiles, # Set with all file names that were not found - not loaded 
+   missingFiles, # Set with all file names that were not found - not loaded
 
    fileNames,    # List with all source file names that are in the binary
    fileText,      # Table mapping filenames to lists of their contents by lineno
@@ -83,7 +83,7 @@ method loadSourceFiles(fname, src)
 end
 
 #
-# Reads the contents of filename to fileText (table mapping filename to a 
+# Reads the contents of filename to fileText (table mapping filename to a
 # list of strings)
 #
 method storeFileText(filename)
@@ -110,7 +110,7 @@ end
 method findDirectory(filename)
    local path, s, file
 
-   # source 
+   # source
    srcPath ? {
       while path := tab(find(";") | 0) do {
          s := path||PS||filename
@@ -118,15 +118,15 @@ method findDirectory(filename)
          if st := stat(s) then {
             #debug("\tfound '",s,"'")
             insert(userFiles,filename)
-            if p := getAbsDirectory(path) then 
+            if p := getAbsDirectory(path) then
                path := p
             return path
             }
          tab(many(';')) | break
          }
-      } 
+      }
 
-   # library files 
+   # library files
    libPath ? {
       while path := tab(find(";") | 0) do {
          s := path||PS||filename
@@ -134,15 +134,15 @@ method findDirectory(filename)
          if st := stat(s) then {
             #debug("\tfound '",s,"'")
             insert(libFiles,filename)
-            if p := getAbsDirectory(path) then 
-               path := p 
-            return path 
+            if p := getAbsDirectory(path) then
+               path := p
+            return path
             }
          tab(many(';')) | break
          }
-      } 
+      }
 
-   # includes 
+   # includes
    incPath ? {
       while path := tab(find(";") | 0) do {
          s := path||PS||filename
@@ -150,7 +150,7 @@ method findDirectory(filename)
          if st := stat(s) then {
             #debug("\tfound '",s,"'")
             insert(incFiles,filename)
-            if p := getAbsDirectory(path) then 
+            if p := getAbsDirectory(path) then
                path := p
             return path
             }
@@ -171,14 +171,14 @@ method getAbsDirectory(dir)
       }
 end
 
-# 
+#
 # Updates (curr_symtab) to reflect the execution of the given program
 # This includes changes made by commands 'up', 'down', and 'coexp'
 #
-method updateCurrSymtab(coState) 
+method updateCurrSymtab(coState)
    local filename, line
 
-   # normal program execution 
+   # normal program execution
    if coState.curr.val === coState.target.val then {
       filename := keyword("file",coState.curr.val,coState.curr.curr_frame)
       line := keyword("line",coState.curr.val,coState.curr.curr_frame)
@@ -191,7 +191,7 @@ method updateCurrSymtab(coState)
 
    # lookup symbol table scope with file/line
    if symt := symtab.lookup_fileline(filename, line) then {
-      curr_symtab := symt 
+      curr_symtab := symt
       #debug("current symbol table: ",curr_symtab.tag," ",curr_symtab.label)
       return
       }
@@ -210,7 +210,7 @@ end
 #
 method findProc(pname)
    if symt := symtab.lookup_name(pname) then {
-      if symt.tag == "proc" then 
+      if symt.tag == "proc" then
          return [symt.filename, symt.start_line, symt.end_line]
       }
 end
@@ -224,7 +224,7 @@ method findProcMethod(name)
    if type(x := curr_symtab.lookup_scope_name(name)) == "Symtab__state" &
       x.tag == ("proc"|"method") then {
       #debug(image(name),": ",x.tag," ",x.label)
-      return [x.filename, x.start_line, x.end_line] 
+      return [x.filename, x.start_line, x.end_line]
       }
 end
 
@@ -236,9 +236,9 @@ method findClassMethod(cls, mthd)
    local symt
    if symt := symtab.lookup_name(cls) then {
       if symt.tag == "class" & (symt := symt.lookup_name(mthd)) then {
-         if symt.tag == "method" then 
+         if symt.tag == "method" then
             return [symt.filename, symt.start_line, symt.end_line]
-         } 
+         }
       }
 end
 
@@ -254,7 +254,7 @@ method findPkgProc(pkg, pname)
          }
       }
 end
- 
+
 #
 # Looks for a class method (mthd) within package (pkg)
 #
@@ -285,9 +285,9 @@ method isProcedure(pname, pkg)
    local symt := symtab
    if \pkg then {
       if /(symt := symtab.pkgtab[pkg]) then fail
-      } 
+      }
    if \(x := symt.nametab[pname]) & type(x) == "Symtab__state" then {
-      if x.tag == "proc" & x.label == pname then return pname 
+      if x.tag == "proc" & x.label == pname then return pname
       }
 end
 
@@ -299,18 +299,18 @@ method isClass(cls, pkg)
    local symt := symtab
    if \pkg then {
       if /(symt := symtab.pkgtab[pkg]) then fail
-      } 
+      }
    if \(x := symt.nametab[cls]) & type(x) == "Symtab__state" then {
       if x.tag == "class" & x.label == cls then return cls
       }
 end
 
 #
-# Checks if var is global. If (pkg) is given, checks if var is global in (pkg). 
+# Checks if var is global. If (pkg) is given, checks if var is global in (pkg).
 #
 method isGlobal(var, pkg)
    local x, symt := symtab
-  
+
    if \pkg then {
       if /(symt := symtab.pkgtab[pkg]) then fail
       }
@@ -346,14 +346,14 @@ end
 # returns a list of all built-in functions used in the loaded program
 #
 method getFunctions()
-   local f, names := [] 
+   local f, names := []
 
    if *functions > 0 then{
       every f := !functions do
          push(names, f)
       return sortf(names)
       }
-   else 
+   else
       fail
 end
 
@@ -363,7 +363,7 @@ end
 #
 method isFunction(name)
 
-   if member(functions, name) then 
+   if member(functions, name) then
       return
    fail
 end
@@ -385,7 +385,7 @@ end
 #
 method isLocal(var)
    local x
-   if curr_symtab.tag ~== "global" & 
+   if curr_symtab.tag ~== "global" &
       \(x := curr_symtab.nametab[var]) & type(x) == "string" then {
       if x == "local" then return var
       }
@@ -395,7 +395,7 @@ end
 # Checks whether var is static in the current scope
 #
 method isStatic(var)
-   local x 
+   local x
    if \(x := curr_symtab.nametab[var]) & type(x) == "string" then {
       if x == "static" then return var
       }
@@ -418,7 +418,7 @@ end
 method getCurrGlobals()
    local globals := [], symt
 
-   symt := curr_symtab 
+   symt := curr_symtab
    while symt := \symt.parent do {
       if symt.tag == "package" then {
          #debug("found package ",symt.label)
@@ -457,7 +457,7 @@ method getCurrParams()
 end
 
 #
-# If pkg is null, returns all global variables outside of packages. 
+# If pkg is null, returns all global variables outside of packages.
 # If a package is specified, returns global variables from pkg.
 #
 method getGlobals(pkg)
@@ -465,9 +465,9 @@ method getGlobals(pkg)
 
    if /pkg then globals |||:= symtab.locals
    else {
-      if \(symt := symtab.pkgtab[pkg]) then 
+      if \(symt := symtab.pkgtab[pkg]) then
          every x := !symt.locals do put(globals, pkg||"__"||x)
-      } 
+      }
    return globals
 end
 
@@ -477,12 +477,12 @@ end
 #
 method getPackages(pkg)
    local globnames := [], prefix := ""
-   if /pkg then 
+   if /pkg then
       globnames |||:= symtab.packages
    else {
       if \(symt := symtab.pkgtab[pkg]) then {
             prefix := pkg||"__"
-         every x := !symt.globals do put(globnames, prefix||x) 
+         every x := !symt.globals do put(globnames, prefix||x)
          every x := !symt.procs do put(globnames,"procedure "||prefix||x)
          every x := !symt.records do put(globnames,"record "||prefix||x)
          every x := !symt.classes do put(globnames,"class "||prefix||x)
@@ -492,37 +492,37 @@ method getPackages(pkg)
 end
 
 #
-# If pkg is null, returns all procedures outside of packages. 
+# If pkg is null, returns all procedures outside of packages.
 # If a package is specified, returns procedures from pkg.
 #
 method getProcedures(pkg)
    local procs := [], symt
-   
+
    if /pkg then procs |||:= symtab.procs
    else {
-      if \(symt := symtab.pkgtab[pkg]) then 
+      if \(symt := symtab.pkgtab[pkg]) then
          every x := !symt.procs do put(procs, pkg||"__"||x)
       }
    return procs
 end
 
 #
-# If pkg is null, returns all records outside of packages. 
+# If pkg is null, returns all records outside of packages.
 # If a package is specified, returns records from pkg.
 #
 method getRecords(pkg)
    local records := [], symt
-   
+
    if /pkg then records |||:= symtab.records
    else {
-      if \(symt := symtab.pkgtab[pkg]) then 
-         every x := !symt.records do put(records, pkg||"__"||x) 
+      if \(symt := symtab.pkgtab[pkg]) then
+         every x := !symt.records do put(records, pkg||"__"||x)
       }
    return records
 end
 
 #
-# If pkg is null, returns all classes outside of packages. If a package is 
+# If pkg is null, returns all classes outside of packages. If a package is
 # specified, returns classes from pkg.
 # If cls is specified, then returns all members and methods from that class
 # if it exists (from pkg if specified, or from global scope if not).
@@ -546,11 +546,11 @@ method getClasses(pkg, cls)
       # get class fields
       if \(symt := symt.nametab[cls]) then {
          if type(symt) == "Symtab__state" & symt.tag == "class" then {
-            every x := !symt.locals do put(names,x) 
+            every x := !symt.locals do put(names,x)
             every x := !symt.methods do put(names,"method "||x)
-            return names  
-            } 
-         } 
+            return names
+            }
+         }
       else {
          write("\n   Could not find class",prefix,cls,". Please try again.")
          fail
@@ -560,8 +560,8 @@ method getClasses(pkg, cls)
    else if /pkg then classes |||:= symtab.classes
    # returns all classes from package [pkg] - /cls & \pkg
    else {
-      if \(symt := symtab.pkgtab[pkg]) then 
-         every x := !symt.classes do put(classes, pkg||"__"||x) 
+      if \(symt := symtab.pkgtab[pkg]) then
+         every x := !symt.classes do put(classes, pkg||"__"||x)
       }
    return classes
 end
@@ -576,7 +576,7 @@ end
 method isSrcFile(fname)
 
   if \fname then{
-     if not find(".icn", fname) then fname ||:= ".icn" 
+     if not find(".icn", fname) then fname ||:= ".icn"
      if member(foundFiles, fname) | member(missingFiles, fname) then
         return
      }
@@ -608,7 +608,7 @@ method getSourceFileSize(f)
   fstat := stat(f) | fail
   fsize := fstat.size
 
-  return fsize 
+  return fsize
 end
 
 #
@@ -649,14 +649,14 @@ method getSrcCode(fname)
    if not member(fileText, fname) then fail
 
    if \(text := fileText[fname]) then {
-      every line := 1 to *text do 
+      every line := 1 to *text do
          put(code, line||"\t"||text[line])
       return code
       }
 end
 
 #
-# returns a sorted list of all opend src file names 
+# returns a sorted list of all opend src file names
 #
 method getFoundFiles()
    local L
@@ -666,7 +666,7 @@ method getFoundFiles()
       return L
       }
    else
-      fail  
+      fail
 end
 
 #
@@ -695,7 +695,7 @@ end
 method getMissingFiles()
    local L
 
-   if *missingFiles > 0 then{ 
+   if *missingFiles > 0 then{
       L := sortf(missingFiles)
       return L
       }
@@ -708,7 +708,7 @@ end
 #
 method getSourceFiles()
    local L
-   
+
    if *fileNames > 0 then{
       L := sortf(fileNames)
       return L
@@ -722,7 +722,7 @@ end
 #
 method getUserFiles()
    local L
-   
+
    if *userFiles > 0 then{
       L := sortf(userFiles)
       return L
@@ -736,7 +736,7 @@ end
 #
 method getLibFiles()
    local L
-   
+
    if *libFiles > 0 then{
       L := sortf(libFiles)
       return L
@@ -763,10 +763,10 @@ end
 #
 method getSrcPath()
    local path
-   comp_dir := chdir(".")  
+   comp_dir := chdir(".")
    path := ". " || comp_dir
 
-   return path 
+   return path
 end
 
 #
@@ -817,7 +817,7 @@ end
 #
 # NOTE: need to add cmd to show dirs.. gdb: show directories | dir
 #
-method cmdShowDir(cmd) 
+method cmdShowDir(cmd)
    if *cmd = 2 then {
       write("Source directories: ",srcPath)
       return
@@ -826,7 +826,7 @@ method cmdShowDir(cmd)
       Message := "\n   Undefined Command: \""||DState.cmdHistory[1]||"\""||
                  "\n   Try \"help\" for assistance."
       write(Message)
-      } 
+      }
 end
 
 method reinit()

--- a/uni/udb/state.icn
+++ b/uni/udb/state.icn
@@ -71,7 +71,7 @@ method Write(Msg)
       if type(Msg) == "table" then {
          Msg := Msg["consoleMsg"]
       }
-         
+
       write(Msg)
    }
 

--- a/uni/udb/system.icn
+++ b/uni/udb/system.icn
@@ -1,7 +1,7 @@
 #
 # system.icn - Provides output and utility services for udb
 # Author - Gigi Young
-# 
+#
 
 import json
 
@@ -29,14 +29,14 @@ procedure debug(s[])
 end
 
 #
-# Reads and outputs the text output of system command (cmd) if successful. 
+# Reads and outputs the text output of system command (cmd) if successful.
 # Otherwise fails
 #
 procedure read_system_cmd(cmd)
    local file, s := ""
 
    file := open(cmd,"p") | fail
-   while s ||:= read(file) 
+   while s ||:= read(file)
    close(file)
    return s
 end
@@ -53,23 +53,23 @@ procedure get_win_term_dims()
       if tab(find("Lines:")) & move(6) & tab(many(ws)) then {
          term_lines := tab(many(&digits))
          if tab(find("Columns:")) & move(8) & tab(many(ws)) then {
-            term_cols := tab(many(&digits)) 
+            term_cols := tab(many(&digits))
             return [term_lines, term_cols]
             }
          }
-      } 
-   
+      }
+
 end
- 
+
 #
 # Simplified more function for UNIX. Should probably be checked for compatibilty
 #
 # Assigning (udb_no_more_flag) disables more(). Currently, passing --line to udb
 #    'udb --line [args]'
-# disables more. 
+# disables more.
 # Think about adding a udb command to disable more.
 #
-# A contender for being added to the Unicon library. Think about this 
+# A contender for being added to the Unicon library. Think about this
 # more later. Heh.
 #
 procedure more(L, msg)
@@ -83,17 +83,17 @@ procedure more(L, msg)
       every write(!L)
       return
       }
-   
+
    format_lines(L)
 
    prompt := "<Press 'b'/'f' to scroll back/forward, 'enter' for next line, " ||
              "'q' to quit>"
    total_lines := *L
-   curr_line := 1 
+   curr_line := 1
 
    # get terminal line and column info
 $ifdef _UNIX
-   term_lines := read_system_cmd("tput lines") 
+   term_lines := read_system_cmd("tput lines")
    term_cols := read_system_cmd("tput cols")
 $else
    term_lines := 25
@@ -119,29 +119,29 @@ $endif
       while c := getch() do {
          case c of {
             # get previous page
-            "b": { 
+            "b": {
                if curr_line - 2*page_lines < 1 then curr_line := 1
                else curr_line -:= 2*page_lines
                clear_line(*prompt)
                write("...back 1 page")
-               break 
+               break
                }
             # get next page
-            " "|"f": { 
+            " "|"f": {
                output_lines := page_lines
                clear_line(*prompt)
-               break 
+               break
                }
             # get next line
-            "\n": {  
+            "\n": {
                output_lines := 1
                clear_line(*prompt)
-               break 
+               break
                }
             # quit
-            "q": { 
+            "q": {
                clear_line(*prompt)
-               break break 
+               break break
                }
             }
          }
@@ -170,7 +170,7 @@ $else
 $endif
 
    i := 1
-   while i <= *L do { 
+   while i <= *L do {
       L[i] ? {
          start_pos := 1
          num_char := 0
@@ -184,8 +184,8 @@ $endif
                #write("adding: ",L[i][start_pos:&pos - 1])
                put(lines, L[i][start_pos:&pos - 1])
                start_pos := &pos - 1
-               num_char := 0 
-               } 
+               num_char := 0
+               }
             }
          }
       if *lines > 0 then {
@@ -200,7 +200,7 @@ $endif
          }
       else i +:= 1
       }
-      
+
 end
 
 #
@@ -212,10 +212,10 @@ procedure clear_line(len)
    writes("\r")
 end
 
-# 
-# Inserts string s into list L in alphabetical order 
+#
+# Inserts string s into list L in alphabetical order
 # Assumes that L is sorted already
-# 
+#
 procedure insert_sorted(L, s)
    local size := *L , i := (size+1)/2, lower := 1, upper := *L, rv
 
@@ -223,13 +223,13 @@ procedure insert_sorted(L, s)
 #   every j := 1 to *L do write("L[",j,"]: ", L[j])
 
    if size = 0 then put(L, s)
-   else { 
+   else {
       while lower <= upper do {
       #repeat {
          rv := str_cmp(s, L[i])
 #            write(s," vs ",L[i]," - ",rv)
 #            write(rv,": ",lower," ",i," ",upper)
-         if rv = 0 then { 
+         if rv = 0 then {
             insert(L, i, s)
             break
             }
@@ -268,12 +268,12 @@ end
 # returns -1 if s1 is lexically greater than s2,
 # or returns 0 if s1 is lexically equal to s2.
 #
-procedure str_cmp(s1, s2) 
-   local i1 := i2 := 1 
+procedure str_cmp(s1, s2)
+   local i1 := i2 := 1
 
    repeat {
       if i1 > *s1 then return -1
-      if i2 > *s2 then return 1 
+      if i2 > *s2 then return 1
 
       c1 := ord(s1[i1])
       c2 := ord(s2[i2])
@@ -281,13 +281,13 @@ procedure str_cmp(s1, s2)
          i1 +:= 1
          i2 +:= 1
          }
-      else if c1 < c2 then return -1   
+      else if c1 < c2 then return -1
       else return 1
-      } 
+      }
    c1 := ord(s1[i1])
    c2 := ord(s2[i2])
    if c1 = c2 then return 0
-   else if c1 < c2 then return -1   
+   else if c1 < c2 then return -1
    else return 1
 end
 

--- a/uni/udb/udb.icn
+++ b/uni/udb/udb.icn
@@ -1,6 +1,6 @@
 #
-# udb.icn- main udb Console Session, 
-# latter will handle both Console and GUI Interface through 
+# udb.icn- main udb Console Session,
+# latter will handle both Console and GUI Interface through
 # a command line options
 # Author  : Ziad Al-Sharif
 # e-mail  : zsharif@gmail.com

--- a/uni/uflex/uflexskel.icn
+++ b/uni/uflex/uflexskel.icn
@@ -192,7 +192,7 @@ fprintf(f, "%s",
    \      }\n_
    \   return answer\n_
    end\n\n");
-   
+
 fprintf(f, "%s",
    "# \"recset\" == \"regular expression cset\"\n_
     procedure csetfromrecset(recset)\n_

--- a/uni/ulsp/lsif.icn
+++ b/uni/ulsp/lsif.icn
@@ -328,7 +328,7 @@ class LSIFIndexer(
 
    #<p>
    #   Creates a definitionResult vertex and a textDocument/definition edge that links a given range
-   #   vertex to a resultSet vertex.   
+   #   vertex to a resultSet vertex.
    #   <i>Used internally.</i>
    #   <[param resultSetID The result set of the token that is being hovered over.]>
    #   <[param rangeID The range of the token that is being hovered over.]>
@@ -356,7 +356,7 @@ class LSIFIndexer(
 
    #<p>
    #   Creates a referenceResult vertex and a textDocument/references edge that links a given range
-   #   vertex to a resultSet vertex.  
+   #   vertex to a resultSet vertex.
    #   <i>Used internally.</i>
    #   <[param outID The result set that this reference belongs to.]>
    #   <[param property Either "definitions" or "references".]>

--- a/uni/ulsp/signature.icn
+++ b/uni/ulsp/signature.icn
@@ -67,7 +67,7 @@ class SignatureHandler(
       local _context, sig_tables := [], methodName, objectName, linked_classes, imported_classes,
          internal_classes, package_classes, objects, className, built_in_functions, linked_procedures,
          imported_procedures, internal_procedures, package_procedures, line, charNum
-      
+
       currentSigItems := []
 
       # Collect context information (inside comment, space before, object before, no object before) #

--- a/uni/ulsp/symbols.icn
+++ b/uni/ulsp/symbols.icn
@@ -24,7 +24,7 @@ class SymbolHandler(filehandler)
             class_name, class_table, class_range, class_selectionRange, method_name,
             method_table, method_range, method_selectionRange, variable_name, class_symbol,
             method_symbol, pos_table, sl, sc, el, ec, entity_table, proc_symbol, var_symbol,
-            initially_table, initially_range, initially_selectionRange, variable_selectionRange, 
+            initially_table, initially_range, initially_selectionRange, variable_selectionRange,
             results_list
       results_list := []
       pos_table := filehandler.getInternalPositions()

--- a/uni/unidep/filearg.icn
+++ b/uni/unidep/filearg.icn
@@ -33,7 +33,7 @@ import parser
 # their package is removed from this set.  If the final value is non-empty, then an
 # error occurs.  This prevents compilation errors when a file tries to import
 # an un-needed package before any files have been added to that package.
-# 
+#
 class FileArg(file,
               parsed_program,
               local_package_level_syms,
@@ -116,12 +116,12 @@ class FileArg(file,
    # objects.  The table's contents are later added to the global
    # symbol table, before init2() is called.
    #
-   method init1(file) 
+   method init1(file)
       local sym, si, cl, fc
       self.file := file
       self.parsed_program := ParsedProgram(parse_unicon(file)) |
 	 err("Couldn't parse " || file)
-      
+
       self.local_package_level_syms := table()
       self.local_package_level_class_syms := table()
 
@@ -136,7 +136,7 @@ class FileArg(file,
          si.file := self.file
          si.name := sym
          si.package_name := \parsed_program.package_name
-         si.filearg := self 
+         si.filearg := self
          insert(local_package_level_syms, sym, si)
 	 }
 
@@ -162,7 +162,7 @@ class FileArg(file,
 
       return
    end
-   
+
    #
    # The second init stage creates a table of imported symbols.  This
    # is a map from symbol name to a list of SymbolInfo objects.  So if
@@ -184,7 +184,7 @@ class FileArg(file,
          # Process each symbol in the package.
          every x := !sort(t) do {
             if member(imported_syms, x[1]) then
-               l := imported_syms[x[1]] 
+               l := imported_syms[x[1]]
             else {
                l := []
                insert(imported_syms, x[1], l)
@@ -194,7 +194,7 @@ class FileArg(file,
             # Same for the classes table, if it is a class.
             if \x[2].is_class then {
                if member(imported_class_syms, x[1]) then
-                  l := imported_class_syms[x[1]] 
+                  l := imported_class_syms[x[1]]
                else {
                   l := []
                   insert(imported_class_syms, x[1], l)
@@ -239,7 +239,7 @@ class FileArg(file,
             add_deps_for_function(m, fc.get_inherited_syms())
       }
       every p := !parsed_program.procedures do
-         add_deps_for_function(p) 
+         add_deps_for_function(p)
 
       include_files := get_include_dependencies(self.file)
 
@@ -334,7 +334,7 @@ class FileArg(file,
                         if member(t, node.children[3].s) then {
                            si := t[node.children[3].s]
                            if \si.filearg then {
-                              if \debug then 
+                              if \debug then
                                  write("creating dependency on absolute ",
 				       "reference si=", si.to_string())
                               add_dep(si)
@@ -389,7 +389,7 @@ class FileArg(file,
 
          node := lhs
       }
-      
+
       scopecheck_expr(node, res1, res2, local_vars, self_vars)
    end
 
@@ -411,7 +411,7 @@ class FileArg(file,
       local l
       \symbol_info.filearg | stop("internal error")
 
-      if symbol_info.filearg === self then 
+      if symbol_info.filearg === self then
          return
 
       if member(filearg_dependencies, symbol_info.filearg) then

--- a/uni/unidep/fileargclass.icn
+++ b/uni/unidep/fileargclass.icn
@@ -58,7 +58,7 @@ class FileArgClass(parent,
                # in one of the fileargs.
                #
                if si := symbol_table.lookup_unqualified_symbol_info(sn) then
-                  # 
+                  #
                   # Must be a filearg, as that part of the symbol table only holds default pacakge filearg classes.
                   #
                   do_filearg(si)
@@ -151,7 +151,7 @@ class FileArgClass(parent,
       #
       every do_lookup(!ci.get_supers())
    end
-   
+
    # debug function
    method show_inherited_syms()
       write("Inherited syms for class " || parsed_class.get_name() || " in file " || parent.file)

--- a/uni/unidep/main.icn
+++ b/uni/unidep/main.icn
@@ -41,20 +41,20 @@ procedure main(a)
       symbol_table.dump()
 
    every a := !all_fileargs do
-      a.init2() 
+      a.init2()
 
    every a := !all_fileargs do
-      a.init3() 
+      a.init3()
 
    every a := !all_fileargs do
-      a.init4() 
-      
+      a.init4()
+
    if \debug then
       write("doing final checks")
 
    every a := !all_fileargs do {
       a.check_for_unused_imports()
-      a.circle_check() 
+      a.circle_check()
    }
 
    if \opts["r"] then {
@@ -75,7 +75,7 @@ procedure main(a)
             t ||:= " " || convert_filename(fa.file) | err("expected a .icn file:" || fa.file)
          put(lines, t)
       }
-      if s := \opts["f"] then 
+      if s := \opts["f"] then
          output_to(s, lines)
       else {
          if stat("makefile") then
@@ -84,7 +84,7 @@ procedure main(a)
             output_to("Makefile", lines)
          else
             stop("No makefile to output to", lines)
-      }         
+      }
    }
 
    return

--- a/uni/unidep/symbolinfo.icn
+++ b/uni/unidep/symbolinfo.icn
@@ -17,7 +17,7 @@
 # is_class is a flag indicating whether or not the sym represents a class (may
 # or may not be external; if not then filearg_class will also be set).
 #
-class SymbolInfo(name, 
+class SymbolInfo(name,
                  file,
                  package_name,
                  filearg_class,

--- a/uni/unidep/symboltable.icn
+++ b/uni/unidep/symboltable.icn
@@ -21,7 +21,7 @@ import parser
 # is a map of class names in the default namespace, defined in the FileArgs.  The values
 # are the corresponding SymbolInfo objects.
 #
-class SymbolTable(packages, 
+class SymbolTable(packages,
                   external_packages_loaded,
                   default_namespace
                   )
@@ -63,7 +63,7 @@ class SymbolTable(packages,
       local pi, t, classes, sym, si
 
       if member(external_packages_loaded, name) then
-         return 
+         return
       insert(external_packages_loaded, name)
 
       pi := parser::load_package_info(name) | fail

--- a/uni/unidep/util.icn
+++ b/uni/unidep/util.icn
@@ -27,7 +27,7 @@ procedure resolve_include(incl)
    }
 
    if s := \include_cache[incl] then
-      return s 
+      return s
 
    # Current directory
    if stat(incl) then {

--- a/uni/unidoc/UniAll.icn
+++ b/uni/unidoc/UniAll.icn
@@ -29,7 +29,7 @@ global fixName
 #  The UniAll class holds the entire internal form of a Unicon
 #    documentation set.
 #</p>
-class UniAll : Object (files, packages, 
+class UniAll : Object (files, packages,
                       curFile, curClass, curPackage, curComments, fileHead,
                       uniFile, resolveFlag, targetDir, saveSrcFlag,
                       importSet, linkSet, badFiles, sourcePath, uniFilez)
@@ -83,7 +83,7 @@ class UniAll : Object (files, packages,
     #
     method addFile(fName)
         if curFile := /files[fName] := UFile(fName) then {
-            if \saveSrcFlag then 
+            if \saveSrcFlag then
                 curFile.setSrcFile(uniFile.getFilename())
             return curFile
             }
@@ -94,7 +94,7 @@ class UniAll : Object (files, packages,
     # </p>
     method addTag(obj)
         if uniFile.hasSource() then {
-            if \saveSrcFlag then 
+            if \saveSrcFlag then
                 obj.setSrcFile(uniFile.getFilename())
             tag := obj.getFormType()||"_"||obj.getName()
             uniFile.setTag(tag)
@@ -165,7 +165,7 @@ class UniAll : Object (files, packages,
                    UniFile(fName, genDirs(\sourcePath)) | {
                    insert(badFiles, fName)
                    fail
-                   } 
+                   }
 
         if \contents then {
             if \uniFile := uniFilez[fName] then {
@@ -190,9 +190,9 @@ class UniAll : Object (files, packages,
 
             uniFilez[fName] := uniFile
             }
-        
+
         # See if we need to resolve imports and links...
-        
+
         if \resolveFlag then {     # Yep...
 
             cleanSets()
@@ -209,7 +209,7 @@ class UniAll : Object (files, packages,
 
             }
 
-            
+
     end
 
     #<p>
@@ -316,17 +316,17 @@ class UniAll : Object (files, packages,
         token := uniFile.nextToken() | fail
 
         #write("token = " || ximage(token))
-    
+
         case token.Type() of {
             "UniDoc::BlankLine" : processBlank(uniFile)
             "UniDoc::Comment"   : processComment(uniFile, token.value)
             "UniDoc::Keyword"   : processKeyword(uniFile, token.value)
             }
-    
+
         uniFile.clearLine()
         return
     end
-    
+
     # <p>
     #   Process a blank line.  Blank lines are only interesting
     #   in that they serve to distinguish comment blocks.
@@ -339,7 +339,7 @@ class UniAll : Object (files, packages,
             }
         curComments := Comments()    # discard current comment block
     end
-    
+
     # <p>
     #   Process a comment.
     # </p>
@@ -347,7 +347,7 @@ class UniAll : Object (files, packages,
     method processComment(f, s)
         curComments.add(s)
     end
-    
+
     # <p>
     # Process a keyword.  Not all keywords are interesting.  Many
     # are simply ignored.
@@ -366,7 +366,7 @@ class UniAll : Object (files, packages,
             "record"    : processRecord(f)
             }
     end
-    
+
     # <p>
     # There are places in a Unicon program where an entity may be
     # represented by either a <i>name</i> or a <i>string</i>.
@@ -397,7 +397,7 @@ class UniAll : Object (files, packages,
         curPackage.addFile(curFile)
         packages["(main)"].delFile(curFile.getName())
     end
-    
+
     # <p>
     # Process an import statement.
     # </p>
@@ -434,9 +434,9 @@ class UniAll : Object (files, packages,
                 sawComma := &null
                 }
             }
-    
+
     end
-    
+
     # <p>
     # Process a link statement.
     # </p>
@@ -474,9 +474,9 @@ class UniAll : Object (files, packages,
                 sawComma := &null
                 }
             }
-    
+
     end
-    
+
     # <p>
     # Process a class header.  If there's an <b>initially</b> clause that
     # will get tacked on later.
@@ -539,7 +539,7 @@ class UniAll : Object (files, packages,
                 curClass.addField(field)
                 }
             }
-    
+
         if not f.EOS() then {
             token := f.nextToken()
             if token.Type() == "UniDoc::Comment" then {
@@ -607,7 +607,7 @@ class UniAll : Object (files, packages,
 
         return glob
     end
-    
+
     # <p>
     # Process an initially clause, treating it as a class
     # constructor.
@@ -646,7 +646,7 @@ class UniAll : Object (files, packages,
         else {
             f.pushback(token)
             }
-    
+
         if not f.EOS() then {
             token := f.nextToken()
             if token.Type() == "UniDoc::Comment" then {
@@ -654,13 +654,13 @@ class UniAll : Object (files, packages,
                 }
             else f.pushback(token)
             }
-        
+
         # No param list on constructor, so assume all fields!
         if /const.getParams() then {
             const.setParams(curClass.getParams())
             }
     end
-    
+
     # <p>
     # Process a method definition.
     # </p>
@@ -684,7 +684,7 @@ class UniAll : Object (files, packages,
         else if token.Type() ~== "UniDoc::LParen" then {
             f.pushback(token)
             }
-        
+
         while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
             if token.Type() == "UniDoc::Comma" then {
                 next
@@ -703,7 +703,7 @@ class UniAll : Object (files, packages,
                 met.addParam(param)
                 }
             }
-    
+
         if not f.EOS() then {
             token := f.nextToken()
             if token.Type() == "UniDoc::Comment" then {
@@ -711,9 +711,9 @@ class UniAll : Object (files, packages,
                 }
             else f.pushback(token)
             }
-        
+
     end
-    
+
     # <p>
     # Process a procedure definition.
     # </p>
@@ -738,7 +738,7 @@ class UniAll : Object (files, packages,
         else if token.Type() ~== "UniDoc::LParen" then {
             f.pushback(token)
             }
-        
+
         while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
             if token.Type() == "UniDoc::Comma" then {
                 next
@@ -757,7 +757,7 @@ class UniAll : Object (files, packages,
                 proced.addParam(param)
                 }
             }
-    
+
         if not f.EOS() then {
             token := f.nextToken() | fail
             if token.Type() == "UniDoc::Comment" then {
@@ -766,7 +766,7 @@ class UniAll : Object (files, packages,
             else f.pushback(token)
             }
     end
-    
+
     # <p>
     # Process a global statement.
     # </p>
@@ -800,7 +800,7 @@ class UniAll : Object (files, packages,
 
             uniFile.setInside()                # re-enable Unicon keywords
     end
-    
+
     # <p>
     # Process a record definition.
     # </p>
@@ -825,7 +825,7 @@ class UniAll : Object (files, packages,
         else if token.Type() ~== "UniDoc::LParen" then {
             f.pushback(token)
             }
-        
+
         while (token := f.nextToken()).className() ~== "UniDoc::RParen" do {
             if token.Type() == "UniDoc::Comma" then {
                 next
@@ -844,7 +844,7 @@ class UniAll : Object (files, packages,
                 rec.addField(field)
                 }
             }
-    
+
         if not f.EOS() then {
             token := f.nextToken()
             if token.Type() == "UniDoc::Comment" then {
@@ -852,13 +852,13 @@ class UniAll : Object (files, packages,
                 }
             else f.pushback(token)
             }
-        
+
             uniFile.setInside()                # re-enable Unicon keywords
     end
 
     # <p>
     # Produce a table of all methods that are inherited by
-    #   a class.  Keys are superclasses, entries are 
+    #   a class.  Keys are superclasses, entries are
     #   UniDoc::Set()s of methods.
     # </p>
     method inherited(aClass)
@@ -888,7 +888,7 @@ class UniAll : Object (files, packages,
     #    given a table whose keys are superclasses.
     # </p>
     method makeNameTab(aTab)
-        
+
         nTab := table()
         every sc := key(aTab) do {
             nTab[sc.getName()] := sc
@@ -896,7 +896,7 @@ class UniAll : Object (files, packages,
         every put(nList := [], (!sort(nTab))[2])
         return nList
     end
-            
+
     # <p>
     # Produce a list of <i>all</i> packages.
     # </p>

--- a/uni/unidoc/UniFile.icn
+++ b/uni/unidoc/UniFile.icn
@@ -213,13 +213,13 @@ class UniFile : Object (iKeySet, uKeySet, oldTokens, buffer, line, fName,
                         return line
                         }
                     else {  # Hard cases, might have continuation
-    
+
                         if ="#" then {          # Easy
                             line := buffer
                             clearBuffer()
                             return line
                             }
-    
+
                         if =";" then {          # Not too hard
                             #  (We're not going to care about anything
                             #  else on the line...)
@@ -236,7 +236,7 @@ class UniFile : Object (iKeySet, uKeySet, oldTokens, buffer, line, fName,
                                 break
                                 }
                             }
-    
+
                         if ="\"" then {         # Harder
                             if not (line ||:= matchString()) then {
                                 # Must be a continued string!
@@ -246,19 +246,19 @@ class UniFile : Object (iKeySet, uKeySet, oldTokens, buffer, line, fName,
                                 break
                                 }
                             }
-    
+
                         }
                     }
                 }
                 lineNum +:= 1
             }
-            
-    
+
+
         if *buffer > 0 then {
             line := buffer
             clearBuffer()
             }
-    
+
     end
 
     # <p>
@@ -331,15 +331,15 @@ class UniFile : Object (iKeySet, uKeySet, oldTokens, buffer, line, fName,
         cBuf := CodeBuf()
         setSaveSrc("yes")
         lineNum := 0
-        # String scanning to populate something that is storing all the file contents when the file is closed 
+        # String scanning to populate something that is storing all the file contents when the file is closed
         contents ? {
                 while  curLine := tab(upto('\n') | 0) do {
-                    cBuf.add(curLine) 
+                    cBuf.add(curLine)
                     ="\n" | break
-                }          
+                }
             }
-    end 
-    
+    end
+
     method readFile(f)
         cBuf := CodeBuf()
         while line := read(f) do cBuf.add(line)

--- a/uni/unidoc/UniForm.icn
+++ b/uni/unidoc/UniForm.icn
@@ -99,7 +99,7 @@ class Sequence : Object (contents, comments)
                 }
             }
     end
-    
+
     initially
         /contents := []
         /comments := Comments()
@@ -456,7 +456,7 @@ class URecord : UEntity (name, parent, comments, fields)
 end
 
 # <p>
-# An import 
+# An import
 # </p>
 class UImport : UEntity (name, parent, comments)
 
@@ -489,7 +489,7 @@ class UClass : UEntity ( name, parent, comments, constructor,
              }
         name := newName
     end
-        
+
     # <p>
     # Return the full name (with package name included) for this class.
     # </p>

--- a/uni/unidoc/UniHTML.icn
+++ b/uni/unidoc/UniHTML.icn
@@ -315,7 +315,7 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
         outputUrlList(page, "Methods:",          mkList(aClass.getMethods()))
         outputInheritedMethods(page, aClass)
         outputUrlList(page, "Fields:",           mkList(aClass.getParams()))
-        sRef := displaySrcURL(aClass, "Source code.") 
+        sRef := displaySrcURL(aClass, "Source code.")
         if sRef ~== "Source code." then {
             write(page, "<b><i>", sRef, "</i></b><p></p>")
             }
@@ -391,7 +391,7 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
         write(page, "<p>This file is part of the <b>",
                         displayURL(getURL(p), p.getName()),
                        "</b> package.</p>")
-        sRef := displaySrcURL(aFile, "Source code.") 
+        sRef := displaySrcURL(aFile, "Source code.")
         if sRef ~== "Source code." then {
             write(page, "<b><i>", sRef, "</i></b><p></p>")
             }
@@ -414,7 +414,7 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
     # </p>
     method outputMethods(page, label, aClass)
         local metd, mList
-    
+
         mList := mkList(aClass.getMethods())
         if *mList > 0 then {
             outputHeading(page, label, "+2", "#eeeeff")
@@ -468,7 +468,7 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
                 }
             }
     end
-    
+
     # <p>
     # <i>This is intended for internal use only!</i>
     # </p>
@@ -495,7 +495,7 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
             outputUrlList(page, &null, aList)
             }
     end
-    
+
     # <p>
     # <i>This is intended for internal use only!</i>
     # </p>
@@ -523,13 +523,13 @@ class UniHTML : Object (title, idoc, mainIndex, linkPath,
         /fileMap[obj] := mkURL(obj)
         return fileMap[obj]
     end
-    
+
     # <p>
     # <i>This is intended for internal use only!</i>
     # </p>
     method mkURL(obj)
         local bName, pName, cat, p, nObj
-    
+
         bName := obj.getName()
         case obj.className() of {
             "UniDoc::ULink"       |
@@ -659,7 +659,7 @@ end
 procedure getTagFromURL(url)
     reverse(url) ? return reverse(tab(upto('#'))||move(1))
 end
-        
+
 # <p>
 # <i>This is intended for internal use only!</i>
 # </p>
@@ -815,7 +815,7 @@ procedure stripParagraph(s)
                2(="<pre>\n",tab(-*"</pre>\n"),="</pre>\n")
     return s
 end
-        
+
 
 # <p>
 # <i>This is intended for internal use only!</i>
@@ -833,31 +833,31 @@ procedure cmts2html(comments)
             s ||:= if cblock.isLegacy() then "</pre>\n"
             }
         s := checkSpecial(s, keyMap)
-        if \(throws := keyMap["throws"]) then {   
+        if \(throws := keyMap["throws"]) then {
             t := "\n<b>Throws:</b> "
             t ||:= "<table>\n"
             while t ||:= ::get(throws)
             s1 := t || "\n</table>\n" || s1
             }
-        if \(fails := keyMap["fails"]) then {   
+        if \(fails := keyMap["fails"]) then {
             t := "\n<b>Fails:</b> "
             t ||:= "<table>\n"
             while t ||:= ::get(fails)
             s1 := t || "\n</table>\n" || s1
             }
-        if \(returns := keyMap["returns"]) then {   
+        if \(returns := keyMap["returns"]) then {
             t := "\n<b>Returns:</b> "
             t ||:= "<table>\n"
             while t ||:= ::get(returns)
             s1 := t || "\n</table>\n" || s1
             }
-        if \(generates := keyMap["generates"]) then {   
+        if \(generates := keyMap["generates"]) then {
             t := "\n<b>Generates:</b> "
             t ||:= "<table>\n"
             while t ||:= ::get(generates)
             s1 := t || "\n</table>\n" || s1
             }
-        if \(params := keyMap["params"]) then {   
+        if \(params := keyMap["params"]) then {
             t := "\n<b>Parameter"||(if *params > 1 then "s" else "")||":</b> "
             t ||:= "<table>\n"
             while t ||:= ::get(params)

--- a/uni/xml/attlist.icn
+++ b/uni/xml/attlist.icn
@@ -35,7 +35,7 @@ class AttList(attribute_defs, has_id)
    #
    # Add an attribute def; called during parsing.
    #
-   method add_attribute_def(name, def) 
+   method add_attribute_def(name, def)
       insert(attribute_defs, name, def)
       if \def.def_type == "ID" then
          has_id := 1

--- a/uni/xml/attributedef.icn
+++ b/uni/xml/attributedef.icn
@@ -17,14 +17,14 @@ package xml
 #            ENUMERATION for an enumerated type
 # def_set is the set of enumerations for NOTATION/ENUMERATION types.
 # default_decl is #REQUIRED, #IMPLIED or #FIXED, or null
-# default_value is the default value, or null; can only be non-null when 
+# default_value is the default value, or null; can only be non-null when
 #                 default_decl is #FIXED or null
 # in_ext_subset  indicates whether this declaration occurred in the external DTD subset;
 #                needed for validation.
 #
-class AttributeDef(def_type, 
-                   def_set, 
-                   default_decl, 
+class AttributeDef(def_type,
+                   def_set,
+                   default_decl,
                    default_value,
                    in_ext_subset)
    #

--- a/uni/xml/canonicalxmlformatter.icn
+++ b/uni/xml/canonicalxmlformatter.icn
@@ -32,7 +32,7 @@ class CanonicalXmlFormatter : XmlFormatter()
 
       if *n.parent.notation_declarations = 0 then
          return ""
-      
+
       s := "<!DOCTYPE " || n.name
       s ||:= " [\n"
       every x := !sort(n.parent.notation_declarations) do {

--- a/uni/xml/contentspec.icn
+++ b/uni/xml/contentspec.icn
@@ -165,7 +165,7 @@ class ContentSpec(op, arg1, arg2, is_mixed_flag)
             return "(" || s || x.arg2.to_string() || ")"
          }
 
-         "+" | "*" | "?" : 
+         "+" | "*" | "?" :
             return arg1.to_string() || op
       }
    end

--- a/uni/xml/defaultresolver.icn
+++ b/uni/xml/defaultresolver.icn
@@ -15,7 +15,7 @@ import http, net
 # The default resolver resolves from a URL or the local file system.
 #
 # If the system id begins with "http://", it is treated as a web URL, and
-# loaded over the network.  
+# loaded over the network.
 #
 # If it begins with "file://", then it is treated as a
 # local file (for an absolute path on Unix like systems, that would be
@@ -29,8 +29,8 @@ class DefaultResolver : Resolver(public_mapping, uri_cache, cache_uris_flag)
    # will then be loaded when the public id is encountered, rather than the
    # given system id.  The alternative may be a simple filename if desired.
    #
-   # @example 
-   # @  set_public_mapping("-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN", 
+   # @example
+   # @  set_public_mapping("-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN",
    # @                     "/tmp/web-app_2_3.dtd")
    # @param pub_id the public id
    # @param uri the alternative uri

--- a/uni/xml/doctype.icn
+++ b/uni/xml/doctype.icn
@@ -50,12 +50,12 @@ class DocType : Node(name, external_id)
    #
    # Get a string representation of this object.
    #
-   method to_string() 
+   method to_string()
       local s
       s := (\external_id).to_string() | image(external_id)
       return "DocType[" || image(name) || "," || s || "]"
    end
-   
+
    initially()
       self.Node.initially()
 end

--- a/uni/xml/entitydef.icn
+++ b/uni/xml/entitydef.icn
@@ -12,7 +12,7 @@ package xml
 # Represents the definition of an entity.
 #
 class EntityDef(str,
-                external_id, 
+                external_id,
                 notation,
                 in_ext_subset)
 

--- a/uni/xml/globaldemo.icn
+++ b/uni/xml/globaldemo.icn
@@ -45,7 +45,7 @@ procedure main()
    query := body.search_children_global_name(query_name) | stop("No query")
 
    every child := query.search_children() do {
-      write("Child ", child.get_global_name().to_string(), 
+      write("Child ", child.get_global_name().to_string(),
             " type=", image(child.get_attribute_global_name(type_name)),
             " text=", image(child.get_string_content()))
    }

--- a/uni/xml/globalname.icn
+++ b/uni/xml/globalname.icn
@@ -26,7 +26,7 @@ package xml
 class GlobalName(local_name, uri)
    #
    # Return the original tag local_name
-   # 
+   #
    method get_local_name()
       return local_name
    end

--- a/uni/xml/htmlelement.icn
+++ b/uni/xml/htmlelement.icn
@@ -12,7 +12,7 @@ class HtmlElement : Element()
    #
    # Set the name of the element, which is converted to upper case.
    #
-   method set_name(s) 
+   method set_name(s)
       self.Element.set_name(map(s, &lcase, &ucase))
    end
 

--- a/uni/xml/htmlparser.icn
+++ b/uni/xml/htmlparser.icn
@@ -15,7 +15,7 @@ class Tag : Node(name, closed, attributes, empty)
    # Set the name of the tag, which is converted to upper case.  Any
    # leading "/" should be omitted.
    #
-   method set_name(s) 
+   method set_name(s)
       return name := map(s, &lcase, &ucase)
    end
 
@@ -100,13 +100,13 @@ class HtmlParser : Parser(doc)
             node := parse_node() | break
 
             case node.get_type() of {
-               "doctype" : 
+               "doctype" :
                   doc.add_child(node)
 
                "comment" : {
                   doc.add_child(node)
                }
-               
+
                "tag" : {
                   if not(node.is_closed()) & (node.name == "HTML") then {
                      #
@@ -154,12 +154,12 @@ class HtmlParser : Parser(doc)
       res.name := start_tag.name
       res.attributes := start_tag.attributes
 
-      if \debug then 
+      if \debug then
          print_debug("Parsing node ", start_tag.name)
 
       if start_tag.name == "PLAINTEXT" then
          res.add_child("" ~== remove_entities(tab(0)))
-      else if not(start_tag.is_empty() | 
+      else if not(start_tag.is_empty() |
                   html_is_standalone_tag(start_tag.name)) then {
          repeat {
             res.add_child("" ~== remove_entities(move_to_node()))
@@ -170,7 +170,7 @@ class HtmlParser : Parser(doc)
             node := parse_node(res) | break
 
             if node.get_type() == "tag" then {
-               if start_tag.balances(node) then 
+               if start_tag.balances(node) then
                   break
 
                if html_is_autoclose_tag(start_tag.name) & start_tag.name == node.name then {
@@ -197,7 +197,7 @@ class HtmlParser : Parser(doc)
                      print_debug("Skipping closing tag", node.to_string())
                } else {
                   res.add_child(n := parse_element(node, res))
-                  if \debug then 
+                  if \debug then
                      print_debug("Adding node ", n.to_string() || " to" || start_tag.to_string())
                }
             } else {
@@ -205,10 +205,10 @@ class HtmlParser : Parser(doc)
                # It's either a coment, or something else; just add it to the list of children
                #
                res.add_child(node)
-            }            
+            }
          }
       }
-      if \debug then 
+      if \debug then
          print_debug("Finished parsing node ", start_tag.to_string())
       return res
    end
@@ -325,7 +325,7 @@ class HtmlParser : Parser(doc)
          s ||:= move(1)
       }
 
-      if \debug then 
+      if \debug then
          print_debug("Moved to node")
 
       return s
@@ -432,9 +432,9 @@ procedure html_is_standalone_tag(name)
    static s
    initial {
       s := set()
-      every insert(s, "IMG" | "BR" | "HR" | "META" | "BASE" | "INPUT" | "AREA" | 
-                   "OPTION" | "BASEFONT" | "BGSOUND" | "COL" | "COLGROUP" | "ISINDEX" | 
-                   "LINK" | "NEXTID" | "SPACER" | "TBODY" | "TFOOT" | 
+      every insert(s, "IMG" | "BR" | "HR" | "META" | "BASE" | "INPUT" | "AREA" |
+                   "OPTION" | "BASEFONT" | "BGSOUND" | "COL" | "COLGROUP" | "ISINDEX" |
+                   "LINK" | "NEXTID" | "SPACER" | "TBODY" | "TFOOT" |
                    "THEAD" | "WBR")
    }
    return member(s, name)

--- a/uni/xml/testinvalid.icn
+++ b/uni/xml/testinvalid.icn
@@ -30,7 +30,7 @@ procedure main(a)
    *a > 0 | stop("usage: testcase source [output]")
 
    f := open(a[1]) | stop("couldnt open" || a[1])
-   s := ""   
+   s := ""
    while s ||:= reads(f, 1000)
    close(f)
 

--- a/uni/xml/testpatterns.icn
+++ b/uni/xml/testpatterns.icn
@@ -13,57 +13,57 @@ global p
 procedure main()
    p := XmlParser()
 
-   test("(a,b,c)", 
-        ["abc"], 
+   test("(a,b,c)",
+        ["abc"],
         ["ab", "xy", ""])
 
 
-   test("(a|b|c|d)", 
-        ["a","b","c","d"], 
+   test("(a|b|c|d)",
+        ["a","b","c","d"],
         ["ab", "xy", ""])
 
-   test("(a|b|c|d)*", 
-        ["","abcddababab","cccccc","dddbababbad"], 
+   test("(a|b|c|d)*",
+        ["","abcddababab","cccccc","dddbababbad"],
         ["abx", "xy", "aaaax"])
 
-   test("(a,b?,c)", 
-        ["abc","ac"], 
+   test("(a,b?,c)",
+        ["abc","ac"],
         ["ab", "xy", ""])
 
-   test("(a,(x|y),c)", 
-        ["axc","ayc"], 
+   test("(a,(x|y),c)",
+        ["axc","ayc"],
         ["ab", "ac", ""])
 
-   test("(a*)*", 
-        ["aaa","a","aa",""], 
+   test("(a*)*",
+        ["aaa","a","aa",""],
         ["adb", "xy", "z"])
 
-   test("(a*)+", 
-        ["aaa","a","aa",""], 
+   test("(a*)+",
+        ["aaa","a","aa",""],
         ["adb", "xy", "z"])
 
-   test("(a+)", 
-        ["aaa","a","aa"], 
+   test("(a+)",
+        ["aaa","a","aa"],
         ["adb", "xy", "z",""])
 
-   test("(a*,b*)", 
-        ["aaabb","a","b","", "aab"], 
+   test("(a*,b*)",
+        ["aaabb","a","b","", "aab"],
         ["adb", "xy", "z"])
 
-   test("(a*,b+)*", 
-        ["bbb","","b","abbabbbbbbabbbbabbab", "ab"], 
+   test("(a*,b+)*",
+        ["bbb","","b","abbabbbbbbabbbbabbab", "ab"],
         ["bbbbbaabbbbaaadb", "xy", "z"])
 
-   test("(x*,a,x*,b,x*,c,x*)", 
+   test("(x*,a,x*,b,x*,c,x*)",
         ["xxabxxxxc"],
         ["bbbbbaabbbbaaadb", "xy", "z"])
 
-   test("(x*,x,x,x,x*)", 
+   test("(x*,x,x,x,x*)",
         ["xxx","xxxx","xxxxx"],
         ["", "x", "xx", "z"])
 
-   test("((a|b),(a|d),(a|e))", 
-        ["aaa","ade","ada"], 
+   test("((a|b),(a|d),(a|e))",
+        ["aaa","ade","ada"],
         ["adb", "xy", "z",""])
 
    write("ok")

--- a/uni/xml/testvalid.icn
+++ b/uni/xml/testvalid.icn
@@ -32,7 +32,7 @@ procedure main(a)
    close(f)
 
    if d := p.parse(s) then {
-      if *a = 1 then 
+      if *a = 1 then
          exit(0)
 
       f := open(a[2]) | stop("couldnt open" || a[2])

--- a/uni/xml/webscraper.icn
+++ b/uni/xml/webscraper.icn
@@ -133,7 +133,7 @@ class WebScraper:Error:Object(paths)
       l := []
       repeat {
          push(l, n)
-         n := n.parent 
+         n := n.parent
          n.get_type() == "element" | return l
       }
    end
@@ -160,11 +160,11 @@ class WebScraper:Error:Object(paths)
             }
             "T" : {
                #n.print_structure()
-               n := n.get_nth_element(e[2], e[3]) | return error("While looking up " || 
+               n := n.get_nth_element(e[2], e[3]) | return error("While looking up " ||
                                                                  id || ": Element " || e[3] || " not found.")
             }
             "S" : {
-               n := n.get_nth_string(e[2]) | return error("While looking up " || 
+               n := n.get_nth_string(e[2]) | return error("While looking up " ||
                                                        id || ": String at " || e[2] || " not found.")
             }
             default : stop("Unknown command")

--- a/uni/xml/xmldocument.icn
+++ b/uni/xml/xmldocument.icn
@@ -65,7 +65,7 @@ class XmlDocument : Document(
    #
    # Debug function: Dump the element declarations
    #
-   method show_element_declarations() 
+   method show_element_declarations()
       local x
       write("--- Element declarations")
       every x := !sort(element_declarations) do  {
@@ -77,7 +77,7 @@ class XmlDocument : Document(
    #
    # Debug function: Dump the notation declarations
    #
-   method show_notation_declarations() 
+   method show_notation_declarations()
       local x
       write("--- Notation declarations")
       every x := !sort(notation_declarations) do  {
@@ -89,7 +89,7 @@ class XmlDocument : Document(
    #
    # Debug function: Dump the attribute declarations
    #
-   method show_attribute_lists() 
+   method show_attribute_lists()
       local x, y
       write("--- Attribute lists")
       every x := !sort(attribute_lists) do  {
@@ -106,7 +106,7 @@ class XmlDocument : Document(
    method show_id_attributes()
       local x
       write("--- ID Attributes")
-      every x := !sort(id_attribute_values) do 
+      every x := !sort(id_attribute_values) do
          write(x)
    end
 
@@ -135,7 +135,7 @@ class XmlDocument : Document(
    end
 
    #
-   # Return the notation_declarations.  A table mapping names to 
+   # Return the notation_declarations.  A table mapping names to
    # NotationDecl objects.
    #
    method get_notation_declarations()
@@ -150,7 +150,7 @@ class XmlDocument : Document(
    end
 
    #
-   # Return the id_attribute_values.  A set of all the ID attribute values 
+   # Return the id_attribute_values.  A set of all the ID attribute values
    # encountered during parsing
    #
    method get_id_attribute_values()

--- a/uni/xml/xmlelement.icn
+++ b/uni/xml/xmlelement.icn
@@ -21,23 +21,23 @@ package xml
 #
 # If n is the XmlElement representing the <top> element, then its
 # global name is GlobalName("top") (ie the same as its local name).  The inner
-# XmlElement however, has a global name of 
+# XmlElement however, has a global name of
 #
 #    GlobalName("inner", "http://an.url.com"),
 #
-# and a single attribute with key 
+# and a single attribute with key
 #
 #    GlobalName("attr", "http://an.url.com").
 #
 # The original parsed name and attribute table are still available
 # via the methods in the superclass Element.  For example, get_name()
-# for the inner XmlElement returns "nsid:inner".   
+# for the inner XmlElement returns "nsid:inner".
 #
 class XmlElement : Element(
                            whitespace_children,
-                           global_name, 
-                           attributes_global_name, 
-                           namespace_declarations, 
+                           global_name,
+                           attributes_global_name,
+                           namespace_declarations,
                            xml_space_preserve)
    #
    # Set the global (namespace-aware) name.  The global
@@ -109,7 +109,7 @@ class XmlElement : Element(
          if e.equals(gn) then
             return attributes_global_name[e]
       }
-      return 
+      return
    end
 
    #

--- a/uni/xml/xmlformatter.icn
+++ b/uni/xml/xmlformatter.icn
@@ -101,7 +101,7 @@ class XmlFormatter : Formatter(indent, no_whitespace, text_trim, as_read)
       local s
       s := "<?" || n.target
       if \n.content then
-         s ||:= " " || n.content 
+         s ||:= " " || n.content
       return s || "?>"
    end
 

--- a/uni/xml/xmlparser.icn
+++ b/uni/xml/xmlparser.icn
@@ -21,7 +21,7 @@ class Diversion(id, subject, pos)
 end
 
 class XmlParser : Parser : Error(doc,
-                                  resolver, 
+                                  resolver,
                                   error_handler,
                                   current_divert_id,
                                   divert_stack,
@@ -197,7 +197,7 @@ class XmlParser : Parser : Error(doc,
    # If quiet is non-null, just fail silently on error.
    #
    # @p
-   method parse_names(quiet) 
+   method parse_names(quiet)
       local l
 
       l := []
@@ -206,7 +206,7 @@ class XmlParser : Parser : Error(doc,
          looking_at_space_then_cset(xml_name_start) | break
          spaces()
       }
-      
+
       return l
    end
 
@@ -237,7 +237,7 @@ class XmlParser : Parser : Error(doc,
    # If quiet is non-null, just fail silently on error.
    #
    # @p
-   method parse_nmtokens(quiet) 
+   method parse_nmtokens(quiet)
       local l
 
       l := []
@@ -246,7 +246,7 @@ class XmlParser : Parser : Error(doc,
          looking_at_space_then_cset(xml_name_char) | break
          spaces()
       }
-      
+
       return l
    end
 
@@ -262,7 +262,7 @@ class XmlParser : Parser : Error(doc,
       repeat {
          if any('%') then {
             # Can't reference a pe in the internal subset; see ibm test ibm29n04.xml
-            if /in_ext_subset then 
+            if /in_ext_subset then
                return err("cannnot reference a parameter entity in the internal subset")
             # In an entity value, perefs (%..;) are always expanded
             res ||:= resolve_entity(lookup_pe_reference(parse_pe_reference())) | fail
@@ -278,7 +278,7 @@ class XmlParser : Parser : Error(doc,
             res ||:= move(1) | return err("Unexpected eof")
       }
    end
-   
+
    #
    # [10] AttValue ::= '"' ([^<&"] | Reference)* '"' |  "'" ([^<&'] | Reference)* "'"
    #
@@ -358,7 +358,7 @@ class XmlParser : Parser : Error(doc,
             } else if any('&') then {
                # Char refs aren't recursively treated; entity refs are.
                if match("&#") then
-                  res ||:= parse_char_ref(1) | fail 
+                  res ||:= parse_char_ref(1) | fail
                else {
                   ref := parse_entity_ref() | fail
                   if member(\circle, ref) then
@@ -417,7 +417,7 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [11] SystemLiteral ::= ('"' [^"]* '"') | ("'" [^']* "'") 
+   # [11] SystemLiteral ::= ('"' [^"]* '"') | ("'" [^']* "'")
    #
    # @p
    method parse_system_literal()
@@ -508,7 +508,7 @@ class XmlParser : Parser : Error(doc,
    #
    # [18] CDSect ::= CDStart CData CDEnd
    # [19] CDStart ::= '<![CDATA['
-   # [20] CData ::= (Char* - (Char* ']]>' Char*)) 
+   # [20] CData ::= (Char* - (Char* ']]>' Char*))
    # [21] CDEnd ::= ']]>'
    #
    # @p
@@ -544,7 +544,7 @@ class XmlParser : Parser : Error(doc,
    # [23] XMLDecl ::= '<?xml' VersionInfo EncodingDecl? SDDecl? S? '?>'
    #
    # @p
-   method parse_xml_decl() 
+   method parse_xml_decl()
       local res
       res := XmlDecl()
       ="<?xml" | return err("'<?xml' expected")
@@ -594,7 +594,7 @@ class XmlParser : Parser : Error(doc,
       ="=" | return err("'=' expected")
       opt_spaces()
       return
-   end      
+   end
 
    #
    # [26] VersionNum ::= ([a-zA-Z0-9_.:] | '-')+
@@ -665,7 +665,7 @@ class XmlParser : Parser : Error(doc,
       =">" | return err("'>' expected")
 
       if \res.external_id then {
-         # Resolve and parse the external subset 
+         # Resolve and parse the external subset
          s := resolve(res.external_id) | fail
          start_divert(res.external_id.to_string())
          in_ext_subset := 1
@@ -675,7 +675,7 @@ class XmlParser : Parser : Error(doc,
          }
          in_ext_subset := &null
          end_divert()
-      } 
+      }
 
       return res
    end
@@ -684,7 +684,7 @@ class XmlParser : Parser : Error(doc,
    # Parse (markupdecl | DeclSep) *
    #
    # [28a] DeclSep ::= PEReference | S
-   # [29] markupdecl ::= elementdecl | AttlistDecl | EntityDecl | NotationDecl | PI | Comment 
+   # [29] markupdecl ::= elementdecl | AttlistDecl | EntityDecl | NotationDecl | PI | Comment
    #
    # @p
    method parse_markup_decls()
@@ -706,7 +706,7 @@ class XmlParser : Parser : Error(doc,
             # Recursively parse the value of the pe.
             ref := parse_pe_reference() | fail
             o := lookup_pe_reference(ref) | fail
-            if \o.str then { 
+            if \o.str then {
                start_divert("macro")
                normalize_eol(o.str) ? {
                   parse_markup_decls() | fail
@@ -727,12 +727,12 @@ class XmlParser : Parser : Error(doc,
             }
          } else if any(xml_space) then
             spaces()
-         else 
+         else
             break
       }
       return
    end
-   
+
    #
    # [30] extSubset ::= TextDecl? extSubsetDecl
    #
@@ -768,7 +768,7 @@ class XmlParser : Parser : Error(doc,
             # Recursively parse the value of the pe.
             ref := parse_pe_reference() | fail
             o := lookup_pe_reference(ref) | fail
-            if \o.str then { 
+            if \o.str then {
                start_divert("macro")
                normalize_eol(o.str) ? {
                   parse_ext_subset_decl() | fail
@@ -789,14 +789,14 @@ class XmlParser : Parser : Error(doc,
             }
          } else if any(xml_space) then
             spaces()
-         else 
+         else
             break
       }
       return
    end
 
    #
-   # [32] SDDecl ::= S 'standalone' Eq (("'" ('yes' | 'no') "'") | ('"' ('yes' | 'no') '"')) 
+   # [32] SDDecl ::= S 'standalone' Eq (("'" ('yes' | 'no') "'") | ('"' ('yes' | 'no') '"'))
    #
    # @p
    method parse_sdecl()
@@ -898,7 +898,7 @@ class XmlParser : Parser : Error(doc,
       parse_eq() | fail
 
       #
-      # Try to get the AttributeDef for this attribute.  
+      # Try to get the AttributeDef for this attribute.
       #
       attdef := (\attlist).attribute_defs[att]
 
@@ -949,7 +949,7 @@ class XmlParser : Parser : Error(doc,
                #
                if \doc.standalone & \o.in_ext_subset then
                   return err("cannot reference an entity declared externally, in a standalone document")
-               if \o.str then { 
+               if \o.str then {
                   # Simple expansion, parsed as content.
                   start_divert("macro")
                   normalize_eol(o.str) ? {
@@ -1025,11 +1025,11 @@ class XmlParser : Parser : Error(doc,
          invalid("Multiple element declarations for element " || name)
       else
          insert(doc.element_declarations, name, element_decl)
-      return 
+      return
    end
 
    #
-   # [46] contentspec ::= 'EMPTY' | 'ANY' | Mixed | children 
+   # [46] contentspec ::= 'EMPTY' | 'ANY' | Mixed | children
    #
    # @p
    method parse_content_spec()
@@ -1122,7 +1122,7 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [51] Mixed ::= '(' S? '#PCDATA' (S? '|' S? Name)* S? ')*' | '(' S? '#PCDATA' S? ')' 
+   # [51] Mixed ::= '(' S? '#PCDATA' (S? '|' S? Name)* S? ')*' | '(' S? '#PCDATA' S? ')'
    # Converts to a string with spaces removed.
    #
    # @p
@@ -1132,7 +1132,7 @@ class XmlParser : Parser : Error(doc,
       tab(dtd_match("(")) | return err("( expected")
       dtd_opt_spaces()
       a := ContentSpec(tab(dtd_match("#PCDATA"))) | return err("'#PCDATA' expected")
-       
+
       dtd_opt_spaces()
 
       seen := set()
@@ -1221,10 +1221,10 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [54] AttType ::= StringType | TokenizedType | EnumeratedType 
+   # [54] AttType ::= StringType | TokenizedType | EnumeratedType
    # [55] StringType ::= 'CDATA'
    # [56] TokenizedType ::= 'ID' | 'IDREF'| 'IDREFS' | 'ENTITY' | 'ENTITIES' | 'NMTOKEN' | 'NMTOKENS'
-   # [57] EnumeratedType ::= NotationType | Enumeration 
+   # [57] EnumeratedType ::= NotationType | Enumeration
    #
    # @p
    method parse_att_type(attribute_def)
@@ -1245,7 +1245,7 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [58] NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')' 
+   # [58] NotationType ::= 'NOTATION' S '(' S? Name (S? '|' S? Name)* S? ')'
    #
    # @p
    method parse_notation_type()
@@ -1345,11 +1345,11 @@ class XmlParser : Parser : Error(doc,
                if val ? not(parse_nmtokens(1) & pos(0)) then
                   invalid("default attribute value " || val || " must be comprised of valid nmtokens")
             }
-            "ENUMERATION" : { 
+            "ENUMERATION" : {
                if not(member(attribute_def.def_set, val)) then
                   invalid("default attribute value " || val || " is not one of the declared enumerations")
             }
-            "NOTATION" : { 
+            "NOTATION" : {
                if not(member(attribute_def.def_set, val)) then
                   invalid("default attribute value " || val || " is not one of the declared notations")
             }
@@ -1359,8 +1359,8 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [61] conditionalSect ::= includeSect | ignoreSect 
-   # [62] includeSect ::= '<![' S? 'INCLUDE' S? '[' extSubsetDecl ']]>' 
+   # [61] conditionalSect ::= includeSect | ignoreSect
+   # [62] includeSect ::= '<![' S? 'INCLUDE' S? '[' extSubsetDecl ']]>'
    # [63] ignoreSect ::= '<![' S? 'IGNORE' S? '[' ignoreSectContents* ']]>'
    #
    # @p
@@ -1375,7 +1375,7 @@ class XmlParser : Parser : Error(doc,
          dtd_opt_spaces()
          tab(dtd_match("[")) | return err("'[' expected")
          parse_ignore_sect_contents() | fail
-      } else 
+      } else
          return err("'INCLUDE' or 'IGNORE' expected")
 
       tab(dtd_match("]]>")) | return err("']]>' expected")
@@ -1385,13 +1385,13 @@ class XmlParser : Parser : Error(doc,
 
    #
    # [64] ignoreSectContents ::= Ignore ('<![' ignoreSectContents ']]>' Ignore)*
-   # [65] Ignore ::= Char* - (Char* ('<![' | ']]>') Char*) 
+   # [65] Ignore ::= Char* - (Char* ('<![' | ']]>') Char*)
    #
    # @p
    method parse_ignore_sect_contents()
       repeat {
          tab(upto('<]')) | return err("ignore section not closed")
-         if match("]]>") then 
+         if match("]]>") then
             return
          else if ="<![" then {
             parse_ignore_sect_contents() | fail
@@ -1413,20 +1413,20 @@ class XmlParser : Parser : Error(doc,
 
       if any('x') then {
          s ||:= move(1)
-         c := &digits ++ 'abcdefABCDEF' 
+         c := &digits ++ 'abcdefABCDEF'
          any(c) | return err(c || " expected")
-         digs := tab(many(c)) 
+         digs := tab(many(c))
          i := format_string_to_int(digs, 16) | 63
       } else {
          c := &digits
          any(c) | return err(c || " expected")
-         digs := tab(many(c)) 
+         digs := tab(many(c))
          i := integer(digs) | 63
       }
       s ||:= digs
       s ||:= =";" | return err("';' expected")
 
-      if /expand then 
+      if /expand then
          return s
       else {
          if i = (16r9 | 16rA | 16rD) | (16r20 <= i <= 16rFF) then
@@ -1541,13 +1541,13 @@ class XmlParser : Parser : Error(doc,
       } else {
          name := dtd_parse_name() | fail
          dtd_spaces() | fail
-         val := parse_entity_def() | fail 
+         val := parse_entity_def() | fail
          # Second and subsequent definitions generate a warning, and are ignored.
          if member(doc.general_entities, name) then
             warn("multiple parameter entity definitions for " || name)
          else
             insert(doc.general_entities, name, val)
-      }         
+      }
       dtd_opt_spaces()
       tab(dtd_match(">")) | return err("'>' expected")
       return
@@ -1569,11 +1569,11 @@ class XmlParser : Parser : Error(doc,
             res.notation := parse_ndata_decl() | fail
             member(doc.notation_declarations, res.notation) | invalid("NDATA declaration " || res.notation || " not declared as a NOTATION")
          }
-      } else 
+      } else
          res.str := parse_entity_value() | fail
       return res
    end
-   
+
    #
    # [74] PEDef ::= EntityValue | ExternalID
    # return a string or an ExternalID
@@ -1581,19 +1581,19 @@ class XmlParser : Parser : Error(doc,
    # @p
    method parse_pe_def()
       local res
-         
+
       res := EntityDef()
       res.in_ext_subset := in_ext_subset
       if dtd_match("SYSTEM" | "PUBLIC") then
          res.external_id := parse_external_id() | fail
-      else 
+      else
          res.str := parse_entity_value() | fail
       return res
    end
 
    #
    #
-   # [75] ExternalID ::= 'SYSTEM' S SystemLiteral | 'PUBLIC' S PubidLiteral S SystemLiteral 
+   # [75] ExternalID ::= 'SYSTEM' S SystemLiteral | 'PUBLIC' S PubidLiteral S SystemLiteral
    #
    # @p
    method parse_external_id()
@@ -1634,7 +1634,7 @@ class XmlParser : Parser : Error(doc,
 
       if looking_at_space_then("version") then
          parse_version_info() | fail
-      
+
       parse_encoding_decl() | fail
 
       opt_spaces()
@@ -1655,7 +1655,7 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # [80] EncodingDecl ::= S 'encoding' Eq ('"' EncName '"' | "'" EncName "'" ) 
+   # [80] EncodingDecl ::= S 'encoding' Eq ('"' EncName '"' | "'" EncName "'" )
    #
    # @p
    method parse_encoding_decl()
@@ -1690,7 +1690,7 @@ class XmlParser : Parser : Error(doc,
 
    #
    # [82] NotationDecl ::= '<!NOTATION' S Name S (ExternalID | PublicID) S? '>'
-   # [83] PublicID ::= 'PUBLIC' S PubidLiteral 
+   # [83] PublicID ::= 'PUBLIC' S PubidLiteral
    #
    # @p
    method parse_notation_decl()
@@ -1752,7 +1752,7 @@ class XmlParser : Parser : Error(doc,
    #
    # Validate the given element child content; this may fail on error or just emit a warning
    #
-   method validate_children(el, parent_el) 
+   method validate_children(el, parent_el)
       local element_decl, xs, tl
 
       #
@@ -1760,7 +1760,7 @@ class XmlParser : Parser : Error(doc,
       #
       if not member(doc.element_declarations, el.name) then {
          invalid(el.name || " is an undeclared element name")
-         return 
+         return
       }
 
       element_decl := doc.element_declarations[el.name]
@@ -1836,7 +1836,7 @@ class XmlParser : Parser : Error(doc,
                # Insert any default value.
                insert(el.attributes, x[1], \x[2].default_value)
             }
-         }       
+         }
       }
 
       #
@@ -1851,7 +1851,7 @@ class XmlParser : Parser : Error(doc,
       }
    end
 
-   method validate_attribute_value(element_name, attdef, name, val) 
+   method validate_attribute_value(element_name, attdef, name, val)
       local l, entity_def, n
       case attdef.def_type of {
          "CDATA" : {
@@ -1908,18 +1908,18 @@ class XmlParser : Parser : Error(doc,
             if val ? not(parse_nmtokens(1) & pos(0)) then
                invalid("attribute value " || val || " must be comprised of valid nmtokens")
          }
-         "ENUMERATION" : { 
+         "ENUMERATION" : {
             if not(member(attdef.def_set, val)) then
                invalid("attribute value " || val || " is not one of the declared enumerations")
          }
-         "NOTATION" : { 
+         "NOTATION" : {
             if not(member(attdef.def_set, val)) then
                invalid("attribute value " || val || " is not one of the declared notations")
          }
       }
    end
 
-   method start_divert(id) 
+   method start_divert(id)
       push(divert_stack, Diversion(current_divert_id, &subject, &pos))
       current_divert_id := id
    end
@@ -1934,7 +1934,7 @@ class XmlParser : Parser : Error(doc,
    method warn(s)
       local stack
       # No warnings after a fatal error.
-      if \reason then 
+      if \reason then
          fail
 
       stack := copy(divert_stack)
@@ -1955,7 +1955,7 @@ class XmlParser : Parser : Error(doc,
          fail
 
       # None after a fatal error.
-      if \reason then 
+      if \reason then
          fail
 
       stack := copy(divert_stack)
@@ -1972,7 +1972,7 @@ class XmlParser : Parser : Error(doc,
       local stack
 
       # Ensure only one fatal error is ever sent.
-      if \reason then 
+      if \reason then
          fail
 
       error(s)
@@ -2069,7 +2069,7 @@ class XmlParser : Parser : Error(doc,
          try_dtd_insert(i) | fail
       }
    end
-   
+
    #
    # Equivalent to any(), but checks for pe expansions
    #
@@ -2127,7 +2127,7 @@ class XmlParser : Parser : Error(doc,
          if /in_ext_subset then {
             # Only show an error once; this prevents the same error message
             # being produced several times.
-            if /dtd_insert_shown_error then 
+            if /dtd_insert_shown_error then
                invalid("Cannot reference a pe except in the external dtd")
             dtd_insert_shown_error := 1
             fail
@@ -2154,13 +2154,13 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # This method post-processes the parsed tree to fill in the 
+   # This method post-processes the parsed tree to fill in the
    # global names in the XmlElement structures.
    #
    # @p
    method do_namespace_processing()
       local t
-      
+
       t := table()
       insert(t, "xml", "http://www.w3.org/XML/1998/namespace")
 
@@ -2230,7 +2230,7 @@ class XmlParser : Parser : Error(doc,
             if ="xmlns" then {
                next
             }
-            insert(el.attributes_global_name, 
+            insert(el.attributes_global_name,
                    convert_name(resolve_table, k), el.attributes[k]) | fail
          }
       }
@@ -2239,7 +2239,7 @@ class XmlParser : Parser : Error(doc,
    end
 
    #
-   # Given a name "eg SOAP-ENV:Envelope", return the global name, using the 
+   # Given a name "eg SOAP-ENV:Envelope", return the global name, using the
    # given resolve table for the conversion.  The returned value is a
    # GlobalName instance.
    #
@@ -2266,9 +2266,9 @@ class XmlParser : Parser : Error(doc,
       }
    end
 
-   # 
+   #
    # Make a map of namespace id's to uri's from the attributes in the
-   # given element.  
+   # given element.
    #
    # @p
    method make_declarations_map(el)
@@ -2325,7 +2325,7 @@ procedure init_xml_globals()
       xml_letter ++:= char(c)
    # [4] NameChar ::= Letter | Digit | '.' | '-' | '_' | ':' | CombiningChar | Extender
    xml_name_char := xml_letter ++ &digits ++ '.-_:'
-   xml_name_start := xml_letter ++ '_:' 
+   xml_name_start := xml_letter ++ '_:'
    # [13] PubidChar ::= #x20 | #xD | #xA | [a-zA-Z0-9] | [-'()+,./:=?;!*#@$_%]
    xml_pubid_char := ' \n\r' ++ &lcase ++ &ucase ++ &digits ++ '-\'()+,./:=?;!*#@$_%'
 end


### PR DESCRIPTION
When updating Unicon files that have spaces/tabs at the EOL's, various editors have been setup to remove such characters. This causes additional commit changes that can confuse what is actually being changed in the source files.

This commit is intended to circumvent those future changes by enforcing the removal of spaces/tabs as a purely cosmetic change now.