### PR TITLE
Use OpenBSD profil(2) signature in fmonitr.r

### DIFF
--- a/src/runtime/fmonitr.r
+++ b/src/runtime/fmonitr.r
@@ -565,11 +565,15 @@ void EVInit()
     *  the text segment.
     */
 #if HAVE_PROFIL
+#ifdef OpenBSD
+   profil((char *)(ticker.s), sizeof(ticker.s), 2, (long) EVInit & ~0x3FFFF, 2, -1);
+#else
 #ifdef PROFIL_CHAR_P
    profil((char *)(ticker.s), sizeof(ticker.s), (long) EVInit & ~0x3FFFF, 2);
 #else                                   /* PROFIL_CHAR_P */
    profil((unsigned short *)(ticker.s), sizeof(ticker.s),
           (long) EVInit & ~0x3FFFF, 2);
+#endif
 #endif                                  /* PROFIL_CHAR_P */
 #endif                                  /* HAVE_PROFIL */
 #endif                                  /* UNIX */


### PR DESCRIPTION
From marcespie's patch on uniconproject/unicon#622.