### PR TITLE
‎uni/gprogs: fix mutex error in qmazer

### DIFF
--- a/uni/gprogs/qmazer.icn
+++ b/uni/gprogs/qmazer.icn
@@ -127,7 +127,7 @@ class QMouse(maze, loc, parent, len, val)
                                     CELL*(loc.c-1),CELL*(loc.r-1))
                         }
                     mark(maze, r,c)
-                    unlock(region[r,c])
+
                     return Position(r,c)
                     }
                 }


### PR DESCRIPTION
Remove line 130 - unlock command is causing runtime error.

Thanks to Stephen Wampler