### PR TITLE
Use a random port in the posix tcp test to avoid address-in-use failures

### DIFF
--- a/tests/posix/tcp.icn
+++ b/tests/posix/tcp.icn
@@ -1,10 +1,12 @@
 # $Id: tcp.icn,v 1.3 2002-03-12 23:12:00 phliar Exp $
 
 procedure main()
+# random port because we want to avoid REUSE_ADDR errors
+   sockname := "127.0.0.1:" || string(1234+?10000)
 
    if fork() ~= 0 then {
       delay(2)
-      f := open("127.0.0.1:1234", "n") | stop("Couldn't open connection: ",
+      f := open(sockname, "n") | stop("Couldn't open connection: ",
                                     &errortext | "Unknown")
       write(f, "hellow, world!")
       write("ret: ", read(f))
@@ -12,7 +14,7 @@ procedure main()
       exit(0)
    }
 
-   if f := open("127.0.0.1:1234", "na") then {
+   if f := open(sockname, "na") then {
       if fork() = 0 then {
          handle(f)
          exit(0)


### PR DESCRIPTION
From marcespie's patch on uniconproject/unicon#627.