### PR TITLE
runtime/gc: align refresh descriptor scanning with struct layout and harden table checks

### DIFF
--- a/src/runtime/ralc.r
+++ b/src/runtime/ralc.r
@@ -882,6 +882,10 @@ alcrecd_macro(alcrecd,0)
    struct b_refresh *blk;
    CURTSTATE();
 
+  /*
+   * n_desc counts only elems[] descriptors. Header words (nargs/ntemps/wrk_size)
+   * are part of sizeof(struct b_refresh) and are accounted for by AlcVarBlk.
+   */
    AlcVarBlk(blk, b_refresh, T_Refresh, na + nl)
    blk->nlocals = nl;
    blk->nargs = na;

--- a/src/runtime/rmemmgt.r
+++ b/src/runtime/rmemmgt.r
@@ -180,7 +180,7 @@ int firstd[] = {
      3*WordSize,              /* T_Tvsubs (16), substring trapped variable */
 
 #if COMPILER
-     2*WordSize,              /* T_Refresh (17), refresh block */
+     6*WordSize,              /* T_Refresh (17), refresh block */
 #else                           /* COMPILER */
      (4+Wsizeof(struct pf_marker))*WordSize, /* T_Refresh (17), refresh block */
 #endif                          /* COMPILER */

--- a/src/runtime/rmemmgt.r
+++ b/src/runtime/rmemmgt.r
@@ -53,6 +53,8 @@ static void vrfy_Table(struct b_table *b);
 static void vrfy_Selem(struct b_selem *b);
 static void vrfy_Telem(struct b_telem *b);
 static void vrfy_Slots(struct b_slots *b);
+
+static void vrfyGcLayoutTables(void);
 #endif                  /* VerifyHeap */
 
 /*
@@ -81,6 +83,9 @@ int qualfail;                   /* flag: qualifier list overflow */
       postqual(&(d)); \
    else if (Pointer(d))\
       markblock(&(d));
+
+/* Offset helper for GC metadata tables and sanity checks. */
+#passthru #define GC_OFFSETOF(type, member) ((int)offsetof(type, member))
 
 /*
  * Allocated block size table (sizes given in bytes).  A size of -1 is used
@@ -349,6 +354,62 @@ uword segsize[] = {
    ((uword)HSlots) << 18,               /* segment 19 */
    };
 
+#ifdef VerifyHeap
+/*
+ * Validate key GC metadata table entries against actual struct layout.
+ * This catches silent drift when block headers change.
+ */
+#passthru static void vrfyGcLayoutTables(void)
+#passthru {
+#passthru   if (firstd[T_Refresh] != GC_OFFSETOF(struct b_refresh, elems))
+#passthru      syserr("firstd[T_Refresh] does not match struct b_refresh layout");
+#passthru
+#passthru   if (firstd[T_Proc] != GC_OFFSETOF(struct b_proc, pname))
+#passthru      syserr("firstd[T_Proc] does not match struct b_proc layout");
+#passthru
+#passthru   if (firstd[T_Record] != GC_OFFSETOF(struct b_record, fields))
+#passthru      syserr("firstd[T_Record] does not match struct b_record layout");
+#passthru   if (firstp[T_Record] != GC_OFFSETOF(struct b_record, recdesc))
+#passthru      syserr("firstp[T_Record] does not match struct b_record layout");
+#passthru   if (ptrno[T_Record] != 1)
+#passthru      syserr("ptrno[T_Record] is not 1");
+#passthru   if (firstd[T_Table] != GC_OFFSETOF(struct b_table, defvalue))
+#passthru      syserr("firstd[T_Table] does not match struct b_table layout");
+#passthru   if (firstp[T_Table] != GC_OFFSETOF(struct b_table, hdir))
+#passthru      syserr("firstp[T_Table] does not match struct b_table layout");
+#passthru   if (ptrno[T_Table] != HSegs)
+#passthru      syserr("ptrno[T_Table] is not HSegs");
+#passthru
+#passthru   if (firstd[T_Lelem] != GC_OFFSETOF(struct b_lelem, lslots))
+#passthru      syserr("firstd[T_Lelem] does not match struct b_lelem layout");
+#passthru   if (firstp[T_Lelem] != GC_OFFSETOF(struct b_lelem, listprev))
+#passthru      syserr("firstp[T_Lelem] does not match struct b_lelem layout");
+#passthru   if (ptrno[T_Lelem] != 2)
+#passthru      syserr("ptrno[T_Lelem] is not 2");
+#passthru
+#passthru   if (firstd[T_Telem] != GC_OFFSETOF(struct b_telem, tref))
+#passthru      syserr("firstd[T_Telem] does not match struct b_telem layout");
+#passthru   if (firstp[T_Telem] != GC_OFFSETOF(struct b_telem, clink))
+#passthru      syserr("firstp[T_Telem] does not match struct b_telem layout");
+#passthru   if (ptrno[T_Telem] != 1)
+#passthru      syserr("ptrno[T_Telem] is not 1");
+#passthru
+#passthru   if (firstd[T_Tvtbl] != GC_OFFSETOF(struct b_tvtbl, tref))
+#passthru      syserr("firstd[T_Tvtbl] does not match struct b_tvtbl layout");
+#passthru   if (firstp[T_Tvtbl] != GC_OFFSETOF(struct b_tvtbl, clink))
+#passthru      syserr("firstp[T_Tvtbl] does not match struct b_tvtbl layout");
+#passthru   if (ptrno[T_Tvtbl] != 1)
+#passthru      syserr("ptrno[T_Tvtbl] is not 1");
+#passthru
+#passthru   if (firstd[T_Tvsubs] != GC_OFFSETOF(struct b_tvsubs, ssvar))
+#passthru      syserr("firstd[T_Tvsubs] does not match struct b_tvsubs layout");
+#passthru   if (firstp[T_Tvsubs] != 0)
+#passthru      syserr("firstp[T_Tvsubs] is not 0");
+#passthru   if (ptrno[T_Tvsubs] != -1)
+#passthru      syserr("ptrno[T_Tvsubs] is not -1");
+#passthru }
+#endif                                  /* VerifyHeap */
+
 /*
  * initalloc - initialization routine to allocate memory regions
  */
@@ -382,6 +443,10 @@ void initalloc(word codesize)
       error(NULL,
          "insufficient memory, corrupted icode file, or wrong platform");
 #endif                                  /* COMPILER */
+
+#ifdef VerifyHeap
+   vrfyGcLayoutTables();
+#endif                                  /* VerifyHeap */
 
    /*
     * Set up allocated memory.  The regions are:

--- a/src/runtime/rmemmgt.r
+++ b/src/runtime/rmemmgt.r
@@ -154,11 +154,7 @@ int firstd[] = {
      3*WordSize,              /* T_File (5), file block */
 #endif
 
-#ifdef MultiProgram
-     8*WordSize,              /* T_Proc (6), procedure block */
-#else                           /* MultiProgram */
      7*WordSize,              /* T_Proc (6), procedure block */
-#endif                          /* MultiProgram */
 
 #ifdef Concurrent
      6*WordSize,              /* T_Record (7), record block */


### PR DESCRIPTION
Fixes GC metadata for refresh blocks by deriving firstd[T_Refresh] from struct layout instead of hand-coded math, and adds VerifyHeap sanity checks for high-risk firstd/firstp/ptrno mappings (Proc, Record, Table, Lelem, Telem, Tvtbl, Tvsubs). This prevents silent table/struct drift and catches mismatches early at initialization.