### PR TITLE
Fix rpoll on OpenBSD

### DIFF
--- a/ipl/cfuncs/fpoll.c
+++ b/ipl/cfuncs/fpoll.c
@@ -75,7 +75,9 @@ int fpoll(int argc, descriptor *argv)	/*: await data from file */
 #elif __sun
    /* insert your implementation here */
 #elif __OpenBSD__
-   /* no way to do in OpenBSD, FILEs are opaque, sorry ! */
+#include <stdio_ext.h>
+   if (__freadahead(f) > 0)
+      RetArg(1);
 #else
    if (f->_cnt > 0)
       RetArg(1);


### PR DESCRIPTION
from the __freadahead(3) manpage:

BUGS
     These functions are under-specified and non-portable.  They exist to
     permit a particular portability library to function without direct
     manipulation of stdio structures; everyone else should either implement
     their own stdio layer, do the work of defining and standardizing the
     required functionality, or reconsider their life decisions.