### PR TITLE
config: fix layout width via single body max-width

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,11 @@
 #   README.md → index.html; doc/** mirrored; doc/README.md → doc/index.html
 #   CONTRIBUTING / COPYING → .md + .html; config/editor/**; doc/book, doc/icon, doc/ib indexes
 #   Link pass: internal .md/COPYING/README paths → /unicon/… HTML routes
-# Repo Settings → Pages → Source: GitHub Actions.
+#
+# Pages must use THIS workflow (pandoc + nav). If Settings → Pages → Build: Deployment
+# source is a branch instead of "GitHub Actions", GitHub serves Jekyll-rendered README
+# (no top nav, theme style.css). Fix: Settings → Pages → set Source to GitHub Actions.
+# https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site
 #
 # Pull requests run build only (no deploy) so you can verify before merge.
 

--- a/config/scripts/gh-pages/assets/site.css
+++ b/config/scripts/gh-pages/assets/site.css
@@ -6,42 +6,49 @@
   --border: #d1d9e0;
   --link: #0969da;
   --nav-bg: #ffffff;
-  /* Default: comfortable measure for phones/small laptops */
+  /* One knob for content width — applied on body below (no competing body > * max-width). */
   --max: 52rem;
 }
 
-/* Use more horizontal space on wide screens (avoids a “phone column” on desktop) */
 @media (min-width: 1100px) {
   :root {
-    --max: min(72rem, 92vw);
+    --max: min(72rem, 94vw);
   }
 }
 
 @media (min-width: 1600px) {
   :root {
-    --max: min(82rem, 90vw);
+    --max: min(85rem, 92vw);
   }
 }
+
 * { box-sizing: border-box; }
+
+html {
+  background: var(--bg);
+}
+
 body {
-  margin: 0;
+  margin: 0 auto;
+  max-width: var(--max);
+  padding-left: 1rem;
+  padding-right: 1rem;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.55;
   color: var(--text);
   background: var(--bg);
 }
+
 .unicon-site-nav {
   background: var(--nav-bg);
   border-bottom: 1px solid var(--border);
-  padding: 0.65rem 1rem;
+  padding: 0.65rem 0;
   position: sticky;
   top: 0;
   z-index: 10;
 }
 .unicon-site-nav-inner {
-  max-width: var(--max);
-  margin: 0 auto;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -56,42 +63,6 @@ body {
 .unicon-site-nav a:hover { text-decoration: underline; }
 .unicon-site-nav .sep { color: var(--muted); user-select: none; }
 .unicon-site-nav .home { margin-right: 0.25rem; }
-
-/* Main column: pandoc emits flat body children between nav and footer.
-   :where() keeps specificity low so body > p / body > pre rules below win for max-width. */
-body > :where(*:not(.unicon-site-nav):not(.unicon-site-footer)) {
-  max-width: var(--max);
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-/* Full column width: code blocks, tables, highlighted code (div.sourceCode), figures */
-body > pre,
-body > table,
-body > div.sourceCode,
-body > figure {
-  max-width: var(--max);
-}
-
-/* ~65ch measure for body text, headings, lists, TOC */
-body > p,
-body > ul,
-body > ol,
-body > dl,
-body > h1,
-body > h2,
-body > h3,
-body > h4,
-body > h5,
-body > h6,
-body > blockquote,
-body > hr,
-body > header,
-body > nav#TOC {
-  max-width: min(65ch, calc(100% - 2rem));
-}
 
 #title-block-header,
 header {
@@ -112,9 +83,8 @@ pre {
   border-radius: 6px;
 }
 .unicon-site-footer {
-  max-width: var(--max);
-  margin: 2rem auto 0;
-  padding: 1rem;
+  margin: 2rem 0 0;
+  padding: 1rem 0;
   border-top: 1px solid var(--border);
   font-size: 0.875rem;
   color: var(--muted);

--- a/config/scripts/gh-pages/serve-local.sh
+++ b/config/scripts/gh-pages/serve-local.sh
@@ -27,4 +27,5 @@ cd "$TMP"
 
 echo "Open: http://127.0.0.1:${PORT}/unicon/"
 echo "CSS and nav use /unicon/... paths (same as github.io). Ctrl+C to stop."
+echo "After changing the site, run build-gh-pages-site.sh again, then restart this script (copy is one-time)."
 exec python3 -m http.server "$PORT"


### PR DESCRIPTION

Apply --max only on body (drop competing body > * max-width rules) so responsive breakpoints behave predictably. Note in pages.yml that branch deployment serves Jekyll without pandoc nav. Remind in serve-local.sh to rebuild and restart after site changes.