### PR TITLE
Update colorway - removal of null code if/then expressions and extraneous repeat loop

### DIFF
--- a/ipl/gprocs/colorway.icn
+++ b/ipl/gprocs/colorway.icn
@@ -401,10 +401,6 @@ end
 
 procedure quit()
 
-   if \cw_touched then {
-				# ask for save if touched
-      }
-
    exit()
 
 end

--- a/ipl/gprocs/colorway.icn
+++ b/ipl/gprocs/colorway.icn
@@ -249,20 +249,18 @@ procedure add_way()
    local name
 
    repeat {
-      repeat {
-         if TextDialog("Add color:", "name", , 60) == "Cancel" then return
-         if \cw.table[dialog_value[1]] then {
-            Notice("Name is in use.")
-            next
-            }
-         name := dialog_value[1]
-         if ColorDialog("Choose color:") == "Cancel" then return
-         cw.table[name] := dialog_value
-         win_cw()
-         cw_touched := 1
-         next
-         }
-      }
+	  if TextDialog("Add color:", "name", , 60) == "Cancel" then return
+	  if \cw.table[dialog_value[1]] then {
+		 Notice("Name is in use.")
+		 next
+		 }
+	  name := dialog_value[1]
+	  if ColorDialog("Choose color:") == "Cancel" then return
+	  cw.table[name] := dialog_value
+	  win_cw()
+	  cw_touched := 1
+	  next
+	  }
 
 end
 
@@ -351,10 +349,6 @@ procedure win_cw()
 end
 
 procedure new_cw()
-
-   if /cw_touched then {
-	# ask if colorway is to be saved first
-      }
 
    cw := colorway(table())
    win_cw()


### PR DESCRIPTION
In the file ipl/gprocs/colorway, a couple of the procedures have null if/then expressions. These may have had code in them in the past but are now null actions.

In addition one procedure had a double repeat loop of which the outer loop was extraneous and is removed.