### PR TITLE
rtt: speed up iconc rtt build by passing all files at once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Parallel gcc inside urtt (HAVE_WORKING_FORK); does not change default local builds.
+env:
+  RTT_JOBS: "16"
+
 jobs:
   Windows:
     runs-on: ${{ matrix.cfg.os }}
@@ -48,7 +52,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: windows-latest,  name: 'Windows 64-bit', pkg: 'Windows_64-bit',  opt: '--disable-iconc --enable-werror' }
+        -  { os: windows-latest,  name: 'Windows 64-bit', pkg: 'Windows_64-bit',  opt: '--enable-werror' }
         #-  { os: windows-latest,  name: 'Windows 32-bit', opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
 
     defaults:
@@ -290,8 +294,8 @@ jobs:
     strategy:
       matrix:
         platform:
-         -  { arch: riscv64 } # emulated
-         -  { arch: x86 }
+         -  { arch: riscv64, configure_opt: '--disable-iconc' } # emulated; skip iconc
+         -  { arch: x86, configure_opt: "" }
     steps:
     - name: Install extra dependencies
       shell: 'sh'
@@ -311,7 +315,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Configure
-      run: ./configure --disable-iconc
+      run: ./configure ${{ matrix.platform.configure_opt }}
       shell: alpine.sh {0}
 
     - name: Make

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    env:
+      RTT_JOBS: "16"
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,6 +18,9 @@ concurrency:
   group: packages-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RTT_JOBS: "16"
+
 jobs:
   Windows:
     runs-on: ${{ matrix.cfg.os }}
@@ -26,7 +29,7 @@ jobs:
     strategy:
       matrix:
         cfg:
-        -  { os: windows-2022,  name: 'Windows_64-bit',  opt: '--disable-iconc' }
+        -  { os: windows-2022,  name: 'Windows_64-bit',  opt: '' }
         #-  { os: windows-latest,  name: 'Windows_32-bit', opt: '--build=i686-w64-mingw32 --host=i686-w64-mingw32' }
 
     defaults:

--- a/Makedefs.in
+++ b/Makedefs.in
@@ -90,6 +90,7 @@ UNICONHOST=@unicon_host@
 SHELL = /bin/sh
 # Prepend detect_leaks=0 for urtt so LSan does not fail the build when ASan is on;
 # merge with any ASAN_OPTIONS the user already set (e.g. abort_on_error=1).
+# urtt: runtime may pass -j N via RTT_JFLAG when RTT_CC_JOBS is known; else urtt uses MAKEFLAGS. Override: RTT_JOBS env.
 RTT=env ASAN_OPTIONS="detect_leaks=0$${ASAN_OPTIONS:+:$${ASAN_OPTIONS}}" ../../bin/urtt
 RM = rm -f
 CP = cp -f

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 #  Top Level Makefile for Unicon
 #
-# Keep Makefile in sync with this file except for the first two assignments (srcdir/TOPDIR).
-#
 # Out-of-tree builds: run configure from a build directory (e.g. ../configure).
 # TOPDIR is the source tree; UNICON_TOP_BUILDDIR is the configure/build directory (Makedefs,
 # auto.h, config.status). Object files and binaries still go under TOPDIR in this phase; switch

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,5 @@
 #  Top Level Makefile for Unicon
 #
-# Keep Makefile in sync with this file except for the first two assignments (srcdir/TOPDIR).
-#
 # Out-of-tree builds: run configure from a build directory (e.g. ../configure).
 # TOPDIR is the source tree; UNICON_TOP_BUILDDIR is the configure/build directory (Makedefs,
 # auto.h, config.status). Object files and binaries still go under TOPDIR in this phase; switch

--- a/plugins/src/SHA/Makefile
+++ b/plugins/src/SHA/Makefile
@@ -17,6 +17,11 @@ RFCDIR = ./RFC6234
 RFC6234Files = $(RFCDIR)/sha1.o $(RFCDIR)/sha224-256.o ./$(RFCDIR)/sha384-512.o \
 			./$(RFCDIR)/usha.o ./$(RFCDIR)/hkdf.o ./$(RFCDIR)/hmac.o
 
+# One sub-make for all RFC6234 objects (stamp: works on GNU Make 3.81+). Parallel
+# make must not run "cd RFC6234; $(MAKE)" once per .o or sub-makes race on shatest/*.o.
+RFC6234_SRC := $(wildcard $(RFCDIR)/*.c)
+RFC6234_STAMP := $(RFCDIR)/.built
+
 # @Replace: add any additional (non-standard name) c source file(s) here
 COBJ = $(LNAME).o $(RFC6234Files)
 CSRC = $(LNAME).c
@@ -34,8 +39,11 @@ include ../Makedefs
 
 default:	 $(LIBD)/$(LNAME).u
 
-$(RFC6234Files):
-	cd $(RFCDIR); $(MAKE)
+$(RFC6234Files): $(RFC6234_STAMP) ;
+
+$(RFC6234_STAMP): $(RFC6234_SRC) $(RFCDIR)/Makefile
+	cd $(RFCDIR) && $(MAKE)
+	@touch $@
 
 shaPlugTest: shaPlugTest.icn
 	$(TOPDIR)/bin/unicon -s $< -o $@
@@ -45,6 +53,6 @@ test: shaPlugTest
 
 # @Replace: To add plugin specific clean up actions, include a clean:: target
 clean::
-	$(RM) shaPlugTest
+	$(RM) shaPlugTest $(RFC6234_STAMP)
 	cd $(RFCDIR); $(MAKE) $@
 

--- a/plugins/src/SHA/RFC6234/shatest.c
+++ b/plugins/src/SHA/RFC6234/shatest.c
@@ -1026,7 +1026,7 @@ int hashHkdf(int testno, int loopno, int hashno,
   int err;
   unsigned char prk[USHAMaxHashSize+1];
   uint8_t okm[255 * USHAMaxHashSize+1];
-  char buf[20];
+  char buf[32];
 
   if (printResults == PRINTTEXT) {
     printf("\nTest %d: Iteration %d\n\tSALT\t'", testno+1, loopno);

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,11 @@ default: all
 UNICON_TOP_BUILDDIR ?= $(TOPDIR)
 include $(UNICON_TOP_BUILDDIR)/Makedefs
 
+# Sub-makes often get --jobserver-auth without -jN in MAKEFLAGS; export N so runtime/urtt matches top-level -j.
+ifneq ($(filter -j%,$(MAKEFLAGS)),)
+export RTT_CC_JOBS := $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+endif
+
 # Common components.
 
 all: Common Icont iyacc Iconx $(WICONTTARGET) $(WICONXTARGET) $(ICONCTARGET)
@@ -49,7 +54,7 @@ wunicont wicont Wicont: Wiconx
 Iconc: Common Iconx
 	$(RM) iconc/*.$(O)
 	$(RM) common/doincl$(EXE)
-	$(MAKE) -j1 -C runtime comp_all_uniconc
+	$(MAKE) -C runtime comp_all_uniconc
 	$(MAKE) -C iconc
 	$(MAKE) -C common doincl
 
@@ -59,7 +64,7 @@ FreshIconc:
 	$(RM) iconc/*.$(O)
 	$(RM) ../bin/rt.h
 	$(RM) common/doincl$(EXE)
-	$(MAKE) -j1 -C runtime comp_all_uniconc
+	$(MAKE) -C runtime comp_all_uniconc
 	$(MAKE) -C iconc
 	$(MAKE) -C common doincl
 
@@ -73,7 +78,7 @@ clean Clean:
 	cd common;	$(RM) *.o doincl$(EXE) patchstr$(EXE)
 	cd preproc;	$(RM) *.o pp$(EXE)
 	cd rtt;		$(RM) *.o rtt$(EXE)
-	cd runtime;	$(RM) *.o *.c rt.db rt.a rttcur.lst rttfull.lst $(UNICONX)$(EXE) $(UNICONWX)$(EXE)
+	cd runtime;	$(RM) *.o *.c rt.db rt.a rttcur.lst rttfull.lst compiler-rtl-stamp $(UNICONX)$(EXE) $(UNICONWX)$(EXE)
 	cd icont;	$(RM) *.o $(UNICONT)$(EXE) $(UNICONWT)$(EXE)
 	cd xpm;		$(RM) *.o *.a
 	cd xpm/lib;	$(RM) *.o *.a

--- a/src/common/mlocal.c
+++ b/src/common/mlocal.c
@@ -530,3 +530,147 @@ void get_arch(char *arch){
 
   sprintf(arch, "Arch %s_%d", s, WordBits);
 }
+
+/*
+ * unicon_win32_cmdline_to_argv / unicon_win32_argv_free --
+ * NT command line to argv (whitespace, quotes, FINDFIRST globs).
+ * Matches rsys.r CmdParamToArgv except Graphics < > redirection.
+ */
+#if defined(NT) && WildCards
+
+#include "../h/filepat.h"
+
+static char *dup_win32_argv(const char *p)
+{
+   char *q = strdup(p);
+
+   if (q == NULL) {
+      fprintf(stderr, "unicon_win32_cmdline_to_argv: out of memory\n");
+      exit(EXIT_FAILURE);
+   }
+   return q;
+}
+
+static void argv_grow(char ***avp, size_t n)
+{
+   char **p = realloc(*avp, n * sizeof(char *));
+
+   if (p == NULL) {
+      fprintf(stderr, "unicon_win32_cmdline_to_argv: out of memory\n");
+      exit(EXIT_FAILURE);
+   }
+   *avp = p;
+}
+
+int unicon_win32_cmdline_to_argv(char *s, char ***avp, int dequote)
+{
+   char tmp[MaxPath];
+   char *t = dup_win32_argv(s);
+   char *t2 = t;
+   int rv = 0;
+
+   *avp = NULL;
+   argv_grow(avp, 2);
+   (*avp)[rv] = NULL;
+
+   while (*t2) {
+      while (*t2 && isspace((unsigned char)*t2))
+         t2++;
+      switch (*t2) {
+      case '\0':
+         break;
+      case '"': {
+         char *t3, c = '\0';
+
+         if (dequote)
+            t3 = ++t2;
+         else
+            t3 = t2++;
+         while (*t2 && (*t2 != '"'))
+            t2++;
+         if (*t2 && !dequote)
+            t2++;
+         if ((c = *t2))
+            *t2++ = '\0';
+         argv_grow(avp, (size_t)rv + 2);
+         (*avp)[rv++] = dup_win32_argv(t3);
+         (*avp)[rv] = NULL;
+         if (!dequote && c)
+            *--t2 = c;
+         break;
+      }
+      default: {
+         FINDDATA_T fd;
+         char *t3 = t2;
+
+         while (*t2 && !isspace((unsigned char)*t2))
+            t2++;
+         if (*t2)
+            *t2++ = '\0';
+         strcpy(tmp, t3);
+
+         if (!strcmp(tmp, ">") || !FINDFIRST(tmp, &fd)) {
+            argv_grow(avp, (size_t)rv + 2);
+            (*avp)[rv++] = dup_win32_argv(t3);
+            (*avp)[rv] = NULL;
+         } else {
+            char dir[MaxPath];
+            int end;
+
+            strcpy(dir, t3);
+            do {
+               end = (int)strlen(dir) - 1;
+               while (end >= 0 && dir[end] != '\\' && dir[end] != '/' &&
+                      dir[end] != ':') {
+                  dir[end] = '\0';
+                  end--;
+               }
+               strcat(dir, FILENAME(&fd));
+               argv_grow(avp, (size_t)rv + 2);
+               (*avp)[rv++] = dup_win32_argv(dir);
+               (*avp)[rv] = NULL;
+            } while (FINDNEXT(&fd));
+            FINDCLOSE(&fd);
+         }
+         break;
+      }
+      }
+   }
+   free(t);
+   return rv;
+}
+
+void unicon_win32_argv_free(int argc, char **argv)
+{
+   int i;
+
+   if (argv == NULL)
+      return;
+   for (i = 0; i < argc; i++)
+      free(argv[i]);
+   free(argv);
+}
+
+#else                                   /* !(NT && WildCards) */
+
+int unicon_win32_cmdline_to_argv(char *s, char ***avp, int dequote)
+{
+   (void)s;
+   (void)dequote;
+   *avp = NULL;
+   return -1;
+}
+
+void unicon_win32_argv_free(int argc, char **argv)
+{
+   int i;
+
+   (void)argc;
+   if (argv == NULL)
+      return;
+   for (i = 0; i < argc; i++)
+      free(argv[i]);
+   free(argv);
+}
+
+#endif                                  /* NT && WildCards */

--- a/src/h/mproto.h
+++ b/src/h/mproto.h
@@ -67,3 +67,8 @@ char *relfile   (char *prog, char *mod);
 #if UNIX
    FILE *pathOpen       (char *fname, char*mode);
 #endif
+
+#if NT
+int unicon_win32_cmdline_to_argv(char *s, char ***avp, int dequote);
+void unicon_win32_argv_free(int argc, char **argv);
+#endif                                  /* NT */

--- a/src/rtt/rttmain.c
+++ b/src/rtt/rttmain.c
@@ -2,10 +2,27 @@
 
 /*#include "../h/filepat.h"             ?* added for filepat change */
 
+#if NT
+#include <process.h>
+#endif
+
+#ifdef HAVE_WORKING_FORK
+#include <sys/wait.h>
+#include <unistd.h>
+#endif /* HAVE_WORKING_FORK */
+
 /*
  * prototypes for static functions.
  */
 static void add_tdef (char *name);
+static void rtt_progress_file(const char *path);
+static int rtt_cc_is_tmp_chunk_c(const char *path);
+static void rtt_progress_cc(const char *path);
+#ifdef HAVE_WORKING_FORK
+static int rtt_parallel_cc(const char *ccomp, const char *copts,
+                           const char *file_list, int silent);
+static void rtt_remove_c_files(const char *file_list);
+#endif /* HAVE_WORKING_FORK */
 extern int yynerrs;
 extern int __merr_errors;
 
@@ -62,15 +79,15 @@ char *rt_path = "../src/h/rt.h";
  * End of operating-system specific code.
  */
 
-static char *ostr = "AKECPD:I:U:O:d:cir:st:x";
+static char *ostr = "AKECPD:I:U:O:d:cir:st:xj:";
 
 #if EBCDIC
 static char *options =
-   "<-A> <-E> <-C> <-P> <-K> <-c> <-O copts> <-s> <-Dname<=<text>>> <-Uname> <-Ipath> <-dfile>\n    \
+    "<-A> <-E> <-C> <-P> <-K> <-c> <-O copts> <-s> <-j n> <-Dname<=<text>>> <-Uname> <-Ipath> <-dfile>\n    \
 <-rpath> <-tname> <-x> <files>";
 #else                                   /* EBCDIC */
 static char *options =
-   "[-A] [-E] [-C] [-P] [-K] [-c] [-O copts] [-s] [-Dname[=[text]]] [-Uname] [-Ipath] [-dfile]\n    \
+    "[-A] [-E] [-C] [-P] [-K] [-c] [-O copts] [-s] [-j n] [-Dname[=[text]]] [-Uname] [-Ipath] [-dfile]\n    \
 [-rpath] [-tname] [-x] [files]";
 #endif                                  /* EBCDIC */
 
@@ -101,6 +118,65 @@ char *fulllst_string;
 static char *cur_src;                           /* current source (.r) file */
 
 static int silent = 0;
+
+/*
+ * Parallel gcc -c job cap from -j n (Unix). -1 means option not given.
+ */
+static int rtt_cc_jobs_cli = -1;
+
+/*
+ * One line per input .r while translating. Shown even when -s is set.
+ * -x => "[ICONX RTT]"; compiler RTL => "[ICONC RTT]" (matches runtime Makefile
+ * tone).
+ */
+static void rtt_progress_file(const char *path) {
+  if (path == NULL || *path == '\0')
+    return;
+  if (iconx_flg)
+    fprintf(stdout, "   [ICONX URTT] %s\n", path);
+  else
+    fprintf(stdout, "   [ICONC URTT] %s\n", path);
+  fflush(stdout);
+}
+
+/*
+ * rt.db chunk temps: f_*, o_*, k_* (e.g. f_6t.c, o_1.c, k_060.c) — not fconv.c
+ * (no "f_"). Omit [CC] for these (even with -s).
+ */
+static int rtt_cc_is_tmp_chunk_c(const char *path) {
+  const char *base, *p;
+
+  if (path == NULL || *path == '\0')
+    return 0;
+  base = path;
+  for (p = path; *p != '\0'; p++)
+    if (*p == '/' || *p == '\\')
+      base = p + 1;
+  if (strncmp(base, "f_", 2) != 0 && strncmp(base, "o_", 2) != 0 &&
+      strncmp(base, "k_", 2) != 0)
+    return 0;
+  /* f_.c — nothing between letter_ and . */
+  p = base + 2;
+  if (*p == '\0' || *p == '.')
+    return 0;
+  while (*p != '\0' && *p != '.')
+    p++;
+  return (*p == '.' && p[1] == 'c' && p[2] == '\0');
+}
+
+/*
+ * About to run the C compiler on one generated .c (urtt still prints; tool is
+ * CC).
+ */
+static void rtt_progress_cc(const char *path) {
+  if (path == NULL || *path == '\0')
+    return;
+  /* Skip whether or not -s: default builds pass -s but chunk [CC] is still noise. */
+  if (rtt_cc_is_tmp_chunk_c(path))
+    return;
+  fprintf(stdout, "   [CC] %s\n", path);
+  fflush(stdout);
+}
 
 extern int line_cntrl;
 
@@ -222,6 +298,239 @@ int_PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif                                  /* MSWindows */
 #endif                                  /* NTConsole */
 
+#ifdef HAVE_WORKING_FORK
+/*
+ * Parallel gcc -c jobs after RTT translation (when fork works: configure
+ * HAVE_WORKING_FORK — includes GNU/Linux, MSYS2, Cygwin, etc.).
+ * Precedence: -j n command line, RTT_JOBS env, MAKEFLAGS -jN, bare "make -j"
+ * in MAKEFLAGS => min(CPU, RTT_CC_MAX_JOBS), else 1.
+ */
+#define RTT_CC_MAX_JOBS 32
+#define RTT_MF_JOBS_NONE 0
+#define RTT_MF_JOBS_BARE_J (-1)
+
+/*
+ * Scan MAKEFLAGS for -jN / -j (GNU make sets this for recipe subprocesses).
+ * Returns last -jN (1..1024), RTT_MF_JOBS_BARE_J if bare -j seen without a
+ * following number, or RTT_MF_JOBS_NONE.
+ */
+static int parse_makeflags_jobs(void) {
+  const char *m = getenv("MAKEFLAGS");
+  const char *p;
+  char *end;
+  int last = RTT_MF_JOBS_NONE;
+  int saw_bare = 0;
+
+  if (m == NULL)
+    return RTT_MF_JOBS_NONE;
+  for (p = m; *p != '\0';) {
+    /* Skip --long-option tokens (e.g. --jobserver-auth=...) so "-j" in
+     * "jobserver" is not treated as a bare -j. */
+    if (p[0] == '-' && p[1] == '-') {
+      while (*p != '\0' && !isspace((unsigned char)*p))
+        p++;
+      continue;
+    }
+    if (p[0] == '-' && p[1] == 'j') {
+      const char *q = p + 2;
+      if (isdigit((unsigned char)*q)) {
+        long v = strtol(q, &end, 10);
+        p = end;
+        if (v > 0 && v <= 1024) {
+          last = (int)v;
+          saw_bare = 0;
+        }
+        continue;
+      }
+      saw_bare = 1;
+      p += 2;
+      continue;
+    }
+    p++;
+  }
+  if (last > 0)
+    return last;
+  if (saw_bare)
+    return RTT_MF_JOBS_BARE_J;
+  return RTT_MF_JOBS_NONE;
+}
+
+static int rtt_cc_max_jobs(void) {
+  char *e;
+  long n;
+  char *end;
+  long cpus;
+  int mj;
+
+  if (rtt_cc_jobs_cli > 0)
+    return rtt_cc_jobs_cli;
+
+  e = getenv("RTT_JOBS");
+  if (e != NULL && *e != '\0') {
+    n = strtol(e, &end, 10);
+    if (end != e && n > 0 && n <= 1024)
+      return (int)n;
+  }
+  mj = parse_makeflags_jobs();
+  if (mj > 0)
+    return mj;
+  if (mj == RTT_MF_JOBS_BARE_J) {
+    cpus = (long)sysconf(_SC_NPROCESSORS_ONLN);
+    if (cpus < 1)
+      cpus = 1;
+    if (cpus > RTT_CC_MAX_JOBS)
+      cpus = RTT_CC_MAX_JOBS;
+    return (int)cpus;
+  }
+  return 1;
+}
+
+static void rtt_remove_c_files(const char *file_list) {
+  char *copy, *tok;
+
+  if (file_list == NULL)
+    return;
+  copy = salloc((char *)file_list);
+  for (tok = strtok(copy, " \t\r\n"); tok != NULL;
+       tok = strtok(NULL, " \t\r\n"))
+    if (*tok != '\0')
+      remove(tok);
+  free(copy);
+}
+
+/*
+ * Run the C compiler on each generated .c file, with up to max_jobs
+ * processes at a time (fork pool when max_jobs > 1). file_list is
+ * space-separated paths. Returns 0 on success, non-zero on failure.
+ */
+static int rtt_parallel_cc(const char *ccomp, const char *copts,
+                           const char *file_list, int silent) {
+  char *copy, *copy2, *tok, *cmd;
+  size_t cmdlen;
+  int nfiles, i, fi, max_jobs, nchild, wstatus, fail;
+  pid_t pid;
+  char **files;
+
+  if (ccomp == NULL)
+    ccomp = "cc";
+  if (copts == NULL)
+    copts = "";
+
+  while (*file_list != '\0' && isspace((unsigned char)*file_list))
+    file_list++;
+
+  if (*file_list == '\0')
+    return 0;
+
+  copy = salloc((char *)file_list);
+  nfiles = 0;
+  for (tok = strtok(copy, " \t\r\n"); tok != NULL;
+       tok = strtok(NULL, " \t\r\n"))
+    if (*tok != '\0')
+      nfiles++;
+  free(copy);
+  if (nfiles == 0)
+    return 0;
+
+  files = (char **)alloc((unsigned int)(nfiles * sizeof(char *)));
+  copy2 = salloc((char *)file_list);
+  i = 0;
+  for (tok = strtok(copy2, " \t\r\n"); tok != NULL;
+       tok = strtok(NULL, " \t\r\n"))
+    if (*tok != '\0')
+      files[i++] = salloc(tok);
+  free(copy2);
+
+  max_jobs = rtt_cc_max_jobs();
+  if (max_jobs < 1)
+    max_jobs = 1;
+
+  /*
+   * Serial: must compile every file — do not use "only files[0]" when
+   * max_jobs==1 and nfiles>1 (that skipped f_*.c / o_*.c and broke ar rt.a).
+   */
+  if (max_jobs == 1) {
+    fail = 0;
+    for (i = 0; i < nfiles; i++) {
+      rtt_progress_cc(files[i]);
+      cmdlen = strlen(ccomp) + strlen(copts) + strlen(files[i]) + 16;
+      cmd = (char *)alloc((unsigned int)cmdlen);
+      sprintf(cmd, "%s -c %s %s", ccomp, copts, files[i]);
+      if (!silent) {
+        fprintf(stdout, "%s\n", cmd);
+        fflush(stdout);
+      }
+      if (system(cmd) != 0)
+        fail = 1;
+      free(cmd);
+      if (fail)
+        break;
+    }
+    for (i = 0; i < nfiles; i++)
+      free(files[i]);
+    free(files);
+    return fail;
+  }
+
+  fi = 0;
+  nchild = 0;
+  fail = 0;
+  while (fi < nfiles || nchild > 0) {
+    while (nchild < max_jobs && fi < nfiles && !fail) {
+      rtt_progress_cc(files[fi]);
+      cmdlen = strlen(ccomp) + strlen(copts) + strlen(files[fi]) + 16;
+      cmd = (char *)alloc((unsigned int)cmdlen);
+      sprintf(cmd, "%s -c %s %s", ccomp, copts, files[fi]);
+      if (!silent) {
+        fprintf(stdout, "%s\n", cmd);
+        fflush(stdout);
+      }
+      pid = fork();
+      if (pid < 0) {
+        fprintf(stderr, "%s: fork failed\n", progname);
+        free(cmd);
+        fail = 1;
+        break;
+      }
+      if (pid == 0) {
+        execl("/bin/sh", "sh", "-c", cmd, (char *)NULL);
+        _exit(127);
+      }
+      free(cmd);
+      fi++;
+      nchild++;
+    }
+    if (fail)
+      break;
+    if (nchild == 0)
+      break;
+    pid = waitpid(-1, &wstatus, 0);
+    if (pid < 0) {
+      fprintf(stderr, "%s: waitpid failed\n", progname);
+      fail = 1;
+      break;
+    }
+    nchild--;
+    if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0)
+      fail = 1;
+  }
+
+  while (nchild > 0) {
+    pid = waitpid(-1, &wstatus, 0);
+    if (pid < 0)
+      break;
+    nchild--;
+    if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0)
+      fail = 1;
+  }
+
+  for (i = 0; i < nfiles; i++)
+    free(files[i]);
+  free(files);
+  return fail;
+}
+#endif /* HAVE_WORKING_FORK */
+
 int main(int argc, char **argv)
    {
    int c;
@@ -312,6 +621,17 @@ int main(int argc, char **argv)
          case 'x':  /* produce code for interpreter rather than compiler */
             iconx_flg = 1;
             break;
+         case 'j': /* max parallel gcc -c jobs (Unix, with -c); Makefile uses -j
+                      $(RTT_CC_JOBS) */
+         {
+           char *ej;
+           long v;
+
+           v = strtol(optarg, &ej, 10);
+           if (ej == optarg || v < 1 || v > 1024)
+             show_usage();
+           rtt_cc_jobs_cli = (int)v;
+         } break;
          case 'D':  /* define preprocessor symbol */
          case 'I':  /* path to search for preprocessor includes */
          case 'U':  /* undefine preprocessor symbol */
@@ -398,11 +718,13 @@ int main(int argc, char **argv)
          }
       do {
          argv[optind] = FILENAME(&fd);
+         rtt_progress_file(argv[optind]);
          trans(argv[optind]);
       } while (FINDNEXT(&fd));
       FINDCLOSE(&fd);
 #else                                   /* WildCards */
-      trans(argv[optind]);
+     rtt_progress_file(argv[optind]);
+     trans(argv[optind]);
 #endif                                  /* WildCards */
       optind++;
       }
@@ -441,9 +763,35 @@ int main(int argc, char **argv)
          sprintf(archive_line, "%s %s %s", "ar qc rt.a",
                  fulllst_string, ccomp_opts);
 
+         rtt_progress_file("ar rt.a");
          if (!silent)
             fprintf(stdout, "%s\n", archive_line);
-         if (system(archive_line)) return EXIT_FAILURE;
+#if NT
+         /*
+          * Expand globs and split like CmdParamToArgv (see unicon_win32_* in mlocal.c),
+          * then spawn ar with an explicit argv (same idea as Unix system(archive_line)).
+          */
+         {
+            char **ar_argv;
+            int ar_argc;
+            intptr_t rc;
+
+            ar_argc = unicon_win32_cmdline_to_argv(archive_line, &ar_argv, 0);
+            if (ar_argc < 1 || ar_argv == NULL) {
+               if (ar_argv != NULL)
+                  unicon_win32_argv_free(ar_argc, ar_argv);
+               return EXIT_FAILURE;
+               }
+            rc = _spawnvp(_P_WAIT, ar_argv[0],
+                          (const char *const *)ar_argv);
+            unicon_win32_argv_free(ar_argc, ar_argv);
+            if (rc == (intptr_t)-1 || rc != 0)
+               return EXIT_FAILURE;
+         }
+#else
+         if (system(archive_line))
+            return EXIT_FAILURE;
+#endif
          }
       }
 #endif                                  /* Rttx */
@@ -462,9 +810,24 @@ int main(int argc, char **argv)
    if (ccomp_flg) {
       char *ccomp_line;
       if (ccomp_opts == NULL) ccomp_opts = "";
+#ifdef HAVE_WORKING_FORK
+      if (rtt_parallel_cc(CComp, ccomp_opts, curlst_string, silent))
+        return EXIT_FAILURE;
+      if (0 == keeptmp)
+        rtt_remove_c_files(curlst_string);
+#else  /* HAVE_WORKING_FORK */
       ccomp_line = alloc(strlen(CComp) + strlen(ccomp_opts) +
                          strlen(curlst_string) + 6);
       sprintf(ccomp_line, "%s -c %s%s", CComp, ccomp_opts, curlst_string);
+      {
+        char *ccopy, *ctok;
+        ccopy = salloc(curlst_string);
+        for (ctok = strtok(ccopy, " \t\r\n"); ctok != NULL;
+             ctok = strtok(NULL, " \t\r\n"))
+          if (*ctok != '\0')
+            rtt_progress_cc(ctok);
+        free(ccopy);
+      }
       if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
       if (system(ccomp_line)) return EXIT_FAILURE;
       if (0 == keeptmp) {
@@ -472,6 +835,7 @@ int main(int argc, char **argv)
         if (!silent) { fprintf(stdout, "%s\n", ccomp_line); fflush(stdout); }
         if (system(ccomp_line)) return EXIT_FAILURE;
       }
+#endif /* HAVE_WORKING_FORK */
    }
 
    return EXIT_SUCCESS;

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -7,6 +7,11 @@ default: all
 UNICON_TOP_BUILDDIR ?= $(TOPDIR)
 include $(UNICON_TOP_BUILDDIR)/Makedefs
 
+# Parallel gcc in urtt: only pass -j N when known. Else omit -j so urtt uses MAKEFLAGS/RTT_JOBS (never force -j 1).
+# Parent may export RTT_CC_JOBS (see src/Makefile). ?= keeps an env export from a parallel top-level make.
+RTT_CC_JOBS ?= $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+RTT_JFLAG := $(if $(strip $(RTT_CC_JOBS)),-j $(RTT_CC_JOBS),)
+
 
 HDRS = ../h/define.h ../h/config.h ../h/typedefs.h ../h/monitor.h\
 	  ../h/proto.h ../h/cstructs.h ../h/cpuconf.h ../h/grttin.h\
@@ -40,7 +45,8 @@ XOBJS=	xcnv.$(O)     xdata.$(O)    xdef.$(O)     xerrmsg.$(O)  xextcall.$(O) xfc
 	xrsys.$(O)    xrgfxsys.$(O) xrwinsys.$(O) xrwindow.$(O) xfxtra.$(O)   xrwinrsc.$(O)\
 	xrposix.$(O)  xrmsg.$(O)    xraudio.$(O)
 
-COBJS=	cnv.$(O)     data.$(O)    def.$(O)     errmsg.$(O)  extcall.$(O) fconv.$(O)  \
+# Compiler RTL objects from urtt (batched in one invocation); optional drawstring add-on.
+RTL_COBJS=	cnv.$(O)     data.$(O)    def.$(O)     errmsg.$(O)  extcall.$(O) fconv.$(O)  \
 	fload.$(O)   fmath.$(O)   fmisc.$(O)   fmonitr.$(O) fscan.$(O)   fstr.$(O)   \
 	fstranl.$(O) fstruct.$(O) fsys.$(O)    fwindow.$(O) imain.$(O)   imisc.$(O)  \
 	init.$(O)    interp.$(O)  invoke.$(O)  fdb.$(O)     keyword.$(O) lmisc.$(O)  \
@@ -48,7 +54,16 @@ COBJS=	cnv.$(O)     data.$(O)    def.$(O)     errmsg.$(O)  extcall.$(O) fconv.$(
 	oset.$(O)    ovalue.$(O)  ralc.$(O)    rcoexpr.$(O) rcomp.$(O)   rdb.$(O)    \
 	rdebug.$(O)  rlocal.$(O)  rlrgint.$(O) rmemmgt.$(O) rmisc.$(O)   rstruct.$(O)\
 	rsys.$(O)    rgfxsys.$(O) rwinsys.$(O) rwindow.$(O) fxtra.$(O)   rwinrsc.$(O)\
-	rposix.$(O)  rmsg.$(O)    raudio.$(O)  $(COMMONDRAWSTRING)
+	rposix.$(O)  rmsg.$(O)    raudio.$(O)
+
+COBJS=	$(RTL_COBJS) $(COMMONDRAWSTRING)
+
+# All headers that affect any RTL .r translation (must match former explicit rules).
+RTL_BATCH_DEPS = $(RTLSRC) $(HDRS) ../h/feature.h ../h/revision.h \
+	../h/kdefs.h ../h/fdefs.h ../h/odefs.h \
+	$(GRAPHICSHDRS) $(GRAPHICSRI) rxrsc.ri \
+	../h/posix.h ../h/messagin.h \
+	fxposix.ri fxpattrn.ri fxaudio.ri
 
 # These files are affected by NTConsole on Windows
 CONSOLEOBJS=  xrwindow.$(O) xrsys.$(O) xinit.$(O) xfwindow.$(O) xfsys.$(O) xrwinsys.$(O) xkeyword.$(O)
@@ -101,8 +116,7 @@ CONSOLE:
 
 # urtt's preprocessor does not see $(CPPFLAGS); pass -I so config.h finds auto.h (iconx and iconc).
 x%.$(O): %.r $(HDRS)
-	$(CMNT)	@echo "   [ICONX RTT] $<"
-	$(SLNT)$(RTT) $(NTCONSOLE) -x -I$(dir $(AUTO_H)) $<
+	$(SLNT)$(RTT) $(RTT_JFLAG) $(NTCONSOLE) -x -I$(dir $(AUTO_H)) $<
 	$(SLNT)$(CC) $(NTCONSOLE) $(CPPFLAGS) $(CFLAGS) -c x$*.c
 	$(SLNT)$(RM) x$*.c
 
@@ -113,8 +127,7 @@ xfsys.$(O): fsys.r $(HDRS) $(GRAPHICSHDRS)
 xfwindow.$(O): fwindow.r $(HDRS) $(GRAPHICSHDRS)
 
 xkeyword.$(O): keyword.r $(HDRS) ../h/feature.h ../h/revision.h
-	$(CMNT)	@echo "   [ICONX RTT] $< "
-	$(SLNT)$(RTT) $(NTCONSOLE) -x -I$(dir $(AUTO_H)) keyword.r
+	$(SLNT)$(RTT) $(RTT_JFLAG) $(NTCONSOLE) -x -I$(dir $(AUTO_H)) keyword.r
 	$(SLNT)$(CC) $(NTCONSOLE) $(CPPFLAGS) $(CFLAGS) -c xkeyword.c
 	$(SLNT)$(RM) xkeyword.c
 
@@ -137,9 +150,10 @@ xrwinrsc.$(O): rwinrsc.r $(HDRS) $(GRAPHICSHDRS) rxrsc.ri
 #
 # Make entries for the compiler library
 #
-RTLSRC= cnv.r data.r def.r errmsg.r fconv.r fdb.r fload.r fmath.r\
+# Order matches RTL_COBJS / COBJS (all compiler RTL .r files).
+RTLSRC= cnv.r data.r def.r errmsg.r extcall.r fconv.r fload.r fmath.r\
 	fmisc.r fmonitr.r fscan.r fstr.r fstranl.r fstruct.r\
-	fsys.r fwindow.r init.r invoke.r keyword.r\
+	fsys.r fwindow.r imain.r imisc.r init.r interp.r invoke.r fdb.r keyword.r\
 	lmisc.r oarith.r oasgn.r ocat.r ocomp.r omisc.r\
 	oref.r oset.r ovalue.r ralc.r rcoexpr.r rcomp.r\
 	rdb.r rdebug.r rlrgint.r rlocal.r rmemmgt.r rmisc.r rstruct.r\
@@ -152,39 +166,24 @@ comp_all comp_all_uniconc: update_rev
 
 rt.a: ../../rt/lib/libucommon.a ../../rt/lib/libgdbm.a ../../rt/lib/libtp.a ../../rt/lib/libuconsole.a $(COBJS)
 	$(CMNT) @echo [ICONC RTT] "-A -O ... # rt.a: "
-	$(RTT) $(DASHS) -I$(dir $(AUTO_H)) -A -O  "$(COBJS) f_*.$(O) o_*$(O)"
+	$(RTT) $(RTT_JFLAG) $(DASHS) -I$(dir $(AUTO_H)) -A -O  "$(COBJS) f_*.$(O) o_*$(O)"
 	$(RANLIB) $@
 	$(CP) rt.a ../common/dlrgint.$(O) ../../rt/lib/
 	$(CP) rt.db ../../rt/lib/
 
-keyword.$(O) : keyword.r $(HDRS) ../h/feature.h ../h/revision.h
-	$(CMNT)	@echo "   [ICONC RTT] $< "
-	$(SLNT)$(RTT) $(DASHS) -I$(dir $(AUTO_H)) -c -O "$(CFLAGS) $(CPPFLAGS)" keyword.r
+# One urtt run for all compiler RTL sources: single rt.db load/dump; C compiles parallel in urtt (Unix).
+compiler-rtl-stamp: $(RTL_BATCH_DEPS)
+	$(CMNT)	@echo "   [ICONC RTT batch] $(RTLSRC)"
+	$(RM) rt.db $(RTL_COBJS)
+	$(SLNT)$(RTT) $(RTT_JFLAG) $(DASHS) $(WCONSOLE) -I$(dir $(AUTO_H)) -c -O "$(CFLAGS) $(CPPFLAGS)" $(RTLSRC)
+	@touch compiler-rtl-stamp
 
-%.$(O): %.r $(HDRS)
-	$(CMNT)@echo "   [ICONC RTT] $<"
-	$(SLNT)$(RTT) $(DASHS) $(WCONSOLE) -I$(dir $(AUTO_H)) -c -O "$(CFLAGS) $(CPPFLAGS)"  $<
-
-fwindow.$(O): fwindow.r $(HDRS) $(GRAPHICSHDRS)
-
-rmsg.$(O): rmsg.r $(HDRS) ../h/messagin.h
-
-fxtra.$(O): fxtra.r $(HDRS) ../h/posix.h fxposix.ri fxpattrn.ri fxaudio.ri
-
-raudio.$(O): raudio.r $(HDRS) ../h/posix.h
-
-rposix.$(O): rposix.r $(HDRS) ../h/posix.h
-
-rwinrsc.$(O): rwinrsc.r $(HDRS) $(GRAPHICSHDRS)
-
-rgfxsys.$(O): rgfxsys.r $(HDRS) $(GRAPHICSHDRS)
-
-rwinsys.$(O): rwinsys.r $(HDRS) $(GRAPHICSHDRS)
-
-rwindow.$(O): rwindow.r $(HDRS) $(GRAPHICSHDRS)
+# Objects come from the stamp recipe; if you delete a single $(RTL_COBJS) by hand,
+# also remove compiler-rtl-stamp (or run clean) so urtt runs again.
+$(RTL_COBJS): compiler-rtl-stamp ;
 
 ../common/drawstring3d.o: ../common/drawstring3d.cc
 	cd ../common; $(MAKE) drawstring3d.o
 
 Pure Clean clean:
-	$(RM) *.$(O)
+	$(RM) *.$(O) compiler-rtl-stamp

--- a/src/runtime/rsys.r
+++ b/src/runtime/rsys.r
@@ -1894,6 +1894,9 @@ void detectRedirection()
  * (e.g. in mswinsystem()).  Behavior differs in that output does not
  * remove double quotes from quoted arguments, otherwise receiving process
  * (if a win32 process) would lose quotedness.
+ *
+ * NT quote and FINDFIRST wildcard expansion match unicon_win32_* in mlocal.c
+ * (unicon_win32_cmdline_to_argv); this routine adds Graphics-related < > redirection.
  */
 int CmdParamToArgv(char *s, char ***avp, int dequote)
 {


### PR DESCRIPTION
- Gate fork-based parallel "gcc -c" in urtt on HAVE_WORKING_FORK (from AC_FUNC_FORK) instead of UNIX so MSYS/Cygwin can use it when fork works; native MinGW without fork keeps the system() path.
- Add urtt -j n, MAKEFLAGS/RTT_JOBS handling, progress lines, and fix serial -j1 compile loop for all generated .c files.
- Export RTT_CC_JOBS from src/Makefile when MAKEFLAGS contains -jN; runtime Makefile passes RTT_JFLAG to urtt without forcing -j1.
- Batch compiler RTL with RTL_COBJS, compiler-rtl-stamp, and full RTL_BATCH_DEPS; remove duplicate ICONX RTT echoes (urtt reports progress).
- Drop forced -j1 for comp_all_uniconc; clean compiler-rtl-stamp on clean.