### PR TITLE
Add deduced flags to iconc invocation of cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/rtt/urtt
 src/runtime/iconx
 src/runtime/iconc
 src/iconc/iconc
+src/iconc/ccomp_param.h
 src/runtime/uniconx
 src/runtime/uniconc
 src/iconc/uniconc

--- a/configure
+++ b/configure
@@ -675,6 +675,10 @@ UDOC
 UNIPROGS
 UDBTOOLS
 ICONCCFLAGS
+ICONC_LDFLAGS_STR
+ICONCCFLAGS_STR
+ICONC_CFLAGS_STR
+ICONC_CPPFLAGS_STR
 ICONCTARGET
 SO
 LDDYN
@@ -7950,6 +7954,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 	}
 fi
+
+# Warning suppressions for iconc-generated C only (not Unicon's own CFLAGS).
+# Skip -Wno-parentheses-equality here (already gated above / hardcoded on MacOS).
+ICONCCFLAGS=
 {
 	ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -7980,54 +7988,6 @@ printf "%s\n" "yes" >&6; }
 
 				CFLAGS="$ac_c_flag_save"
 				ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"
-
-
-else $as_nop
-
-			CFLAGS="$ac_c_flag_save"
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	}
-{
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	ac_c_flag_save="$CFLAGS"
-	CFLAGS="$CFLAGS -Werror -Wno-parentheses-equality"
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-parentheses-equality" >&5
-printf %s "checking whether $CC supports -Werror -Wno-parentheses-equality... " >&6; }
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-				CFLAGS="$ac_c_flag_save"
-				ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"
 
 
 else $as_nop
@@ -17922,6 +17882,18 @@ ac_config_files="$ac_config_files Makedefs:Makedefs.in"
 ac_config_files="$ac_config_files Makedefs.uni:Makedefs.uni.in"
 
 ac_config_headers="$ac_config_headers src/h/auto.h:src/h/auto.in"
+
+
+# Escape configure flag values for embedding in C string literals (ccomp_param.h).
+# Leading space keeps growcat concatenation spacing simple.
+iconc_c_escape() {
+  printf ' %s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+ICONC_CPPFLAGS_STR=`iconc_c_escape "$CPPFLAGS"`
+ICONC_CFLAGS_STR=`iconc_c_escape "$CFLAGS"`
+ICONCCFLAGS_STR=`iconc_c_escape "$ICONCCFLAGS"`
+ICONC_LDFLAGS_STR=`iconc_c_escape "$LDFLAGS"`
+
 
 ac_config_files="$ac_config_files src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in"
 

--- a/configure
+++ b/configure
@@ -674,6 +674,7 @@ HTMLDOC
 UDOC
 UNIPROGS
 UDBTOOLS
+ICONCCFLAGS
 ICONCTARGET
 SO
 LDDYN
@@ -7949,6 +7950,198 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 	}
 fi
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-deprecated-non-prototype"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-deprecated-non-prototype" >&5
+printf %s "checking whether $CC supports -Werror -Wno-deprecated-non-prototype... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-parentheses-equality"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-parentheses-equality" >&5
+printf %s "checking whether $CC supports -Werror -Wno-parentheses-equality... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-unused-value"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-unused-value" >&5
+printf %s "checking whether $CC supports -Werror -Wno-unused-value... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-return-type"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-return-type" >&5
+printf %s "checking whether $CC supports -Werror -Wno-return-type... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
 
 #if test x"${enable_werror}" = x"yes" ; then
 #  WERROR="-Werror"
@@ -9122,6 +9315,7 @@ if test x"$debug" = x"yes" ; then
 else
   STRIP="strip $DASHX"
 fi
+
 
 
 
@@ -17729,6 +17923,8 @@ ac_config_files="$ac_config_files Makedefs.uni:Makedefs.uni.in"
 
 ac_config_headers="$ac_config_headers src/h/auto.h:src/h/auto.in"
 
+ac_config_files="$ac_config_files src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in"
+
 
 
 cat >confcache <<\_ACEOF
@@ -18421,6 +18617,7 @@ do
     "Makedefs") CONFIG_FILES="$CONFIG_FILES Makedefs:Makedefs.in" ;;
     "Makedefs.uni") CONFIG_FILES="$CONFIG_FILES Makedefs.uni:Makedefs.uni.in" ;;
     "src/h/auto.h") CONFIG_HEADERS="$CONFIG_HEADERS src/h/auto.h:src/h/auto.in" ;;
+    "src/iconc/ccomp_param.h") CONFIG_FILES="$CONFIG_FILES src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -19316,4 +19513,3 @@ cat unicon-config.log
 echo ""
 echo "do make to continue the build"
 echo "or make -j8 for parallel and faster build"
-

--- a/configure
+++ b/configure
@@ -674,6 +674,7 @@ HTMLDOC
 UDOC
 UNIPROGS
 UDBTOOLS
+ICONCCFLAGS
 ICONCTARGET
 SO
 LDDYN
@@ -7961,6 +7962,198 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 	}
 fi
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-deprecated-non-prototype"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-deprecated-non-prototype" >&5
+printf %s "checking whether $CC supports -Werror -Wno-deprecated-non-prototype... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-parentheses-equality"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-parentheses-equality" >&5
+printf %s "checking whether $CC supports -Werror -Wno-parentheses-equality... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-unused-value"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-unused-value" >&5
+printf %s "checking whether $CC supports -Werror -Wno-unused-value... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
+{
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	ac_c_flag_save="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror -Wno-return-type"
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-return-type" >&5
+printf %s "checking whether $CC supports -Werror -Wno-return-type... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+
+				CFLAGS="$ac_c_flag_save"
+				ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"
+
+
+else $as_nop
+
+			CFLAGS="$ac_c_flag_save"
+			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	}
 
 #if test x"${enable_werror}" = x"yes" ; then
 #  WERROR="-Werror"
@@ -9135,6 +9328,7 @@ if test x"$debug" = x"yes" ; then
 else
   STRIP="strip $DASHX"
 fi
+
 
 
 
@@ -18071,6 +18265,8 @@ ac_config_files="$ac_config_files Makedefs.uni:Makedefs.uni.in"
 
 ac_config_headers="$ac_config_headers src/h/auto.h:src/h/auto.in"
 
+ac_config_files="$ac_config_files src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in"
+
 
 
 cat >confcache <<\_ACEOF
@@ -18763,6 +18959,7 @@ do
     "Makedefs") CONFIG_FILES="$CONFIG_FILES Makedefs:Makedefs.in" ;;
     "Makedefs.uni") CONFIG_FILES="$CONFIG_FILES Makedefs.uni:Makedefs.uni.in" ;;
     "src/h/auto.h") CONFIG_HEADERS="$CONFIG_HEADERS src/h/auto.h:src/h/auto.in" ;;
+    "src/iconc/ccomp_param.h") CONFIG_FILES="$CONFIG_FILES src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac
@@ -19674,4 +19871,3 @@ cat unicon-config.log
 echo ""
 echo "do make to continue the build"
 echo "or make -j8 for parallel and faster build"
-

--- a/configure
+++ b/configure
@@ -675,6 +675,10 @@ UDOC
 UNIPROGS
 UDBTOOLS
 ICONCCFLAGS
+ICONC_LDFLAGS_STR
+ICONCCFLAGS_STR
+ICONC_CFLAGS_STR
+ICONC_CPPFLAGS_STR
 ICONCTARGET
 SO
 LDDYN
@@ -7962,6 +7966,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 	}
 fi
+
+# Warning suppressions for iconc-generated C only (not Unicon's own CFLAGS).
+# Skip -Wno-parentheses-equality here (already gated above / hardcoded on MacOS).
+ICONCCFLAGS=
 {
 	ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -7992,54 +8000,6 @@ printf "%s\n" "yes" >&6; }
 
 				CFLAGS="$ac_c_flag_save"
 				ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"
-
-
-else $as_nop
-
-			CFLAGS="$ac_c_flag_save"
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	}
-{
-	ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-	ac_c_flag_save="$CFLAGS"
-	CFLAGS="$CFLAGS -Werror -Wno-parentheses-equality"
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror -Wno-parentheses-equality" >&5
-printf %s "checking whether $CC supports -Werror -Wno-parentheses-equality... " >&6; }
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-				CFLAGS="$ac_c_flag_save"
-				ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"
 
 
 else $as_nop
@@ -18264,6 +18224,18 @@ ac_config_files="$ac_config_files Makedefs:Makedefs.in"
 ac_config_files="$ac_config_files Makedefs.uni:Makedefs.uni.in"
 
 ac_config_headers="$ac_config_headers src/h/auto.h:src/h/auto.in"
+
+
+# Escape configure flag values for embedding in C string literals (ccomp_param.h).
+# Leading space keeps growcat concatenation spacing simple.
+iconc_c_escape() {
+  printf ' %s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+ICONC_CPPFLAGS_STR=`iconc_c_escape "$CPPFLAGS"`
+ICONC_CFLAGS_STR=`iconc_c_escape "$CFLAGS"`
+ICONCCFLAGS_STR=`iconc_c_escape "$ICONCCFLAGS"`
+ICONC_LDFLAGS_STR=`iconc_c_escape "$LDFLAGS"`
+
 
 ac_config_files="$ac_config_files src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in"
 

--- a/configure.ac
+++ b/configure.ac
@@ -437,8 +437,11 @@ if test x"$CC" = x"clang" || test x"$unicon_os" = x"macos" || test x"$unicon_os"
    AC_CFLAG([-Werror -Wno-parentheses-equality], [], [CFLAGS="$CFLAGS -Wno-parentheses-equality"])
    AC_CXXFLAG([-Werror -Wno-parentheses-equality], [], [CXXFLAGS="$CXXFLAGS -Wno-parentheses-equality"])
 fi
+
+# Warning suppressions for iconc-generated C only (not Unicon's own CFLAGS).
+# Skip -Wno-parentheses-equality here (already gated above / hardcoded on MacOS).
+ICONCCFLAGS=
 AC_CFLAG([-Werror -Wno-deprecated-non-prototype], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"])
-AC_CFLAG([-Werror -Wno-parentheses-equality], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"])
 AC_CFLAG([-Werror -Wno-unused-value], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"])
 AC_CFLAG([-Werror -Wno-return-type], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"])
 
@@ -992,6 +995,20 @@ dnl -shared on Alpine (undefined reference to main from crt1). Expose linker fla
 dnl Strip only a standalone -no-pie token (space-delimited), not substrings like -Wl,-no-pie.
 PLUGIN_LDFLAGS=`echo " $LDFLAGS " | sed 's/ -no-pie / /g' | sed 's/  */ /g' | sed 's/^ //;s/ $//'`
 AC_SUBST([PLUGIN_LDFLAGS])
+
+dnl Escape configure flag values for embedding in C string literals (ccomp_param.h).
+dnl Leading space keeps growcat concatenation spacing simple.
+iconc_c_escape() {
+  printf ' %s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+ICONC_CPPFLAGS_STR=`iconc_c_escape "$CPPFLAGS"`
+ICONC_CFLAGS_STR=`iconc_c_escape "$CFLAGS"`
+ICONCCFLAGS_STR=`iconc_c_escape "$ICONCCFLAGS"`
+ICONC_LDFLAGS_STR=`iconc_c_escape "$LDFLAGS"`
+AC_SUBST([ICONC_CPPFLAGS_STR])
+AC_SUBST([ICONC_CFLAGS_STR])
+AC_SUBST([ICONCCFLAGS_STR])
+AC_SUBST([ICONC_LDFLAGS_STR])
 
 AC_CONFIG_FILES([Makefile:Makefile.in],)
 AC_CONFIG_FILES([Makedefs:Makedefs.in],)

--- a/configure.ac
+++ b/configure.ac
@@ -437,6 +437,10 @@ if test x"$CC" = x"clang" || test x"$unicon_os" = x"macos" || test x"$unicon_os"
    AC_CFLAG([-Werror -Wno-parentheses-equality], [], [CFLAGS="$CFLAGS -Wno-parentheses-equality"])
    AC_CXXFLAG([-Werror -Wno-parentheses-equality], [], [CXXFLAGS="$CXXFLAGS -Wno-parentheses-equality"])
 fi
+AC_CFLAG([-Werror -Wno-deprecated-non-prototype], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"])
+AC_CFLAG([-Werror -Wno-parentheses-equality], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"])
+AC_CFLAG([-Werror -Wno-unused-value], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"])
+AC_CFLAG([-Werror -Wno-return-type], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"])
 
 #if test x"${enable_werror}" = x"yes" ; then
 #  WERROR="-Werror"
@@ -627,6 +631,7 @@ AC_SUBST(CFDYN)
 AC_SUBST(LDDYN)
 AC_SUBST(SO)
 AC_SUBST(ICONCTARGET)
+AC_SUBST(ICONCCFLAGS)
 
 AC_SUBST(UDBTOOLS)
 AC_SUBST(UNIPROGS)
@@ -992,6 +997,7 @@ AC_CONFIG_FILES([Makefile:Makefile.in],)
 AC_CONFIG_FILES([Makedefs:Makedefs.in],)
 AC_CONFIG_FILES([Makedefs.uni:Makedefs.uni.in],)
 AC_CONFIG_HEADERS([src/h/auto.h:src/h/auto.in],)
+AC_CONFIG_FILES([src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in],)
 
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -440,8 +440,11 @@ if test x"$CC" = x"clang" || test x"$unicon_os" = x"macos" || test x"$unicon_os"
    AC_CFLAG([-Werror -Wno-parentheses-equality], [], [CFLAGS="$CFLAGS -Wno-parentheses-equality"])
    AC_CXXFLAG([-Werror -Wno-parentheses-equality], [], [CXXFLAGS="$CXXFLAGS -Wno-parentheses-equality"])
 fi
+
+# Warning suppressions for iconc-generated C only (not Unicon's own CFLAGS).
+# Skip -Wno-parentheses-equality here (already gated above / hardcoded on MacOS).
+ICONCCFLAGS=
 AC_CFLAG([-Werror -Wno-deprecated-non-prototype], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"])
-AC_CFLAG([-Werror -Wno-parentheses-equality], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"])
 AC_CFLAG([-Werror -Wno-unused-value], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"])
 AC_CFLAG([-Werror -Wno-return-type], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"])
 
@@ -1004,6 +1007,20 @@ dnl -shared on Alpine (undefined reference to main from crt1). Expose linker fla
 dnl Strip only a standalone -no-pie token (space-delimited), not substrings like -Wl,-no-pie.
 PLUGIN_LDFLAGS=`echo " $LDFLAGS " | sed 's/ -no-pie / /g' | sed 's/  */ /g' | sed 's/^ //;s/ $//'`
 AC_SUBST([PLUGIN_LDFLAGS])
+
+dnl Escape configure flag values for embedding in C string literals (ccomp_param.h).
+dnl Leading space keeps growcat concatenation spacing simple.
+iconc_c_escape() {
+  printf ' %s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+ICONC_CPPFLAGS_STR=`iconc_c_escape "$CPPFLAGS"`
+ICONC_CFLAGS_STR=`iconc_c_escape "$CFLAGS"`
+ICONCCFLAGS_STR=`iconc_c_escape "$ICONCCFLAGS"`
+ICONC_LDFLAGS_STR=`iconc_c_escape "$LDFLAGS"`
+AC_SUBST([ICONC_CPPFLAGS_STR])
+AC_SUBST([ICONC_CFLAGS_STR])
+AC_SUBST([ICONCCFLAGS_STR])
+AC_SUBST([ICONC_LDFLAGS_STR])
 
 AC_CONFIG_FILES([Makefile:Makefile.in],)
 AC_CONFIG_FILES([Makedefs:Makedefs.in],)

--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,10 @@ if test x"$CC" = x"clang" || test x"$unicon_os" = x"macos" || test x"$unicon_os"
    AC_CFLAG([-Werror -Wno-parentheses-equality], [], [CFLAGS="$CFLAGS -Wno-parentheses-equality"])
    AC_CXXFLAG([-Werror -Wno-parentheses-equality], [], [CXXFLAGS="$CXXFLAGS -Wno-parentheses-equality"])
 fi
+AC_CFLAG([-Werror -Wno-deprecated-non-prototype], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-deprecated-non-prototype"])
+AC_CFLAG([-Werror -Wno-parentheses-equality], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-parentheses-equality"])
+AC_CFLAG([-Werror -Wno-unused-value], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-unused-value"])
+AC_CFLAG([-Werror -Wno-return-type], [], [ICONCCFLAGS="$ICONCCFLAGS -Wno-return-type"])
 
 #if test x"${enable_werror}" = x"yes" ; then
 #  WERROR="-Werror"
@@ -631,6 +635,7 @@ AC_SUBST(CFDYN)
 AC_SUBST(LDDYN)
 AC_SUBST(SO)
 AC_SUBST(ICONCTARGET)
+AC_SUBST(ICONCCFLAGS)
 
 AC_SUBST(UDBTOOLS)
 AC_SUBST(UNIPROGS)
@@ -1004,6 +1009,7 @@ AC_CONFIG_FILES([Makefile:Makefile.in],)
 AC_CONFIG_FILES([Makedefs:Makedefs.in],)
 AC_CONFIG_FILES([Makedefs.uni:Makedefs.uni.in],)
 AC_CONFIG_HEADERS([src/h/auto.h:src/h/auto.in],)
+AC_CONFIG_FILES([src/iconc/ccomp_param.h:src/iconc/ccomp_param.h.in],)
 
 
 AC_OUTPUT

--- a/src/iconc/Makefile
+++ b/src/iconc/Makefile
@@ -31,8 +31,10 @@ $(OBJS):	../h/config.h ../h/cpuconf.h ../h/cstructs.h ../h/define.h\
 	$(CMNT)@echo "   [ICONC] $<"
 	$(SLNT)$(CC) $(CFLAGS) $(CPPFLAGS) -c $<
 
-ccomp.o:	ccomp.c
-		$(CC) $(CFLAGS) $(CPPFLAGS) -DICONC_LIB="\"$(LIBS)\"" -c ccomp.c
+# ccomp_param.h is generated under UNICON_TOP_BUILDDIR (out-of-tree safe).
+ccomp.o:	ccomp.c $(UNICON_TOP_BUILDDIR)/src/iconc/ccomp_param.h
+		$(CC) $(CFLAGS) $(CPPFLAGS) -I$(UNICON_TOP_BUILDDIR)/src/iconc \
+			-DICONC_LIB="\"$(LIBS)\"" -c ccomp.c
 
 ccode.o:	../h/lexdef.h ctoken.h
 chkinv.o:	ctoken.h

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -9,6 +9,7 @@
 #include "ccode.h"
 #include "csym.h"
 #include "cproto.h"
+#include "ccomp_param.h"
 
 extern char *refpath;
 
@@ -278,6 +279,7 @@ Deliberate Syntax Error
       buf = growcat(buf, &buflen, 2, " ", l->libname);
       }
 
+   buf = growcat(buf, &buflen, 4, CPPFLAGS, CFLAGS, ICONCCFLAGS, LDFLAGS);
 #ifdef Messaging
    buf = growcat(buf, &buflen, 1, " -ltp");
 #endif                                  /* Messaging */

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -279,7 +279,8 @@ Deliberate Syntax Error
       buf = growcat(buf, &buflen, 2, " ", l->libname);
       }
 
-   buf = growcat(buf, &buflen, 4, CPPFLAGS, CFLAGS, ICONCCFLAGS, LDFLAGS);
+   buf = growcat(buf, &buflen, 4, ICONC_CPPFLAGS, ICONC_CFLAGS,
+                 ICONCCFLAGS, ICONC_LDFLAGS);
 #ifdef Messaging
    buf = growcat(buf, &buflen, 1, " -ltp");
 #endif                                  /* Messaging */

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -268,6 +268,9 @@ Deliberate Syntax Error
 #endif                                  /* MacOS */
 #endif                                  /* Graphics */
 
+   /* Compile flags before the source file; link flags with the -l tail. */
+   buf = growcat(buf, &buflen, 3, ICONC_CPPFLAGS, ICONC_CFLAGS, ICONCCFLAGS);
+
    buf = growcat(buf, &buflen, 6, " ", ExeFlag, " ", exename, " ", srcname);
 
 #if 0
@@ -275,11 +278,11 @@ Deliberate Syntax Error
       buf = growcat(buf, &buflen, 2, " ", dlrgint);
       }
 #endif
+   buf = growcat(buf, &buflen, 1, ICONC_LDFLAGS);
    for (l = liblst; l != NULL; l = l->next) {
       buf = growcat(buf, &buflen, 2, " ", l->libname);
       }
 
-   buf = growcat(buf, &buflen, 4, CPPFLAGS, CFLAGS, ICONCCFLAGS, LDFLAGS);
 #ifdef Messaging
    buf = growcat(buf, &buflen, 1, " -ltp");
 #endif                                  /* Messaging */

--- a/src/iconc/ccomp_param.h.in
+++ b/src/iconc/ccomp_param.h.in
@@ -1,0 +1,10 @@
+#ifndef __CCOMP_PARAM_H
+#define __CCOMP_PARAM_H
+
+/* note the spaces in front so that it can be used by growcat directly */
+#define CPPFLAGS " @CPPFLAGS@"
+#define CFLAGS " @CFLAGS@"
+#define ICONCCFLAGS " @ICONCCFLAGS@"
+#define LDFLAGS " @LDFLAGS@"
+
+#endif		/* __CCOMP_PARAM_H */

--- a/src/iconc/ccomp_param.h.in
+++ b/src/iconc/ccomp_param.h.in
@@ -1,10 +1,14 @@
-#ifndef __CCOMP_PARAM_H
-#define __CCOMP_PARAM_H
+#ifndef CCOMP_PARAM_H
+#define CCOMP_PARAM_H
 
-/* note the spaces in front so that it can be used by growcat directly */
-#define CPPFLAGS " @CPPFLAGS@"
-#define CFLAGS " @CFLAGS@"
-#define ICONCCFLAGS " @ICONCCFLAGS@"
-#define LDFLAGS " @LDFLAGS@"
+/*
+ * Configure-substituted flags for iconc's host compile/link line.
+ * Leading spaces are included so values can be passed to growcat directly.
+ * Values are C-string-escaped at configure time (see configure.ac).
+ */
+#define ICONC_CPPFLAGS "@ICONC_CPPFLAGS_STR@"
+#define ICONC_CFLAGS "@ICONC_CFLAGS_STR@"
+#define ICONCCFLAGS "@ICONCCFLAGS_STR@"
+#define ICONC_LDFLAGS "@ICONC_LDFLAGS_STR@"
 
-#endif		/* __CCOMP_PARAM_H */
+#endif				/* CCOMP_PARAM_H */


### PR DESCRIPTION
- introduce ICONCCFLAGS to prevent spurious warnings from autogenerated code
- generate ccomp_param.h during configure
- use the extra variables in growcat

side-effect: a number of growcat behind #ifdef may have become entirely redundant.

This time I've rebuilt configure.

This may be of particular interest for @ryandesign as it should solve a number of problems he had.

