### PR TITLE
Update tree.icn - test for constant keywords corrected

### DIFF
--- a/uni/unicon/tree.icn
+++ b/uni/unicon/tree.icn
@@ -1129,7 +1129,7 @@ procedure node_isconst(n)
        case n.label of {
            "keyword": {
                if n.children[2].s ==
-                   ("digits","e","lcase","letters","pi","ucase") then {
+                   ("digits" | "e" | "lcase" | "letters" | "pi" | "ucase") then {
                   # constant keywords; list appears incomplete?
                   return "const"
                   }


### PR DESCRIPTION
The original code on line 1132 in file tree.icn in procedure node_isconst used the following as part of the conditional test

("digits","e","lcase","letters","pi","ucase") then {


I believe this should be 

("digits" | "e" | "lcase" | "letters" | "pi" | "ucase") then {

as this would make more sense in terms of conditional checking for those keywords.