### PR TITLE
Add basic OpenBSD platform support in configure and config.h

### DIFF
--- a/configure
+++ b/configure
@@ -3555,6 +3555,15 @@ printf "%s\n" "#define SUN 1" >>confdefs.h
 printf "%s\n" "#define UNIX 1" >>confdefs.h
 
         ;;
+     *openbsd*)
+        unicon_os="openbsd"
+
+printf "%s\n" "#define UNIX 1" >>confdefs.h
+
+
+printf "%s\n" "#define OpenBSD 1" >>confdefs.h
+
+        ;;
      *bsd*)
         # freebsd for now
         unicon_os="freebsd"

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,11 @@ case $host_os in
         unicon_os="aix"
         AC_DEFINE([UNIX], [1], [Unix platform])
         ;;
+     *openbsd*)
+        unicon_os="openbsd"
+	AC_DEFINE([UNIX], [1], [Unix platform])
+	AC_DEFINE([OpenBSD], [1], [OpenBSD OS])
+        ;;
      *bsd*)
         # freebsd for now
         unicon_os="freebsd"

--- a/src/h/auto.in
+++ b/src/h/auto.in
@@ -436,6 +436,9 @@
 /* Enable Operator Overloading */
 #undef OVLD
 
+/* OpenBSD OS */
+#undef OpenBSD
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/src/h/config.h
+++ b/src/h/config.h
@@ -127,6 +127,24 @@
 #define PROFIL_CHAR_P
 #endif                                  /* FreeBSD */
 
+#if OpenBSD
+#define GenericBSD
+#define BSD_4_4_LITE    1	/* This is new, for 4.4Lite specific stuff */
+
+#define NEED_UTIME
+#define Messaging 1
+
+#define SysOpt
+
+#define MaxStatSize 40960
+
+#define LinkLibs " -lm"
+
+#define HAVE_GETHOSTNAME 1
+#define HAVE_GETPWUID 1
+#define HAVE_GETUID 1
+#endif					/* OpenBSD */
+
 
 #if Windows
 


### PR DESCRIPTION
From marcespie's patch on uniconproject/unicon#621.