### PR TITLE
doc: add CONTRIBUTING guide, refresh README, extend GitHub Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,8 @@
-# Single GitHub Pages site: README.md → site index; doc/README.md → doc/index.html.
+# GitHub Pages (single _site/ artifact):
+#   README.md           → index.html
+#   doc/**              → doc/… (plus doc/README.md → doc/index.html)
+#   CONTRIBUTING.md     → CONTRIBUTING.md + CONTRIBUTING.html
+#   COPYING             → COPYING
 # Repo Settings → Pages → Source: GitHub Actions.
 
 name: Pages
@@ -10,6 +14,8 @@ on:
       - main
     paths:
       - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'COPYING'
       - 'doc/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
@@ -35,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Pandoc
-        uses: pandoc/setup-pandoc@v3
+        uses: pandoc/setup-pandoc@ad820d1f3dfae86543ea82e92b6aaf21c9e12f69 # v3
 
       - name: Build site
         run: |
@@ -51,6 +57,12 @@ jobs:
           pandoc doc/README.md -o "$SITE/doc/index.html" \
             --standalone \
             --metadata title="Unicon documentation" \
+            -t html5
+          test -f CONTRIBUTING.md && test -f COPYING
+          cp CONTRIBUTING.md COPYING "$SITE/"
+          pandoc CONTRIBUTING.md -o "$SITE/CONTRIBUTING.html" \
+            --standalone \
+            --metadata title="Contributing to Unicon" \
             -t html5
           touch "$SITE/.nojekyll"
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+# Single GitHub Pages site: README.md → site index; doc/README.md → doc/index.html.
+# Repo Settings → Pages → Source: GitHub Actions.
+
+name: Pages
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'README.md'
+      - 'doc/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.repository == 'uniconproject/unicon'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Pandoc
+        uses: pandoc/setup-pandoc@v3
+
+      - name: Build site
+        run: |
+          set -e
+          SITE=_site
+          rm -rf "$SITE"
+          mkdir -p "$SITE/doc"
+          pandoc README.md -o "$SITE/index.html" \
+            --standalone \
+            --metadata title="Unicon" \
+            -t html5
+          cp -a doc/. "$SITE/doc/"
+          pandoc doc/README.md -o "$SITE/doc/index.html" \
+            --standalone \
+            --metadata title="Unicon documentation" \
+            -t html5
+          touch "$SITE/.nojekyll"
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,188 @@
+# Contributing to Unicon
+
+## Discussion
+
+Unicon is a community project: improvements to the language, runtime, libraries, tests, documentation, and tooling are all welcome. Before large changes, it helps to **open an issue** (or email) so maintainers can comment on direction, compatibility, and scope—especially for anything that affects the language definition, ABI, or build system.
+
+**What to send as a pull request:** focused commits with a clear motivation; update **tests** or **docs** when behavior or interfaces change. Use the [Pre-submission checklist](#pre-submission-checklist) before you submit. For release-critical fixes, say how you verified the change (platform, `make Test`, sanitizer build, etc.).
+
+## Reporting issues and getting help
+
+- **Bugs and feature ideas:** use [GitHub Issues](https://github.com/uniconproject/unicon/issues) for reproducible bugs, concrete feature requests, and build failures on supported platforms.
+- **Email:** [jeffery@unicon.org](mailto:jeffery@unicon.org) when an issue tracker thread is not a good fit (e.g. security-sensitive reports, or very open-ended design discussion).
+
+## Pull requests
+
+- Use a **clear branch name** and **commit messages** that state what changed and why.
+- Ensure the tree **configures and builds** on at least one platform you can run.
+- Run **`make Test`** when your change can affect the interpreter, compiler, or runtime (CI runs a broad matrix; local `make Test` catches many regressions early).
+- Follow [Code formatting](#code-formatting); avoid unrelated refactors in the same PR.
+
+## Pre-submission checklist
+
+Before you open or update a pull request:
+
+- [ ] **Format code** — follow project conventions; see [Code formatting](#code-formatting).
+- [ ] **License** — confirm your contribution is licensed appropriately; see [License for contributions](#license-for-contributions).
+- [ ] **Sign-off** — add a proper `Signed-off-by` line on commits; see [Signing off](#signing-off).
+
+## Code formatting
+
+Match the **style of the surrounding code** in each file: naming, indentation, brace and comment conventions, and line length habits already used there. **C and Unicon** sources should stay consistent with nearby examples—avoid wide reformatting unrelated to your change. When in doubt, follow existing patterns in the same directory or subsystem.
+
+## License for contributions
+
+By submitting a patch or pull request, you agree that your contribution can be distributed under the **same licensing terms as the rest of the Unicon tree**. The top-level **[`COPYING`](COPYING)** file explains how different parts of the distribution are licensed (for example, **GPL**-covered Unicon extensions, **public-domain** Icon-derived material where noted, the **Library GPL** terms for certain class library and VM uses, and **BSD** for `src/libtp` as described there). Do not contribute material you are not entitled to license in this way, and call out any **third-party** or **externally licensed** files clearly in the commit message or PR description.
+
+## Signing off
+
+A **`Signed-off-by`** trailer is a developer’s **certification** that they have the **right to submit** the patch for inclusion in the project. It records agreement to the **[Developer’s Certificate of Origin](https://developercertificate.org/)**. **Commits without a proper `Signed-off-by` line cannot and will not be merged.**
+
+Add **`Signed-off-by: Your Name <email@example.com>`** to each commit message (typically the last line). With Git, use **`git commit -s`** (or **`git commit --signoff`**) so Git fills the line from your `user.name` and `user.email`.
+
+Example:
+
+```text
+Signed-off-by: Ada Lovelace <ada@example.com>
+```
+
+## Source tree (overview)
+
+- **`src/`** — C implementation of the **translator** (`icont`), **compiler** (`iconc`), **preprocessor**, and **runtime** (virtual machine, memory / GC, built-ins), plus headers in **`h/`** and related pieces such as **`rtt`**, **`asm`**, and **`lib/`** (bundled/native glue used by the build).
+- **`uni/`** — the **Unicon compiler** (under **`unicon/`**, **`parser/`**, and related dirs), **`lib/`** (Unicon library sources), and Unicon-language **tools and subsystems** (for example **`ivib`**, **`ide`**, **`udb`**, **`uflex`**, **`ulsp`**, **`utf8`**, **`3d`**, **`gui`**, **`shell`**, **`xml`**, **`unidoc`**, **`monvis`**).
+- **`ipl/`** — **Icon Program Library** packages shipped with the system; **`tests/`** — regression and feature tests.
+
+---
+
+## Configure options (overview)
+
+The build is driven by **`./configure`** (GNU autoconf). The authoritative list of flags is:
+
+```sh
+./configure --help
+```
+
+Below is a contributor-oriented summary. Many features are **on by default** and are **auto-disabled** if dependencies are missing unless you **explicitly** `--enable-FEATURE`, in which case configure **fails** if that dependency is absent.
+
+### Feature toggles (high level)
+
+Typical `--disable-*` / `--enable-*` switches control subsystems such as **graphics**, **3D graphics**, **concurrency**, **SSL**, **audio**, **plugins**, **Iconc** (the Unicon compiler), **operator overloading** (`--enable-ovld`), **UDB tools**, and more. Use **`./configure --help`** for the full set and for platform-specific notes.
+
+**`--enable-thin`** — minimalist build: turns off non-critical features to shrink the build and speed iteration when you only need a core interpreter/compiler.
+
+**`--enable-verbosebuild`** — print full compiler command lines (useful when debugging flags or include paths).
+
+**`--enable-doc`** / **`--enable-htmldoc`** — add Makefile rules to build documentation (see top-level `Makefile` / `doc/`).
+
+### Developer mode, warnings, and debug symbols
+
+| Option | Purpose |
+|--------|---------|
+| **`--enable-debug`** | Add **debug symbols** (`-g`) and, when no custom `CFLAGS` are set, a suitable **optimization level** for debugging (e.g. `-O0` for a normal debug build; sanitizer builds may use `-O1`). Use this whenever you need **GDB**, **lldb**, or readable **stack traces**. |
+| **`--enable-devmode`** | **Developer mode:** enables **`--enable-debug`** and **compiler warnings** (`--enable-warnings`), and defines **`DEVELOPMODE`** in the build. Extra **developer-only hooks** in the runtime (see `DEVELOPMODE` in sources) are available for deeper inspection. |
+| **`--enable-devmode=all`** | Same as **`yes`**, and also enables **heap debugging** and **heap verification** ([Heap debugging](#heap-debugging-and-verification))—heavier, use when tracking **memory / GC / pointer** bugs. |
+| **`--enable-warnings`** | Turn on **most** compiler warnings (off by default in many configurations). |
+| **`--enable-werror`** | Treat **warnings as errors**—use in CI or when cleaning up warning debt; can be noisy on new toolchains. |
+
+**When to use what:** day-to-day hacking on C/R code: **`--enable-devmode`** (or at least **`--enable-debug`** + **`--enable-warnings`**). Shipping binaries or bisecting performance: default optimized builds without devmode.
+
+### Heap debugging and verification
+
+These options add **runtime checks** in the Unicon **heap / block** layer. They **slow execution** and are meant for **development and debugging**, not production installs.
+
+| Option | What it does |
+|--------|----------------|
+| **`--enable-debugheap`** | Defines **`DebugHeap`**. Block access macros (e.g. `Blk`) gain **runtime type and pointer checks** so invalid block references are caught closer to the bug (see comments in `src/h/rmacros.h`). Use when **`gdb`** / **Valgrind** are not enough and you suspect **corrupted pointers** or **wrong block kinds**. |
+| **`--enable-verifyheap`** | Defines **`VerifyHeap`**. Enables **structured heap/GC verification** and logging controlled at run time (see **`VRFY`** below). Use when debugging **GC invariants**, **region** issues, or subtle **memory** problems. |
+
+**`--enable-devmode=all`** turns on **both** options together with the rest of developer mode (see [Developer mode, warnings, and debug symbols](#developer-mode-warnings-and-debug-symbols)).
+
+**Relationship:** **`DebugHeap`** checks block access at use sites; **`VerifyHeap`** runs structured checks around **GC** and related structures. Use either or both.
+
+### Runtime: `VRFY` and `VRFYOP` (when VerifyHeap is enabled)
+
+With **`VerifyHeap`** compiled in, the runtime reads:
+
+- **`VRFY`** — bit-significant verification flags. **`0`** disables extra checks. **`-1`** enables **all** verification checks. **`-2`** enables all checks but **suppresses some logging** (CI sometimes sets **`VRFY=-2`** during tests to reduce noise while still exercising checks). Other values select subsets of types to verify (see implementation and comments in `src/runtime/rmemmgt.r` and the Unicon implementation documentation).
+- **`VRFYOP`** — controls **“is verified”** style messages (see `init.r` / `rmemmgt.r`).
+
+Example for a noisy local debug session:
+
+```sh
+export VRFY=-1
+./yourprog
+```
+
+For quieter output with checks still on:
+
+```sh
+export VRFY=-2
+./yourprog
+```
+
+---
+
+## Developer builds: compiler sanitizers
+
+[AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) helps find
+out-of-bounds accesses, use-after-free, and related memory bugs in the Unicon runtime and
+in native code. It is supported when building with GCC or Clang on typical Unix-like hosts.
+
+**Configure and build** with ASan enabled. Adding `--enable-debug` gives debug symbols so
+stack traces and debuggers are usable:
+
+```sh
+./configure --enable-asan --enable-debug
+make -j
+```
+
+Other `configure` switches select additional LLVM/GCC sanitizers (flags are applied to compile
+and link steps, including shared libraries):
+
+| Option | Effect |
+|--------|--------|
+| `--enable-asan` | AddressSanitizer (`-fsanitize=address`) |
+| `--enable-tsan` | ThreadSanitizer (`-fsanitize=thread`) |
+| `--enable-ubsan` | UndefinedBehaviorSanitizer (`-fsanitize=undefined`) |
+| `--enable-msan` | MemorySanitizer (`-fsanitize=memory`) |
+| `--enable-hwasan` | HardwareAssisted AddressSanitizer (`-fsanitize=hwaddress`; common on AArch64) |
+
+Use **at most one** of `--enable-asan`, `--enable-tsan`, `--enable-msan`, and `--enable-hwasan`.
+**`--enable-ubsan`** may be combined with `--enable-asan` or `--enable-tsan`. MSan usually needs
+a toolchain (and often libc) built for MemorySanitizer. After `./configure`, `unicon-config.log`
+shows a single summary line such as `San: ASan UBSan`, or `San: no` when none of these are enabled.
+
+**Optional runtime tuning** via `ASAN_OPTIONS`, for example:
+
+```sh
+export ASAN_OPTIONS=abort_on_error=1:verbosity=1
+./bin/iconx prog.icn
+```
+
+**LeakSanitizer** runs with ASan on typical Linux setups and treats any allocation
+still live at exit as a leak, which can cause `make` to fail while building.
+If remaining leak reports are only a distraction while you care about
+**memory safety errors** (not leaks),
+you can disable leak detection for the whole build:
+
+```sh
+export ASAN_OPTIONS=detect_leaks=0
+make -j
+```
+
+**Debug under GDB** as usual; the process is already instrumented:
+
+```sh
+gdb --args ./bin/iconx prog.icn
+```
+
+Use the same `ASAN_OPTIONS` in the environment GDB passes to the program if you need
+specific sanitizer behavior while stepping.
+
+---
+
+## Further reading
+
+- Shipped documentation index: [`doc/README.md`](doc/README.md)
+- Continuous integration: [`.github/workflows/build.yml`](.github/workflows/build.yml)
+- Heap / verification details in the implementation book: `doc/ib/` (e.g. discussion of `VRFY` in the appendices)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ including most Linux distributions, Windows, macOS, and BSD systems. It also sup
 most modern CPU architectures such as i386, amd64, armhf, arm64, and ppc64el.
 
 
+Documentation
+-------------
+Shipped manuals, technical reports, and other files are indexed under **[`doc/`](doc/)** — see **[`doc/README.md`](doc/README.md)** for the full list. More books and UTRs are linked from [unicon.sourceforge.io](https://unicon.sourceforge.io/).
+
+**GitHub Pages:** [uniconproject.github.io/unicon](https://uniconproject.github.io/unicon/) (this README) · **[`doc/`](doc/)** for the documentation index.
+
+
 Installation
 ------------
 The latest sources are available from Unicon's git repositories on SourceForge and GitHub.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,40 @@
-Unicon
-======
+# Unicon
 
-Unicon is a very high level programming language. It runs on many operating systems
-including most Linux distributions, Windows, macOS, and BSD systems. It also supports
-most modern CPU architectures such as i386, amd64, armhf, arm64, and ppc64el.
+Unicon is a very high level programming language descended from [Icon](https://www.cs.arizona.edu/icon/): expression-based, **goal-directed** evaluation, rich string and structure handling, and integrated graphics and systems programming features. It is a **general-purpose** language with object-oriented extensions, concurrency, and database and network libraries, used for teaching, research, and applications. It runs on many operating systems (Linux, Windows, macOS, BSD) and on common CPU architectures (e.g. i386, amd64, arm64).
 
+**License:** the project is distributed under the **GNU General Public License**; see the [COPYING](COPYING) file in this repository (Debian packaging references **GPL-2+** in `debian/copyright`).
 
-Documentation
--------------
-Shipped manuals, technical reports, and other files are indexed under **[`doc/`](doc/)** — see **[`doc/README.md`](doc/README.md)** for the full list. More books and UTRs are linked from [unicon.sourceforge.io](https://unicon.sourceforge.io/).
+## Contents
+
+- [Documentation](#documentation)
+- [Installation](#installation)
+- [Build Instructions](#build-instructions)
+- [Contributing](#contributing)
+- [Help](#help)
+
+## Documentation
+
+Shipped manuals, technical reports, and other files are indexed under **[`doc/`](doc/)** — see **[`doc/README.md`](doc/README.md)** for the full list. On [unicon.sourceforge.io](https://unicon.sourceforge.io/), **[Books](https://unicon.sourceforge.io/ubooks.html)** lists editions and free PDFs (including *Programming with Unicon* and related titles), and **[Unicon Programming](https://unicon.sourceforge.io/up/index.html)** is an example-oriented online guide. **[Rosetta Code](https://rosettacode.org/wiki/Category:Unicon)** has Unicon solutions for many programming tasks. More technical reports and resources are linked from the project site.
 
 **GitHub Pages:** [uniconproject.github.io/unicon](https://uniconproject.github.io/unicon/) (this README) · **[`doc/`](doc/)** for the documentation index.
 
+### Editors and IDEs
 
-Installation
-------------
-The latest sources are available from Unicon's git repositories on SourceForge and GitHub.
+**Syntax highlighting:** [`config/editor/`](config/editor/) ships highlighting and editor integration files for several environments (GNU Emacs, Sublime Text, Notepad++, and others); see [`config/editor/README`](config/editor/README) for installation notes.
+
+**Visual Studio Code:** a [`.vscode/`](.vscode/) directory in this repository holds workspace settings (tasks, launch, optional recommendations). Unicon support is available in three extensions: [**Unicon Helper**](https://marketplace.visualstudio.com/items?itemName=jafar.unicon-lsp), [**Unicon Debugger**](https://marketplace.visualstudio.com/items?itemName=jafar.unicon-debugger), and [**Unicon Syntax**](https://marketplace.visualstudio.com/items?itemName=jafar.unicon-syntax) — or search the [Marketplace](https://marketplace.visualstudio.com/search?term=unicon&target=VSCode) for “Unicon”.
+
+
+## Installation
+
+The latest sources are available from Unicon's git repositories and GitHub.
 To get the sources from either repo do:
 
 ```
 git clone https://github.com/uniconproject/unicon.git
 
 ```
-or
 
-```
-git clone git://git.code.sf.net/p/unicon/unicon
-```
 On Windows systems it is advised to add the `--config core.autocrlf=input` option to the `git` command.
 `git` is available on Linux via the standard package managers, for example on a Debian system:
 
@@ -34,14 +42,13 @@ On Windows systems it is advised to add the `--config core.autocrlf=input` optio
 sudo apt install git
 ```
 On macOS git is available with Xcode. On Windows you can install and set up git using the instructions:
-[here](http://unicon.org/git.html)
+[here](https://unicon.org/git.html)
 
-For source tarballs and binary distributions, see unicon.org
-[download page](http://unicon.org/downloads.html)
+For source tarballs and binary distributions, see the unicon.org
+[download page](https://unicon.org/downloads.html).
 
 
-Build Instructions
-------------------
+## Build Instructions
 
 _Prerequisites_
 - Gnu/Unix utilities such as shell, make, grep, etc.
@@ -65,7 +72,7 @@ can be turned off by doing `--disable-FEATURE`, for example:
 disables all graphics support. On the other hand, some features are disabled by default. Those can
 be turned on by doing `--enable-FEATURE`, for example, to enable operator overloading:
 ```
---configure --enable-ovld
+./configure --enable-ovld
 ```
 One other aspect to consider is that the configure script is opportunistic when it comes to turning on features.
 Features that are enabled by default will be disabled automatically if they are missing dependencies. If you want
@@ -211,67 +218,12 @@ make
 ```
 
 
-Compiler sanitizers
--------------------
+## Contributing
 
-[AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) helps find
-out-of-bounds accesses, use-after-free, and related memory bugs in the Unicon runtime and
-in native code. It is supported when building with GCC or Clang on typical Unix-like hosts.
-
-**Configure and build** with ASan enabled. Adding `--enable-debug` gives debug symbols so
-stack traces and debuggers are usable:
-
-```
-./configure --enable-asan --enable-debug
-make -j
-```
-
-Other configure switches select additional LLVM/GCC sanitizers (flags are applied to compile
-and link steps, including shared libraries):
-
-| Option | Effect |
-|--------|--------|
-| `--enable-asan` | AddressSanitizer (`-fsanitize=address`) |
-| `--enable-tsan` | ThreadSanitizer (`-fsanitize=thread`) |
-| `--enable-ubsan` | UndefinedBehaviorSanitizer (`-fsanitize=undefined`) |
-| `--enable-msan` | MemorySanitizer (`-fsanitize=memory`) |
-| `--enable-hwasan` | HardwareAssisted AddressSanitizer (`-fsanitize=hwaddress`; common on AArch64) |
-
-Use **at most one** of `--enable-asan`, `--enable-tsan`, `--enable-msan`, and `--enable-hwasan`.
-**`--enable-ubsan`** may be combined with `--enable-asan` or `--enable-tsan`. MSan usually needs
-a toolchain (and often libc) built for MemorySanitizer. After `./configure`, `unicon-config.log`
-shows a single summary line such as `San: ASan UBSan`, or `San: no` when none of these are enabled.
-
-**Optional runtime tuning** via `ASAN_OPTIONS`, for example:
-
-```
-export ASAN_OPTIONS=abort_on_error=1:verbosity=1
-./bin/iconx prog.icn
-```
-
-**LeakSanitizer** runs with ASan on typical Linux setups and treats any allocation
-still live at exit as a leak, which can cause `make` to fail while building.
-If remaining leak reports are only a distraction while you care about
-**memory safety errors** (not leaks),
-you can disable leak detection for the whole build:
-
-```
-export ASAN_OPTIONS=detect_leaks=0
-make -j
-```
-
-**Debug under GDB** as usual; the process is already instrumented:
-
-```
-gdb --args ./bin/iconx prog.icn
-```
-
-Use the same `ASAN_OPTIONS` in the environment GDB passes to the program if you need
-specific sanitizer behavior while stepping.
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for reporting issues, pull requests, and **developer builds** (compiler sanitizers, GDB, `ASAN_OPTIONS`, etc.).
 
 
-Help
-----
+## Help
 
-Questions and comments to: jeffery@unicon.org
-
+- **GitHub:** [Issues](https://github.com/uniconproject/unicon/issues) for bugs and feature requests.
+- **Email:** [jeffery@unicon.org](mailto:jeffery@unicon.org) for other questions and comments.

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,6 +4,18 @@ This page indexes manuals, technical reports, and HTML shipped under `doc/` in t
 
 **On the web:** the [Unicon project site](https://unicon.sourceforge.io/) hosts a [Books](https://unicon.sourceforge.io/ubooks.html) page and a [Technical Reports](https://unicon.sourceforge.io/reports.html) index with downloads and mirrors for many of the same works.
 
+## Contents
+
+- [Programming with Unicon](#programming-with-unicon)
+- [The Icon Programming Language Implementation](#the-icon-programming-language-implementation)
+- [Unicon Technical Reports (UTRs)](#unicon-technical-reports-utrs)
+  - [Unicode reference data (for UTF-8 / UTR work)](#unicode-reference-data-for-utf-8-utr-work)
+- [Other documentation](#other-documentation)
+  - [General Unicon pages](#general-unicon-pages)
+  - [Icon 9.3 legacy](#icon-93-legacy)
+  - [UDB — Unicon debugger](#udb-unicon-debugger)
+- [Building PDFs from LaTeX](#building-pdfs-from-latex)
+
 ---
 
 ## Programming with Unicon
@@ -42,7 +54,7 @@ Standard Markdown tables use equal column widths, so a narrow “#” column sti
 - **UTR #7** — [HTML](utr/utr7.html) — *Version 13.1 of Unicon for Microsoft Windows*
 - **UTR #8** — [HTML](unicon/utr8.html), [PDF](unicon/utr8.pdf) — *Unicon Language Reference*
 - **UTR #9** — [HTML](utr/utr9.html), [PDF](utr/utr9c.pdf) — *Unicon 3D Graphics User's Guide and Reference Manual*
-- **UTR #10** — [HTML](utr/utr10.html), [HTML](udb/utr10.html), [PDF](udb/utr10.pdf), [Word](udb/utr10.docx) — *Debugging With UDB*
+- **UTR #10** — [HTML (utr)](utr/utr10.html), [HTML (udb)](udb/utr10.html), [PDF](udb/utr10.pdf), [Word](udb/utr10.docx) — *Debugging With UDB*
 - **UTR #11** — [HTML](unicon/utr11.html) — *Unicon Manual Page*
 - **UTR #12** — [HTML](utr/utr12.html) — *UI: a Unicon Development Environment*
 - **UTR #13** — [OpenDocument](utr/utr13.odt) — *The Unicon Messaging Facilities*

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,150 @@
+# Unicon documentation
+
+This page indexes manuals, technical reports, and HTML shipped under `doc/` in the source tree. Paths are relative to `doc/`.
+
+**On the web:** the [Unicon project site](https://unicon.sourceforge.io/) hosts a [Books](https://unicon.sourceforge.io/ubooks.html) page and a [Technical Reports](https://unicon.sourceforge.io/reports.html) index with downloads and mirrors for many of the same works.
+
+---
+
+## Programming with Unicon
+
+LaTeX source for the book *Programming with Unicon*. See also the site’s [Books](https://unicon.sourceforge.io/ubooks.html) page for published editions and related titles.
+
+- [README](book/README) — LaTeX build notes and TeX package dependencies
+- [`*.tex` sources](book/) — book manuscript (no standalone `.html` / `.md` in-tree)
+
+*Location in tree: `doc/book/`.*
+
+---
+
+## The Icon Programming Language Implementation
+
+Implementation-oriented LaTeX (parts 1–3, appendices) for *The Icon Programming Language Implementation*.
+
+- [`*.tex` sources](ib/) — full manuscript (no `.html` / `.md` / `.txt` in-tree)
+
+*Location in tree: `doc/ib/`.*
+
+---
+
+## Unicon Technical Reports (UTRs)
+
+Numbered project reports (UTR #1, UTR #2, …). HTML, PDF, and office exports may live under `doc/utr/`, `doc/unicon/`, or `doc/udb/` depending on age and format. The [Technical Reports](https://unicon.sourceforge.io/reports.html) page on [unicon.sourceforge.io](https://unicon.sourceforge.io/) lists reports with links to PDFs/HTML on unicon.org and elsewhere.
+
+Standard Markdown tables use equal column widths, so a narrow “#” column still wastes space. Each report below is one line: **UTR #N** — format links — *title*.
+
+- **UTR #1** — [HTML](unicon/utr1/utr1.htm) — *An ODBC Interface for the Unicon Programming Language*
+- **UTR #2** — [PDF](unicon/utr2.pdf) — *iflex: A Lexical Analyzer Generator for Icon*
+- **UTR #3** — [PDF](unicon/utr3.pdf) — *iyacc: A Parser Generator for Icon*
+- **UTR #4** — [HTML](unicon/utr4.html) — *Writing CGI and PHP Scripts in Icon and Unicon*
+- **UTR #5** — [PDF](unicon/utr5.pdf), [OpenDocument](utr/utr5b.odt) — *The Implementation of Graphics in Unicon* (V10 PDF; V12 internals in ODT **UTR-5b**)
+- **UTR #6** — [HTML](utr/utr6.html), [HTML (Word export)](unicon/utr6.html), [fragment](unicon/utr6/header.htm) — *An IVIB Primer* (`header.htm` is a small fragment; main body is `utr6.html`)
+- **UTR #7** — [HTML](utr/utr7.html) — *Version 13.1 of Unicon for Microsoft Windows*
+- **UTR #8** — [HTML](unicon/utr8.html), [PDF](unicon/utr8.pdf) — *Unicon Language Reference*
+- **UTR #9** — [HTML](utr/utr9.html), [PDF](utr/utr9c.pdf) — *Unicon 3D Graphics User's Guide and Reference Manual*
+- **UTR #10** — [HTML](utr/utr10.html), [HTML](udb/utr10.html), [PDF](udb/utr10.pdf), [Word](udb/utr10.docx) — *Debugging With UDB*
+- **UTR #11** — [HTML](unicon/utr11.html) — *Unicon Manual Page*
+- **UTR #12** — [HTML](utr/utr12.html) — *UI: a Unicon Development Environment*
+- **UTR #13** — [OpenDocument](utr/utr13.odt) — *The Unicon Messaging Facilities*
+- **UTR #14** — [Word](utr/utr14.docx) — *Unicon Threads User's Guide and Reference Manual*
+- **UTR #21** — [HTML](utr/utr21.html) — *Configuring and Building Version 13 of Unicon*
+
+### Unicode reference data (for UTF-8 / UTR work)
+
+Machine-readable tables in `doc/utr/utf8/`:
+
+- [UnicodeData.txt](utr/utf8/UnicodeData.txt) — Unicode character database  
+- [CaseFolding.txt](utr/utf8/CaseFolding.txt) — case-folding mappings  
+- [SpecialCasing.txt](utr/utf8/SpecialCasing.txt) — special-casing rules  
+- [utf8info.txt](utr/utf8/utf8info.txt) — UTF-8 / Unicon notes  
+
+---
+
+## Other documentation
+
+### General Unicon pages
+
+Pages that are not a single numbered UTR (guides, indexes, examples).
+
+| File | Title / purpose |
+|------|-----------------|
+| [faq.html](unicon/faq.html) | *Unicon: Frequently Asked Questions* |
+| [posix.html](unicon/posix.html) | *Unicon: A Posix Interface for the Icon Programming Language* |
+| [reports.html](unicon/reports.html) | *Technical Reports* — in-tree index; see also the project site [Technical Reports](https://unicon.sourceforge.io/reports.html) |
+| [svn.html](unicon/svn.html) | *Unicon Source Code SVN Repository* — **legacy** (SVN; development uses Git today) |
+| [simple.html](unicon/simple.html), [simp.html](unicon/simp.html) | *A Simple Example — Using the CGI Icon Library* |
+
+*Location in tree: `doc/unicon/`.*
+
+### Icon 9.3 legacy
+
+Inherited Icon Project documents (IPDs), FAQs, and manual pages.
+
+**Index**
+
+- [README](icon/README) — lists IPDs and manual pages  
+
+**HTML**
+
+| File | Title |
+|------|--------|
+| [faq.htm](icon/faq.htm) | *Frequently Asked Questions about the Icon programming language* |
+| [ipd266.htm](icon/ipd266.htm) | *An Overview of the Icon Programming Language; Version 9* |
+| [ipd281.htm](icon/ipd281.htm) | *Graphics Facilities for the Icon Programming Language; Version 9.3* |
+| [ipd283.htm](icon/ipd283.htm) | *The Icon Program Library; Version 9.3.3* |
+
+**PDF — manual pages**
+
+- [icon.1.pdf](icon/icon.1.pdf) — *icon*(1) — Icon interpreter/compiler  
+- [icon_vt.1.pdf](icon/icon_vt.1.pdf) — *icon_vt*(1) — variant translator  
+
+**PDF — Icon Project Documents (IPD)**
+
+- [ipd046.pdf](icon/ipd046.pdf) — *Trouble report form*
+- [ipd112.pdf](icon/ipd112.pdf) — *Version 8.0 implementation differences*
+- [ipd177.pdf](icon/ipd177.pdf) — *Supporting documentation for XPM*
+- [ipd193.pdf](icon/ipd193.pdf) — *Support Procedures for Icon Program Monitors*
+- [ipd237.pdf](icon/ipd237.pdf) — *Version 9 compiler*
+- [ipd238.pdf](icon/ipd238.pdf) — *Configuring the Version 9 source code*
+- [ipd239.pdf](icon/ipd239.pdf) — *Version 9 implementation differences*
+- [ipd240.pdf](icon/ipd240.pdf) — *Calling C functions*
+- [ipd241.pdf](icon/ipd241.pdf) — *Version 9 benchmark report*
+- [ipd243.pdf](icon/ipd243.pdf) — *Installing Version 9 on UNIX platforms*
+- [ipd244.pdf](icon/ipd244.pdf) — *Icon 9 UNIX Manual Page* (`icon`, `icont`, `iconc`)
+- [ipd245.pdf](icon/ipd245.pdf) — *Variant translators*
+- [ipd246.pdf](icon/ipd246.pdf) — *Icon 9 Variant Translator UNIX Manual Page* (`icon_vt`)
+- [ipd256.pdf](icon/ipd256.pdf) — *Version 9 UNIX user's manual*
+- [ipd261.pdf](icon/ipd261.pdf) — *RTL manual*
+- [ipd263.pdf](icon/ipd263.pdf) — *Building source-code processors for Icon*
+- [ipd265.pdf](icon/ipd265.pdf) — *Visual interface builder*
+- [ipd266.pdf](icon/ipd266.pdf) — *An Overview of the Icon Programming Language; Version 9*
+- [ipd271.pdf](icon/ipd271.pdf) — *Version 9 of Icon for Microsoft Windows*
+- [ipd278.pdf](icon/ipd278.pdf) — *Version 9.3 language features*
+- [ipd279.pdf](icon/ipd279.pdf) — *Version 9.3 Icon program library*
+- [ipd280.pdf](icon/ipd280.pdf) — *Icon glossary*
+- [ipd281.pdf](icon/ipd281.pdf) — *Graphics Facilities for the Icon Programming Language; Version 9.3*
+- [ipd283.pdf](icon/ipd283.pdf) — *The Icon Program Library; Version 9.3.3*
+
+*Location in tree: `doc/icon/`.*
+
+### UDB — Unicon debugger
+
+Overview of the source-level debugger. Full treatment of debugging is **UTR #10** in [Unicon Technical Reports (UTRs)](#unicon-technical-reports-utrs) above.
+
+- [index.html](udb/index.html) — *UDB: The Unicon Source-Level Debugger* (overview)
+
+*Location in tree: `doc/udb/`.*
+
+---
+
+## Building PDFs from LaTeX
+
+The book, implementation book, and UTR LaTeX trees have `Makefile` targets. From the repository root:
+
+```sh
+make -C doc/book
+make -C doc/ib
+make -C doc/utr
+```
+
+See each directory’s `Makefile` for targets and prerequisites.


### PR DESCRIPTION
## Summary
- Add **`CONTRIBUTING.md`** as the place for contributor-focused material: `configure` options (debug / devmode / heap), **`VRFY` / `VRFYOP`** when VerifyHeap is enabled, sanitizer builds, and PR expectations.
- Refresh the root **`README.md`**: clearer intro, table of contents, license pointer to **`COPYING`**, HTTPS links to unicon.org, fix **`./configure`** example (was shown as `--configure`), and move sanitizer details to **`CONTRIBUTING.md`** so the README stays a high-level entry point.
- Update **`.github/workflows/pages.yml`** so GitHub Pages documents the deployed artifacts (README → `index.html`, `doc/`, **`CONTRIBUTING.md`** / **`CONTRIBUTING.html`**, **`COPYING`**) and fail fast if **`CONTRIBUTING.md`** or **`COPYING`** is missing.
