### PR TITLE
prevent clang from warning

### DIFF
--- a/src/runtime/rmisc.r
+++ b/src/runtime/rmisc.r
@@ -1251,7 +1251,9 @@ struct b_coexpr *popact(struct b_coexpr *ce)
     * In that case, setting the actstk to NULL would be counterproductive.
     */
    if ((abp->nactivators == 0)
-#if !COMPILER
+#if COMPILER
+	&& 1 /* XXX prevents warning on (()) with clang */
+#else
         && (abp->astk_nxt
 #ifdef MultiProgram
         || !(curpstate->parent)


### PR DESCRIPTION
clang doesn't like ((a == b)) tests, it thinks it should be reserved to assignments.

The hack prevents the warning, thus if people want to play with -Werror, they can.