### PR TITLE
Initialize yytext buffers after malloc in yylex.h

### DIFF
--- a/src/common/yylex.h
+++ b/src/common/yylex.h
@@ -104,7 +104,9 @@ int yylex()
 
    if (yytext == NULL) {
       yytext = malloc(256);
+      yytext[0] = 0;
       savedyytext = malloc(256);
+      savedyytext[0] = 0;
       yytextsize = 256;
       }
 


### PR DESCRIPTION
From marcespie's patch on uniconproject/unicon#618.