### PR TITLE
    test: Remove configuration specific values from mutex test

### DIFF
--- a/tests/thread/mutexfun.icn
+++ b/tests/thread/mutexfun.icn
@@ -6,22 +6,31 @@
 #
 
 procedure main()
+   local muType
+
    if not (&features == "concurrent threads") then
       stop("This program requires concurrent threads.")
 
    write("Testing mutex functions..")
    write(" calling mutex()...")
    x := mutex()
-   write("mutex() returned x=", image(x), " This is",
-         if integer(x)>0 then "" else " NOT", " OK" )
+   muType := type(x)
+   writes("mutex() returned a value of type ",muType, " This is ")
+   if muType == "integer" & x > 0 then {
+      write("OK")
+   } else {
+      write("NOT OK (value is ", integer(x) | "not an integer", ")")
+      write("Test failed")
+      return
+   }
    write()
    write(" calling lock(x)...")
    y:=lock(x)
-   write("lock(x) returned y=", image(y))
+   write("lock(x) returned ", if y = x then "x" else image(y))
    write()
    write(" calling unlock(x)...")
    y:=unlock(x)
-   write("unlock(x) returned y=", image(y))
+   write("unlock(x) returned ", if y = x then "x" else image(y))
    write()
    write("Done! exiting peacefully...")
 end

--- a/tests/thread/stand/mutexfun.std
+++ b/tests/thread/stand/mutexfun.std
@@ -1,11 +1,11 @@
 Testing mutex functions..
  calling mutex()...
-mutex() returned x=45 This is OK
+mutex() returned a value of type integer This is OK
 
  calling lock(x)...
-lock(x) returned y=45
+lock(x) returned x
 
  calling unlock(x)...
-unlock(x) returned y=45
+unlock(x) returned x
 
 Done! exiting peacefully...


### PR DESCRIPTION
Some configurations have a different number of mutexes, which leads to a test failure (because the test output is not the same as the expected result). This commit changes the output so that exact values are no longer part of the output. The actual tests are unchanged.