### PR TITLE
src/asm: improve coswitch ABIs and comments

### DIFF
--- a/src/asm/arm_32_linux-rswitch.s
+++ b/src/asm/arm_32_linux-rswitch.s
@@ -21,49 +21,37 @@ coswitch:
         #     lr is r14
         #     pc is r15
         #
-        # Must save   : r11, r13-r14
-        # Don't touch : r15
-        # Good measure: r10
-        # Scratch     : r0-r3, r12
-        # Others      : r4-r9
+        # AAPCS callee-saved: r4-r11, r13 (sp), r14 (lr)
         #
         # Old stack pointer -> old_cstate[0]
         # Old link register -> old_cstate[1]
         str     sp,  [r0]
         str     lr,  [r0, #4]
-        # frame pointer
         str     r11, [r0, #8]
         str     r10, [r0, #12]
+        str     r9,  [r0, #16]
+        str     r8,  [r0, #20]
+        str     r7,  [r0, #24]
+        str     r6,  [r0, #28]
+        str     r5,  [r0, #32]
+        str     r4,  [r0, #36]
 
-#       str     r9,  [r0, #16]
-#       str     r8,  [r0, #20]
-#       str     r7,  [r0, #24]
-#       str     r6,  [r0, #28]
-#       str     r5,  [r0, #32]
-#       str     r4,  [r0, #36]
-
-        # Otherwise load the new state
-        # new_cstate[0] -> new stack pointer
-        # new_cstate[1] -> new link register
         ldr     sp,  [r1]
         ldr     lr,  [r1, #4]
-        # frame pointer
         ldr     r11, [r1, #8]
         ldr     r10, [r1, #12]
+        ldr     r9,  [r1, #16]
+        ldr     r8,  [r1, #20]
+        ldr     r7,  [r1, #24]
+        ldr     r6,  [r1, #28]
+        ldr     r5,  [r1, #32]
+        ldr     r4,  [r1, #36]
 
-#       ldr     r9,  [r1, #16]
-#       ldr     r8,  [r1, #20]
-#       ldr     r7,  [r1, #24]
-#       ldr     r6,  [r1, #28]
-#       ldr     r5,  [r1, #32]
-#       ldr     r4,  [r1, #36]
-
-        # If this the first activation
-        # skip to call new_context()
+        # first==0 -> first activation -> new_context
         cmp     r2, #0
         beq     .L1
 
-        # Ready to return, lr (r13) now has the return address
+        # Return; lr (r14) holds the coswitch return address
         bx      lr
 
 .L1:

--- a/src/asm/arm_64_linux-rswitch.s
+++ b/src/asm/arm_64_linux-rswitch.s
@@ -17,9 +17,8 @@ coswitch:
         #     x1     new_cstate
         #     x2     first (equals 0 if first activation)
         #
-        #     sp   x31? , in arm32  r13
-        #     pc        , in arm32  r15
-        #     lr is x30 , in arm32  r14
+        #     AArch64: sp is not x31 (xzr); use sp directly
+        #     AArch32: sp=r13, lr=r14, pc=r15
         #
         # args : r0-r7
         # r8 indirect location, c++?
@@ -73,12 +72,10 @@ coswitch:
         ldr     x28, [x1, #104]
 
 
-        # If this the first activation
-        # skip to call new_context()
+        # first==0 -> first activation -> new_context
         cmp     x2, #0
         beq     .L1
 
-        # Ready to return
         ret
 
 .L1:

--- a/src/asm/arm_64_macos-rswitch.s
+++ b/src/asm/arm_64_macos-rswitch.s
@@ -6,7 +6,7 @@
 #
 
 .data
-.ERR:   .ascii     "new_context() returned in coswitch"
+.ERR:   .string    "new_context() returned in coswitch"
 
 .text
         .p2align    4 ; 16 byte word boundary
@@ -29,10 +29,8 @@ _coswitch:
         # args : x0-x7
         # r8 indirect location, c++?
         # Scratch      : x9-x15
-        # Don't touch  : x18 (platform register - reserved by Rosetta)
-        # Callee-saved : x19-x28 (must be restored if used)
-        # Must save    : xr30, x31
-        # Others       : ?
+        # x18          : platform register (not saved on macOS; layout differs from Linux)
+        # Callee-saved : x19-x28 (saved below); sp, lr (x30), fp (x29) at [0],[8],[16]
         #
         # Old stack pointer -> old_cstate[0]
         # Old link register -> old_cstate[1]
@@ -76,12 +74,10 @@ _coswitch:
         ldr     x28, [x1, #96]
 
 
-        # If this the first activation
-        # skip to call new_context()
+        # first==0 -> first activation -> new_context
         cmp     x2, #0
         beq     .L1
 
-        # Ready to return
         ret
 
 .L1:

--- a/src/asm/ppc_macos-rswitch.s
+++ b/src/asm/ppc_macos-rswitch.s
@@ -11,6 +11,10 @@
 $0:
 .endmacro
 
+        .section __TEXT,__cstring,cstring_literals
+L_nc_err:
+        .asciz "new_context() returned in coswitch"
+
         .file   "rswitch.s"
         .set    RSIZE, 80               ; room for regs 13-31, rounded up mod16
 
@@ -28,7 +32,7 @@ $0:
         stmw    r13, -RSIZE(r1)         ; GPRs 13-31 (save on stack)
 
         cmpi    0, r5, 0
-        beq     first                   ; if first time
+        beq     first                   ; r5==0 -> first activation
 
                                         ; Restore new context:
         lwz     r1, 0(r4)               ; SP
@@ -48,5 +52,6 @@ first:                                  ; First-time call:
         addi    r3, 0, 0                ; arg1
         addi    r4, 0, 0                ; arg2
         bl      _new_context            ; new_context(0,0)
-        addi    r3, 0, 0
+        lis     r3, L_nc_err@ha
+        addi    r3, r3, L_nc_err@l
         bl      _syserr

--- a/src/asm/riscv_64_freebsd-rswitch.s
+++ b/src/asm/riscv_64_freebsd-rswitch.s
@@ -54,7 +54,7 @@ coswitch:
         ld      s10, 96(a1)
         ld      s11, 104(a1)
 
-        beqz    a2, .Lfirst
+        beqz    a2, .Lfirst            # first==0 -> new_context
         ret
 
 .Lfirst:

--- a/src/asm/riscv_64_linux-rswitch.s
+++ b/src/asm/riscv_64_linux-rswitch.s
@@ -58,7 +58,7 @@ coswitch:
         ld      s10, 96(a1)
         ld      s11, 104(a1)
 
-        beqz    a2, .Lfirst
+        beqz    a2, .Lfirst            # first==0 -> new_context
         ret
 
 .Lfirst:

--- a/src/asm/x86_32_windows-rswitch.s
+++ b/src/asm/x86_32_windows-rswitch.s
@@ -1,7 +1,6 @@
 #
-#  Assembler source for context switch using gas 1.38.1 + gcc 1.40 on
-#  Xenix/386, revamped slightly for use with Linux by me (Richard Goer-
-#  witz) on 7/25/94.
+#  Assembler source for context switch — 32-bit Windows (cdecl).
+#  Matches x86_32_linux cstate layout: esp, esp, ebp, ebx, esi, edi.
 #
 
 .file   "rswitch.s"
@@ -18,16 +17,23 @@
 
 _coswitch:
         pushl %ebp
-        movl %esp,%ebp
-        movl 8(%ebp),%eax
+        movl 8(%esp),%eax
         movl %esp,0(%eax)
-        movl %ebp,4(%eax)
-        movl 12(%ebp),%eax
+        movl %esp,4(%eax)
+        movl %ebp,8(%eax)
+        movl %ebx,12(%eax)
+        movl %esi,16(%eax)
+        movl %edi,20(%eax)
+        movl %esp,%ebp
+        movl 12(%esp),%eax
         cmpl $0,16(%ebp)
         movl 0(%eax),%esp
         je .L2
 
         movl 4(%eax),%ebp
+        movl 12(%eax),%ebx
+        movl 16(%eax),%esi
+        movl 20(%eax),%edi
         jmp .L1
 
 .L2:

--- a/src/asm/x86_64_freebsd-rswitch.s
+++ b/src/asm/x86_64_freebsd-rswitch.s
@@ -4,9 +4,11 @@
 #
 # See http://www.amd64.org/ for information about AMD64 programming.
 #
+# Callee-saved GPRs (SysV AMD64): rbx, rbp, r12-r15 plus rsp.
+#
 
         .file       "rswitch.s"
- 
+
         .section    .rodata
 .L0:    .string     "new_context() returned in coswitch"
 
@@ -20,19 +22,33 @@ coswitch:
         #
         #     %rdi     old_cstate
         #     %rsi     new_cstate
-        #     %edx     first (equals 0 if first activation)
+        #     %edx     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rdi)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rdi)      # Old base pointer -> old_cstate[1]
-        movq    0(%rsi), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rsi), %rbp      # new_cstate[1] -> new base pointer
-        orl     %edx, %edx         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %edi, %edi         # Call new_context((int) 0, (ptr) 0)
-        xorl    %esi, %esi         # (Implicitly zero-extended to 64 bits)
+        movq    %rsp, 0(%rdi)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rdi)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rdi)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rdi)     # old %rbx -> old_cstate[3]
+        movq    %r12, 32(%rdi)     # old %r12 -> old_cstate[4]
+        movq    %r13, 40(%rdi)     # old %r13 -> old_cstate[5]
+        movq    %r14, 48(%rdi)     # old %r14 -> old_cstate[6]
+        movq    %r15, 56(%rdi)     # old %r15 -> old_cstate[7]
+        movq    0(%rsi), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rsi), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rsi), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rsi), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rsi), %r12     # new_cstate[4] -> %r12
+        movq    40(%rsi), %r13     # new_cstate[5] -> %r13
+        movq    48(%rsi), %r14     # new_cstate[6] -> %r14
+        movq    56(%rsi), %r15     # new_cstate[7] -> %r15
+
+        orl     %edx, %edx         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:
+        xorl    %edi, %edi         # new_context first arg = 0
+        xorl    %esi, %esi         # new_context second arg = 0
         call    new_context@PLT
-        leaq    .L0(%rip), %rdi    # Call syserr(...)
-        movl    $0, %eax
+        leaq    .L0(%rip), %rdi    # message pointer for syserr (first arg)
+        xorl    %eax, %eax
         jmp     syserr@PLT

--- a/src/asm/x86_64_linux-rswitch.s
+++ b/src/asm/x86_64_linux-rswitch.s
@@ -26,32 +26,32 @@ coswitch:
         #
         #     %rdi     old_cstate
         #     %rsi     new_cstate
-        #     %edx     first (equals 0 if first activation)
+        #     %edx     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rdi)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rdi)      # Old base pointer -> old_cstate[1]
-        movq    %rbp, 16(%rdi)      # Old base pointer -> old_cstate[2]
-        movq    %rbx, 24(%rdi)      # Old bx -> old_cstate[3]
-        movq    %r12, 32(%rdi)      # Old r12 -> old_cstate[4]
-        movq    %r13, 40(%rdi)      # Old r13 -> old_cstate[5]
-        movq    %r14, 48(%rdi)      # Old r14 -> old_cstate[6]
-        movq    %r15, 56(%rdi)      # Old r15 -> old_cstate[7]
-        movq    0(%rsi), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rsi), %rbp      # new_cstate[1] -> new base pointer
-        movq    16(%rsi), %rbp      # new_cstate[2] -> new base pointer
-        movq    24(%rsi), %rbx      # new_cstate[3] -> new bx
-        movq    32(%rsi), %r12      # new_cstate[4] -> new r12
-        movq    40(%rsi), %r13      # new_cstate[5] -> new r13
-        movq    48(%rsi), %r14      # new_cstate[6] -> new r14
-        movq    56(%rsi), %r15      # new_cstate[7] -> new r15
+        movq    %rsp, 0(%rdi)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rdi)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rdi)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rdi)     # old %rbx -> old_cstate[3]
+        movq    %r12, 32(%rdi)     # old %r12 -> old_cstate[4]
+        movq    %r13, 40(%rdi)     # old %r13 -> old_cstate[5]
+        movq    %r14, 48(%rdi)     # old %r14 -> old_cstate[6]
+        movq    %r15, 56(%rdi)     # old %r15 -> old_cstate[7]
+        movq    0(%rsi), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rsi), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rsi), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rsi), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rsi), %r12     # new_cstate[4] -> %r12
+        movq    40(%rsi), %r13     # new_cstate[5] -> %r13
+        movq    48(%rsi), %r14     # new_cstate[6] -> %r14
+        movq    56(%rsi), %r15     # new_cstate[7] -> %r15
 
-        orl     %edx, %edx         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %edi, %edi         # Call new_context((int) 0, (ptr) 0)
-        xorl    %esi, %esi         # (Implicitly zero-extended to 64 bits)
+        orl     %edx, %edx         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:    xorl    %edi, %edi         # new_context first arg = 0
+        xorl    %esi, %esi         # new_context second arg = 0
         call    new_context@PLT
-        leaq    .L0(%rip), %rdi    # Call syserr(...)
-        xorl    %eax, %eax         # 0 to return
+        leaq    .L0(%rip), %rdi    # message pointer for syserr (first arg)
+        xorl    %eax, %eax         # clear %rax (ABI hygiene before tail to syserr)
         jmp     syserr@PLT

--- a/src/asm/x86_64_linux_sunc-rswitch.s
+++ b/src/asm/x86_64_linux_sunc-rswitch.s
@@ -4,9 +4,11 @@
 #
 # See http://www.amd64.org/ for information about AMD64 programming.
 #
+# Callee-saved GPRs (SysV AMD64): rbx, rbp, r12-r15 plus rsp.
+#
 
         .file       "rswitch.s"
- 
+
         .section    .rodata
 .L0:    .string     "new_context() returned in coswitch"
 
@@ -20,19 +22,33 @@ coswitch:
         #
         #     %rdi     old_cstate
         #     %rsi     new_cstate
-        #     %edx     first (equals 0 if first activation)
+        #     %edx     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rdi)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rdi)      # Old base pointer -> old_cstate[1]
-        movq    0(%rsi), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rsi), %rbp      # new_cstate[1] -> new base pointer
-        orl     %edx, %edx         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %edi, %edi         # Call new_context((int) 0, (ptr) 0)
-        xorl    %esi, %esi         # (Implicitly zero-extended to 64 bits)
+        movq    %rsp, 0(%rdi)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rdi)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rdi)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rdi)     # old %rbx -> old_cstate[3]
+        movq    %r12, 32(%rdi)     # old %r12 -> old_cstate[4]
+        movq    %r13, 40(%rdi)     # old %r13 -> old_cstate[5]
+        movq    %r14, 48(%rdi)     # old %r14 -> old_cstate[6]
+        movq    %r15, 56(%rdi)     # old %r15 -> old_cstate[7]
+        movq    0(%rsi), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rsi), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rsi), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rsi), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rsi), %r12     # new_cstate[4] -> %r12
+        movq    40(%rsi), %r13     # new_cstate[5] -> %r13
+        movq    48(%rsi), %r14     # new_cstate[6] -> %r14
+        movq    56(%rsi), %r15     # new_cstate[7] -> %r15
+
+        orl     %edx, %edx         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:
+        xorl    %edi, %edi         # new_context first arg = 0
+        xorl    %esi, %esi         # new_context second arg = 0
         call    new_context@PLT
-        leaq    .L0(%rip), %rdi    # Call syserr(...)
-        movl    $0, %eax
+        leaq    .L0(%rip), %rdi    # message pointer for syserr (first arg)
+        xorl    %eax, %eax
         jmp     syserr@PLT

--- a/src/asm/x86_64_macos-rswitch.s
+++ b/src/asm/x86_64_macos-rswitch.s
@@ -4,9 +4,11 @@
 #
 # Adapted to OSX/clang by Jafar Al-Gharaibeh, April 2016
 #
+# Callee-saved GPRs (SysV AMD64): rbx, rbp, r12-r15 plus rsp.
+#
 
         .file       "rswitch.s"
- 
+
 .L0:    .string     "new_context() returned in coswitch"
 
         .text
@@ -16,19 +18,33 @@ _coswitch:
         #
         #     %rdi     old_cstate
         #     %rsi     new_cstate
-        #     %edx     first (equals 0 if first activation)
+        #     %edx     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rdi)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rdi)      # Old base pointer -> old_cstate[1]
-        movq    0(%rsi), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rsi), %rbp      # new_cstate[1] -> new base pointer
-        orl     %edx, %edx         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %edi, %edi         # Call new_context((int) 0, (ptr) 0)
-        xorl    %esi, %esi         # (Implicitly zero-extended to 64 bits)
-        callq    _new_context
-        leaq    .L0(%rip), %rdi    # Call syserr(...)
-        movl    $0, %eax
+        movq    %rsp, 0(%rdi)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rdi)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rdi)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rdi)     # old %rbx -> old_cstate[3]
+        movq    %r12, 32(%rdi)     # old %r12 -> old_cstate[4]
+        movq    %r13, 40(%rdi)     # old %r13 -> old_cstate[5]
+        movq    %r14, 48(%rdi)     # old %r14 -> old_cstate[6]
+        movq    %r15, 56(%rdi)     # old %r15 -> old_cstate[7]
+        movq    0(%rsi), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rsi), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rsi), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rsi), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rsi), %r12     # new_cstate[4] -> %r12
+        movq    40(%rsi), %r13     # new_cstate[5] -> %r13
+        movq    48(%rsi), %r14     # new_cstate[6] -> %r14
+        movq    56(%rsi), %r15     # new_cstate[7] -> %r15
+
+        orl     %edx, %edx         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:
+        xorl    %edi, %edi         # new_context first arg = 0
+        xorl    %esi, %esi         # new_context second arg = 0
+        callq   _new_context
+        leaq    .L0(%rip), %rdi    # message pointer for syserr (first arg)
+        xorl    %eax, %eax
         jmp     _syserr

--- a/src/asm/x86_64_solaris-rswitch.s
+++ b/src/asm/x86_64_solaris-rswitch.s
@@ -4,9 +4,11 @@
 #
 # See http://www.amd64.org/ for information about AMD64 programming.
 #
+# Callee-saved GPRs (SysV AMD64): rbx, rbp, r12-r15 plus rsp.
+#
 
         .file       "rswitch.s"
- 
+
         .section    .rodata
 .L0:    .string     "new_context() returned in coswitch"
 
@@ -20,19 +22,33 @@ coswitch:
         #
         #     %rdi     old_cstate
         #     %rsi     new_cstate
-        #     %edx     first (equals 0 if first activation)
+        #     %edx     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rdi)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rdi)      # Old base pointer -> old_cstate[1]
-        movq    0(%rsi), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rsi), %rbp      # new_cstate[1] -> new base pointer
-        orl     %edx, %edx         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %edi, %edi         # Call new_context((int) 0, (ptr) 0)
-        xorl    %esi, %esi         # (Implicitly zero-extended to 64 bits)
+        movq    %rsp, 0(%rdi)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rdi)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rdi)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rdi)     # old %rbx -> old_cstate[3]
+        movq    %r12, 32(%rdi)     # old %r12 -> old_cstate[4]
+        movq    %r13, 40(%rdi)     # old %r13 -> old_cstate[5]
+        movq    %r14, 48(%rdi)     # old %r14 -> old_cstate[6]
+        movq    %r15, 56(%rdi)     # old %r15 -> old_cstate[7]
+        movq    0(%rsi), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rsi), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rsi), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rsi), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rsi), %r12     # new_cstate[4] -> %r12
+        movq    40(%rsi), %r13     # new_cstate[5] -> %r13
+        movq    48(%rsi), %r14     # new_cstate[6] -> %r14
+        movq    56(%rsi), %r15     # new_cstate[7] -> %r15
+
+        orl     %edx, %edx         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:
+        xorl    %edi, %edi         # new_context first arg = 0
+        xorl    %esi, %esi         # new_context second arg = 0
         call    new_context@PLT
-        leaq    .L0(%rip), %rdi    # Call syserr(...)
-        movl    $0, %eax
+        leaq    .L0(%rip), %rdi    # message pointer for syserr (first arg)
+        xorl    %eax, %eax
         jmp     syserr@PLT

--- a/src/asm/x86_64_windows-rswitch.s
+++ b/src/asm/x86_64_windows-rswitch.s
@@ -1,9 +1,10 @@
 #
-# Context switch for AMD64 small model.  (Position-independent code.)
+# Context switch for AMD64 Windows.  (Position-independent code.)
 # Barry Schwartz, January 2005.
 # Modified for x64 Windows by Shea Newton, June 2014
 #
-# See http://www.amd64.org/ for information about AMD64 programming.
+# Saves Microsoft x64 non-volatile GPRs: rsp, rbp (slots [0]-[2] as on
+# SysV), rbx [3], rdi [4], rsi [5], r12-r15 [6]-[9].
 #
 
         .file       "x86_64_windows-rswitch.s"
@@ -15,20 +16,40 @@ coswitch:
         #
         #     %rcx     old_cstate
         #     %rdx     new_cstate
-        #     %r8d     first (equals 0 if first activation)
+        #     %r8d     first (0 => first activation => new_context)
         #
 
-        movq    %rsp, 0(%rcx)      # Old stack pointer -> old_cstate[0]
-        movq    %rbp, 8(%rcx)      # Old base pointer -> old_cstate[1]
-        movq    0(%rdx), %rsp      # new_cstate[0] -> new stack pointer
-        movq    8(%rdx), %rbp      # new_cstate[1] -> new base pointer
-        orl     %r8d, %r8d         # Is this the first activation?
-        je      .L1                # If so, skip.
-        ret                        # Otherwise we are done.
-.L1:    xorl    %ecx, %ecx         # Call new_context((int) 0, (ptr) 0)
-        xorl    %edx, %edx         # (Implicitly zero-extended to 64 bits)
+        movq    %rsp, 0(%rcx)      # old %rsp -> old_cstate[0]
+        movq    %rbp, 8(%rcx)      # old %rbp -> old_cstate[1]
+        movq    %rbp, 16(%rcx)     # old %rbp again -> old_cstate[2] (duplicate slot; see runtime)
+        movq    %rbx, 24(%rcx)     # old %rbx -> old_cstate[3]
+        movq    %rdi, 32(%rcx)     # old %rdi -> old_cstate[4] (Windows non-volatile)
+        movq    %rsi, 40(%rcx)     # old %rsi -> old_cstate[5] (Windows non-volatile)
+        movq    %r12, 48(%rcx)     # old %r12 -> old_cstate[6]
+        movq    %r13, 56(%rcx)     # old %r13 -> old_cstate[7]
+        movq    %r14, 64(%rcx)     # old %r14 -> old_cstate[8]
+        movq    %r15, 72(%rcx)     # old %r15 -> old_cstate[9]
+
+        movq    0(%rdx), %rsp      # new_cstate[0] -> %rsp
+        movq    8(%rdx), %rbp      # new_cstate[1] -> %rbp
+        movq    16(%rdx), %rbp     # new_cstate[2] -> %rbp (second load, same as [1])
+        movq    24(%rdx), %rbx     # new_cstate[3] -> %rbx
+        movq    32(%rdx), %rdi     # new_cstate[4] -> %rdi
+        movq    40(%rdx), %rsi     # new_cstate[5] -> %rsi
+        movq    48(%rdx), %r12     # new_cstate[6] -> %r12
+        movq    56(%rdx), %r13     # new_cstate[7] -> %r13
+        movq    64(%rdx), %r14     # new_cstate[8] -> %r14
+        movq    72(%rdx), %r15     # new_cstate[9] -> %r15
+
+        orl     %r8d, %r8d         # ZF set if first==0 (first activation)
+        je      .L1                # first==0 -> new_context path
+        ret                        # first!=0 -> return into restored context
+.L1:
+        xorl    %ecx, %ecx         # new_context first arg = 0 (RCX)
+        xorl    %edx, %edx         # new_context second arg = 0 (RDX)
         call    new_context@PLT
-        leaq    .LC0(%rip), %rcx   # Call syserr(...)
-        movl    $0, %eax
+        leaq    .LC0(%rip), %rcx   # message pointer for syserr (first arg on Windows)
+        xorl    %eax, %eax
         jmp     syserr@PLT
-.LC0:   .string     "new_context() returned in coswitch"
+.LC0:
+        .string     "new_context() returned in coswitch"


### PR DESCRIPTION
- x86_64 (SysV): save rbx and r12-r15 on FreeBSD, Solaris, Sun C, macOS; per-line comments; clarify duplicate rbp slots and tail path.
- x86_64 Windows: save non-volatile rdi/rsi and r12-r15; document slots; syserr message in RCX; fix file header slot description.
- x86_32 Windows: save/restore ebx, esi, edi like Linux layout.
- ARM32: save/restore r4-r9; fix lr comment.
- ARM64 Linux: AArch64/AArch32 comment lines; keep register note block.
- ARM64 macOS: .string for error text; comment tweaks.
- PPC macOS: pass error string pointer to _syserr (L_nc_err); cstring section.
- RISC-V: branch comment for first activation.