### PR TITLE
Add multicast and general socket-attribute support to the network API

### DIFF
--- a/configure
+++ b/configure
@@ -9061,7 +9061,7 @@ case $unicon_host in
        DASHG="-G"
        LDFLAGS="$LDFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
        CPPFLAGS="$CPPFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
-       LIBS="$LIBS -lgdi32 -lws2_32"
+       LIBS="$LIBS -lgdi32 -lws2_32 -liphlpapi"
 
        WSTKLDFLAG="-Xlinker --stack -Xlinker 8192000"
        WGLIBS="-lopengl32 -lglu32 -lkernel32 -luser32 -lgdi32 -lcomdlg32 -lwinmm"

--- a/configure.ac
+++ b/configure.ac
@@ -522,7 +522,7 @@ case $unicon_host in
        DASHG="-G"
        LDFLAGS="$LDFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
        CPPFLAGS="$CPPFLAGS --static -mnop-fun-dllimport -mwin32 -DPTW32_STATIC_LIB "
-       LIBS="$LIBS -lgdi32 -lws2_32"
+       LIBS="$LIBS -lgdi32 -lws2_32 -liphlpapi"
 
        WSTKLDFLAG="-Xlinker --stack -Xlinker 8192000"
        WGLIBS="-lopengl32 -lglu32 -lkernel32 -luser32 -lgdi32 -lcomdlg32 -lwinmm"

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2898,6 +2898,15 @@ domain socket. If the host name is null, it represents the current
 host. Mode \texttt{"n"} allows an optional third parameter,
 an integer timeout (in milliseconds) after which \texttt{open()} fails
 if no connection has been established by that time.
+Trailing arguments may also be \texttt{"\textit{name}=\textit{value}"}
+socket attributes (\texttt{join}, \texttt{source}, \texttt{iface},
+\texttt{ttl}, \texttt{mcastloop}, \texttt{reuseaddr},
+\texttt{reuseport}, \texttt{broadcast}, \texttt{rcvbuf},
+\texttt{sndbuf}); boolean values are \texttt{yes} or \texttt{no}.
+Listeners default to \texttt{reuseaddr=yes}. Binding a UDP socket to a
+multicast group joins that group; \texttt{source@group:port} or
+\texttt{source=} performs a source-specific join instead. Sending to
+\texttt{255.255.255.255} enables broadcast. See Chapter~5 for examples.
 
 For a UDP socket, there is not really a connection, but any writes to
 that file will send a datagram to that address, so that the address
@@ -4996,6 +5005,7 @@ length\\
 1306 \ \ \ \ \ \ \ cipher error\\
 1307 \ \ \ \ \ \ \ private key and certificate mismatch\\
 1308 \ \ \ \ \ \ \ unknown protocol\\
+1310 \ \ \ \ \ \ \ bad socket attribute\\
 
 \subsection*{System errors}
 

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -1903,6 +1903,27 @@ hyperbolic tangent of \texttt{r}. Arguments are given in radians.
 
 \bigskip
 \hrule\vspace{0.1cm}
+\index{Attrib}
+\noindent
+{\bf Attrib(x, ...) : x* } \hfill {\bf get or set attributes}
+
+\noindent
+\texttt{Attrib()} gets or sets attributes of its first argument.
+For a network socket file, trailing string arguments use the same
+\texttt{"\textit{name}"} / \texttt{"\textit{name}=\textit{value}"} form
+as \texttt{open()} socket attributes and \texttt{WAttrib()}: assignments
+set options (including \texttt{join}/\texttt{leave} for multicast
+memberships); bare names query the current value except for
+\texttt{join}, \texttt{leave}, and \texttt{source}, which fail.
+Boolean values are \texttt{yes}/\texttt{no}; numeric values are
+integers. Socket attributes do not require the Concurrent build
+feature.
+For a co-expression or list, integer attribute codes from
+\texttt{threadh.icn} query or set thread inbox/outbox and channel limits
+(see Chapter~8; requires Concurrent).
+
+\bigskip
+\hrule\vspace{0.1cm}
 \index{bal}
 \noindent
 {\bf bal(cs:\&cset, cs:'(', cs:')', s, i, i) : integer* } \hfill {\bf balance string}
@@ -2899,14 +2920,24 @@ host. Mode \texttt{"n"} allows an optional third parameter,
 an integer timeout (in milliseconds) after which \texttt{open()} fails
 if no connection has been established by that time.
 Trailing arguments may also be \texttt{"\textit{name}=\textit{value}"}
-socket attributes (\texttt{join}, \texttt{source}, \texttt{iface},
-\texttt{ttl}, \texttt{mcastloop}, \texttt{reuseaddr},
-\texttt{reuseport}, \texttt{broadcast}, \texttt{rcvbuf},
-\texttt{sndbuf}); boolean values are \texttt{yes} or \texttt{no}.
-Listeners default to \texttt{reuseaddr=yes}. Binding a UDP socket to a
-multicast group joins that group; \texttt{source@group:port} or
+socket attributes (\texttt{join}, \texttt{leave}, \texttt{source},
+\texttt{iface}, \texttt{ttl}, \texttt{mcastloop},
+\texttt{reuseaddr}, \texttt{reuseport}, \texttt{broadcast},
+\texttt{rcvbuf}, \texttt{sndbuf}); boolean values are \texttt{yes} or
+\texttt{no}. \texttt{iface} accepts an IPv4 address, a numeric
+interface index, or (on UNIX) an interface name; when omitted, a
+multicast join covers every UP IPv4 interface and a multicast send
+uses the first non-loopback IPv4 address (else loopback).
+\texttt{ttl} sets unicast and multicast hop limits;
+\texttt{mcastloop} controls delivery of the host's own multicasts
+(default on); \texttt{rcvbuf}/\texttt{sndbuf} take a byte size.
+Listeners default to \texttt{reuseaddr=yes}; multicast binds also
+get \texttt{reuseport=yes} where available. Binding a UDP socket to
+a multicast group joins that group; \texttt{source@group:port} or
 \texttt{source=} performs a source-specific join instead. Sending to
-\texttt{255.255.255.255} enables broadcast. See Chapter~5 for examples.
+\texttt{255.255.255.255} enables broadcast. The same attributes can be
+read or changed after \texttt{open()} with \texttt{Attrib()}. See
+Chapter~5 for examples.
 
 For a UDP socket, there is not really a connection, but any writes to
 that file will send a datagram to that address, so that the address

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2934,7 +2934,8 @@ uses the first non-loopback IPv4 address (else loopback).
 Listeners default to \texttt{reuseaddr=yes}; multicast binds also
 get \texttt{reuseport=yes} where available. Binding a UDP socket to
 a multicast group joins that group; \texttt{source@group:port} or
-\texttt{source=} performs a source-specific join instead. Sending to
+\texttt{source=} performs a source-specific join instead (IPv4 and
+IPv6; for IPv6 SSM prefer an explicit \texttt{iface=}). Sending to
 \texttt{255.255.255.255} enables broadcast. The same attributes can be
 read or changed after \texttt{open()} with \texttt{Attrib()}. See
 Chapter~5 for examples.

--- a/doc/book/system.tex
+++ b/doc/book/system.tex
@@ -784,23 +784,32 @@ SSL and graphics windows. Boolean attributes take \texttt{yes} or
 attributes at all: binding a UDP socket to a multicast group address
 joins that group (any-source multicast, ASM), and listeners default to
 \texttt{reuseaddr=yes} so a restarted server can rebind its port.
-Sending to the limited broadcast address \texttt{255.255.255.255}
-enables \texttt{SO\_BROADCAST} automatically.
+When \texttt{iface=} is omitted, a join covers every UP IPv4
+interface, and a multicast send uses the first non-loopback IPv4
+address (or loopback if that is all the host has); kernel multicast
+loopback remains on by default, so a local receiver still sees the
+packets. Sending to the limited broadcast address
+\texttt{255.255.255.255} enables \texttt{SO\_BROADCAST} automatically.
 
-A multicast receiver that binds the group and a sender that transmits
-to it look like this:
+Here is a minimal receiver that joins a group and prints each
+datagram, and a matching sender. Run the receiver in one terminal and
+the sender in another:
 
 \iconcode{
 procedure main() \\
-\>   group := "239.1.1.1" \\
-\>   port := "5000" \\
-\>   f := open(group {\textbar}{\textbar} ":" {\textbar}{\textbar} port, "nua") {\textbar} \\
-\>\>\>\>stop(\&errortext) \\
-\>   s := open(group {\textbar}{\textbar} ":" {\textbar}{\textbar} port, "nu") {\textbar} \\
-\>\>\>\>stop(\&errortext) \\
-\>   writes(s, "hello") \\
-\>   if *select(f, 5000) {\textgreater} 0 then \\
-\>\>\>write("Received ", receive(f).msg) \\
+\>   local f, r \\
+\>   f := open("239.1.1.1:5000", "nua") {\textbar} stop(\&errortext) \\
+\>   while r := receive(f) do \\
+\>\>\>write(r.addr, "  ", r.msg) \\
+end
+}
+
+\iconcode{
+procedure main() \\
+\>   local f, i \\
+\>   f := open("239.1.1.1:5000", "nu") {\textbar} stop(\&errortext) \\
+\>   every i := 1 to 5 do \\
+\>\>\>writes(f, "hello-" {\textbar}{\textbar} i) \& delay(500) \\
 end
 }
 
@@ -817,9 +826,12 @@ tooling and RFC~4607 \texttt{(S,G)} order --- or pass a
 When binding a wildcard address (or joining additional groups), use
 \texttt{join=} attributes. The form \texttt{join=\textit{group}} is ASM;
 \texttt{join=\textit{group},\textit{source}} is SSM. Attributes may be
-repeated, and ASM and SSM joins may be mixed in the same call. A
-\texttt{iface=} attribute selects the interface used by
-\texttt{join=} attributes that follow it:
+repeated, and ASM and SSM joins may be mixed in the same call. An
+explicit \texttt{iface=} restricts join and send to one interface
+instead of the defaults above; the value may be an IPv4 address, a
+numeric interface index, or an interface name such as \texttt{en0} or
+\texttt{eth0}. An \texttt{iface=} before a \texttt{join=} selects the
+interface used by that join:
 
 \iconcode{
 \>   f := open(":5000", "nua", \\
@@ -828,11 +840,54 @@ repeated, and ASM and SSM joins may be mixed in the same call. A
 \>\>\>"join=232.1.1.1,10.0.0.5")
 }
 
-Other socket attributes include \texttt{reuseaddr}, \texttt{reuseport},
-\texttt{broadcast}, \texttt{rcvbuf}, \texttt{sndbuf}, \texttt{ttl}
-(IPv6 hop limit), and \texttt{mcastloop}. Explicit attributes always
-override the defaults. On send or connect, a \texttt{source@group:port}
-address keeps only the group so the destination is the group address.
+The remaining socket attributes are:
+
+\begin{description}
+\item[\texttt{reuseaddr=yes{\textbar}no}]
+Allows the local address to be reused while a previous binding is
+still in \texttt{TIME\_WAIT}. Listeners default to \texttt{yes} on
+UNIX.
+\item[\texttt{reuseport=yes{\textbar}no}]
+Where the platform provides \texttt{SO\_REUSEPORT}, allows several
+sockets to bind the same address and port (useful when sharing a
+multicast group among processes). Multicast binds enable it by
+default when available.
+\item[\texttt{broadcast=yes{\textbar}no}]
+Enables sending to the limited broadcast address. Opening
+\texttt{255.255.255.255} sets this automatically.
+\item[\texttt{ttl=\textit{n}}]
+Sets both the unicast and multicast hop limits (IPv4 TTL /
+IPv6 hops) to integer \texttt{\textit{n}}.
+\item[\texttt{mcastloop=yes{\textbar}no}]
+Controls whether a host receives its own multicast transmissions.
+The kernel default is \texttt{yes}.
+\item[\texttt{rcvbuf=\textit{n}}, \texttt{sndbuf=\textit{n}}]
+Set the socket receive and send buffer sizes in bytes.
+\end{description}
+
+Explicit attributes always override the defaults. On send or connect,
+a \texttt{source@group:port} address keeps only the group so the
+destination is the group address.
+
+After \texttt{open()}, the same attributes can be read or changed with
+\index{Attrib()}\texttt{Attrib()}, using the same
+\texttt{"\textit{name}"} / \texttt{"\textit{name}=\textit{value}"} style
+as \texttt{WAttrib()}:
+
+\iconcode{
+\>   Attrib(f, "ttl=4") \\
+\>   write(Attrib(f, "ttl")) \\
+\>   Attrib(f, "join=239.1.1.2") \\
+\>   Attrib(f, "iface=127.0.0.1", "leave=239.1.1.1")
+}
+
+\texttt{join} and \texttt{leave} add or drop memberships on an existing
+socket (forms match \texttt{open()}: \texttt{group} or
+\texttt{group,source}); pass \texttt{iface=} before \texttt{leave=}
+when the membership was joined on a specific interface. Memberships
+cannot be queried. Bare names for the other attributes return
+\texttt{yes}/\texttt{no}, an integer, or (for IPv4 \texttt{iface}) a
+dotted address; \texttt{source} cannot be queried either.
 
 \subsection*{Secure Sockets}
 

--- a/doc/book/system.tex
+++ b/doc/book/system.tex
@@ -9,7 +9,7 @@ with the operating system. This chapter shows how to
   \item Launch and interact with other programs
   \item Handle abnormal events that would otherwise terminate your program
   \item Write \index{Internet}Internet \index{client}client and
-    \index{server}server applications.
+    \index{server}server applications, including multicast
 \end{itemize}
 
 \section{The Role of the System Interface}
@@ -771,6 +771,68 @@ protocol, you can do it on top of TCP or UDP; if your program needs to
 use a standard Internet protocol, you should check first to see if the
 protocol is built-in to the language as part of the messaging
 facilities, described in the next section.
+
+\subsection*{Multicast and Socket Attributes}
+\index{multicast}\index{socket attributes}
+Network calls to \texttt{open()} accept trailing
+\texttt{"\textit{name}=\textit{value}"} attributes, in the same style as
+SSL and graphics windows. Boolean attributes take \texttt{yes} or
+\texttt{no}. Unknown attributes fail the \texttt{open()} with error
+1310 (\texttt{bad socket attribute}).
+
+\index{IP multicast}IP multicast uses UDP. The common cases need no
+attributes at all: binding a UDP socket to a multicast group address
+joins that group (any-source multicast, ASM), and listeners default to
+\texttt{reuseaddr=yes} so a restarted server can rebind its port.
+Sending to the limited broadcast address \texttt{255.255.255.255}
+enables \texttt{SO\_BROADCAST} automatically.
+
+A multicast receiver that binds the group and a sender that transmits
+to it look like this:
+
+\iconcode{
+procedure main() \\
+\>   group := "239.1.1.1" \\
+\>   port := "5000" \\
+\>   f := open(group {\textbar}{\textbar} ":" {\textbar}{\textbar} port, "nua") {\textbar} \\
+\>\>\>\>stop(\&errortext) \\
+\>   s := open(group {\textbar}{\textbar} ":" {\textbar}{\textbar} port, "nu") {\textbar} \\
+\>\>\>\>stop(\&errortext) \\
+\>   writes(s, "hello") \\
+\>   if *select(f, 5000) {\textgreater} 0 then \\
+\>\>\>write("Received ", receive(f).msg) \\
+end
+}
+
+For \index{SSM}source-specific multicast (SSM), name the source before
+the group with \texttt{@} --- \texttt{source@group}, matching common
+tooling and RFC~4607 \texttt{(S,G)} order --- or pass a
+\texttt{source=} attribute on a socket already bound to the group:
+
+\iconcode{
+\>   f := open("192.168.1.1@239.1.1.1:5000", "nua") \\
+\>   f := open("239.1.1.1:5000", "nua", "source=192.168.1.1")
+}
+
+When binding a wildcard address (or joining additional groups), use
+\texttt{join=} attributes. The form \texttt{join=\textit{group}} is ASM;
+\texttt{join=\textit{group},\textit{source}} is SSM. Attributes may be
+repeated, and ASM and SSM joins may be mixed in the same call. A
+\texttt{iface=} attribute selects the interface used by
+\texttt{join=} attributes that follow it:
+
+\iconcode{
+\>   f := open(":5000", "nua", \\
+\>\>\>"iface=192.168.1.10", \\
+\>\>\>"join=239.1.1.1", \\
+\>\>\>"join=232.1.1.1,10.0.0.5")
+}
+
+Other socket attributes include \texttt{reuseaddr}, \texttt{reuseport},
+\texttt{broadcast}, \texttt{rcvbuf}, \texttt{sndbuf}, \texttt{ttl}
+(IPv6 hop limit), and \texttt{mcastloop}. Explicit attributes always
+override the defaults. On send or connect, a \texttt{source@group:port}
+address keeps only the group so the destination is the group address.
 
 \subsection*{Secure Sockets}
 

--- a/doc/book/system.tex
+++ b/doc/book/system.tex
@@ -779,6 +779,13 @@ Network calls to \texttt{open()} accept trailing
 SSL and graphics windows. Boolean attributes take \texttt{yes} or
 \texttt{no}. Unknown attributes fail the \texttt{open()} with error
 1310 (\texttt{bad socket attribute}).
+A second \texttt{open()} of the same listener address with no socket
+attributes returns another file handle for the cached socket. An open
+that supplies attributes (\texttt{join=}, \texttt{leave=},
+\texttt{iface=}, and so on) gets its own socket instead, so it cannot
+retune earlier aliases; use \texttt{Attrib()} to change options or leave
+a group on a live shared handle. Closing one alias leaves the others
+usable until the last handle is closed.
 
 \index{IP multicast}IP multicast uses UDP. The common cases need no
 attributes at all: binding a UDP socket to a multicast group address
@@ -816,11 +823,15 @@ end
 For \index{SSM}source-specific multicast (SSM), name the source before
 the group with \texttt{@} --- \texttt{source@group}, matching common
 tooling and RFC~4607 \texttt{(S,G)} order --- or pass a
-\texttt{source=} attribute on a socket already bound to the group:
+\texttt{source=} attribute on a socket already bound to the group.
+Both IPv4 and IPv6 are supported; for IPv6 SSM, pass an explicit
+\texttt{iface=} (name or index) so the join uses a single interface:
 
 \iconcode{
 \>   f := open("192.168.1.1@239.1.1.1:5000", "nua") \\
-\>   f := open("239.1.1.1:5000", "nua", "source=192.168.1.1")
+\>   f := open("239.1.1.1:5000", "nua", "source=192.168.1.1") \\
+\>   f := open("::1@ff3e::1:5000", "nua6", "iface=lo0") \\
+\>   f := open("ff3e::1:5000", "nua6", "iface=lo0", "source=::1")
 }
 
 When binding a wildcard address (or joining additional groups), use

--- a/src/h/posix.h
+++ b/src/h/posix.h
@@ -37,6 +37,7 @@
 
 #include <string.h>   /* _stricmp (fxposix.ri getpw), strlen in String() etc. */
 #include<ws2tcpip.h>
+#include <iphlpapi.h>                   /* if_nametoindex for iface= */
 
 #include <sys/timeb.h>
 #include <sys/locking.h>

--- a/src/h/posix.h
+++ b/src/h/posix.h
@@ -26,6 +26,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <net/if.h>
+#include <ifaddrs.h>
 #include <pwd.h>
 #include <grp.h>
 #endif                                  /* UNIX */

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -989,6 +989,8 @@ dptr rec_structor3d             (char *type);
 int sock_connect                (char *s, int udp, int timeout, int af_fam, dptr attr, int nattr);
 int apply_sock_attrs            (int s, int prebind, dptr attr, int nattr,
                                  char *autojoin, char *autosource);
+int sattrib                     (int s, char *str, long len, dptr answer,
+                                 char *abuf);
 int sock_attrs_af               (dptr attr, int nattr);
 int is_sock_attr                (char *name);
 int sock_getstrg                (char *buf, int maxi, dptr file);

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -986,7 +986,10 @@ dptr make_group                 (struct group *pw, dptr result);
 
 dptr rec_structor               (char *s);
 dptr rec_structor3d             (char *type);
-int sock_connect                (char *s, int udp, int timeout, int af_fam);
+int sock_connect                (char *s, int udp, int timeout, int af_fam, dptr attr, int nattr);
+int apply_sock_attrs            (int s, int prebind, dptr attr, int nattr, char *autojoin);
+int sock_attrs_af               (dptr attr, int nattr);
+int is_sock_attr                (char *name);
 int sock_getstrg                (char *buf, int maxi, dptr file);
 int getmodefd                   (int fd, char *mode);
 int getmodenam                  (char *path, char *mode);
@@ -1004,7 +1007,11 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family);
 void            set_gaierrortext(int i);
 
 dptr make_serv                  (struct servent *pw, dptr result);
-int sock_listen                 (char *s, int udp, int af_fam);
+int sock_listen                 (char *s, int udp, int af_fam, dptr attr, int nattr);
+void sock_close                 (int fd);
+int sock_pin                    (int fd);
+void sock_release               (int fd);
+int sock_purge                  (int fd);
 int sock_name                   (int sock, char* addr, char* addrbuf, int bufsize);
 int sock_me                     (int sock, char* addrbuf, int bufsize);
 int sock_send                   (char* addr, char* msg, int msglen, int af_fam);
@@ -1144,6 +1151,9 @@ int checkTypeInt (dptr da1, dptr da2, word n );
 
 char * getenv_var(const char *name);
 
+/* defined unguarded in errmsg.r; used by socket and SSL attribute code */
+void set_errortext_with_val(int i, char* errval);
+
 #if HAVE_LIBSSL
 #define TLS_SERVER 1
 #define TLS_CLIENT 2
@@ -1153,7 +1163,6 @@ char * getenv_var(const char *name);
 SSL_CTX* create_ssl_context(dptr attr, int n, int type);
 int set_ssl_connection_errortext(SSL *ssl, int err);
 void set_ssl_context_errortext(int err, char* errtext);
-void set_errortext_with_val(int i, char* errval);
 #endif                                  /* HAVE_LIBSSL */
 
 #ifdef GenericBSD

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -987,7 +987,8 @@ dptr make_group                 (struct group *pw, dptr result);
 dptr rec_structor               (char *s);
 dptr rec_structor3d             (char *type);
 int sock_connect                (char *s, int udp, int timeout, int af_fam, dptr attr, int nattr);
-int apply_sock_attrs            (int s, int prebind, dptr attr, int nattr, char *autojoin);
+int apply_sock_attrs            (int s, int prebind, dptr attr, int nattr,
+                                 char *autojoin, char *autosource);
 int sock_attrs_af               (dptr attr, int nattr);
 int is_sock_attr                (char *name);
 int sock_getstrg                (char *buf, int maxi, dptr file);

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -988,7 +988,8 @@ dptr rec_structor               (char *s);
 dptr rec_structor3d             (char *type);
 int sock_connect                (char *s, int udp, int timeout, int af_fam, dptr attr, int nattr);
 int apply_sock_attrs            (int s, int prebind, dptr attr, int nattr,
-                                 char *autojoin, char *autosource);
+                                 char *autojoin, char *autosource,
+                                 int join_only);
 int sattrib                     (int s, char *str, long len, dptr answer,
                                  char *abuf);
 int sock_attrs_af               (dptr attr, int nattr);
@@ -1012,9 +1013,11 @@ void            set_gaierrortext(int i);
 dptr make_serv                  (struct servent *pw, dptr result);
 int sock_listen                 (char *s, int udp, int af_fam, dptr attr, int nattr);
 void sock_close                 (int fd);
-int sock_pin                    (int fd);
+int sock_pin                    (int fd, word gen);
 void sock_release               (int fd);
 int sock_purge                  (int fd);
+void sock_unclaim               (int fd, word gen);
+word sock_listener_gen          (int fd);
 int sock_name                   (int sock, char* addr, char* addrbuf, int bufsize);
 int sock_me                     (int sock, char* addrbuf, int bufsize);
 int sock_send                   (char* addr, char* msg, int msglen, int af_fam);

--- a/src/h/rstructs.h
+++ b/src/h/rstructs.h
@@ -152,6 +152,9 @@ struct b_file {                 /* file block */
 #ifdef Concurrent
    word mutexid;
 #endif                          /* Concurrent */
+#ifdef PosixFns
+   word sock_gen;               /* listener-cache generation; 0 = none */
+#endif                          /* PosixFns */
    struct descrip fname;        /*   file name (string qualifier) */
    };
 

--- a/src/runtime/data.r
+++ b/src/runtime/data.r
@@ -453,6 +453,10 @@ struct errtab errtab[] = {
 
 #endif                                  /* Messaging */
 
+#ifdef PosixFns
+   1310, "bad socket attribute",
+#endif                                  /* PosixFns */
+
 /*
  * End of operating-system specific code.
  */

--- a/src/runtime/fmisc.r
+++ b/src/runtime/fmisc.r
@@ -3041,25 +3041,177 @@ function{0,1} spawn(x, blocksize, stringsize, stacksize, soft)
      }
 end
 
-"Attrib(argv[]) - read/write thread attributes"
+#else                                   /* Concurrent */
 
-function{1} Attrib(argv[argc])
+MissingFuncV(mutex)
+MissingFuncV(lock)
+MissingFuncV(trylock)
+MissingFuncV(unlock)
+MissingFuncV(condvar)
+MissingFuncV(spawn)
+MissingFuncV(signal)
+#endif                                  /* Concurrent */
+
+/*
+ * Attrib() is available with Concurrent (thread/channel attrs) and/or
+ * PosixFns (socket attrs).  Socket support must not depend on Concurrent;
+ * no-concurrency builds still need Attrib(f, "ttl=...") etc.
+ */
+#if defined(Concurrent) || defined(PosixFns)
+
+"Attrib(argv[]) - read/write attributes (threads, sockets, ...)"
+
+function{*} Attrib(argv[argc])
    abstract {
-      return integer
+      return string++integer
       }
    body {
 
       /*
-       * TODO: Generalize Attrib() to accept data of other types
-       * such as arrays, and query/change their attributes.
+       * Attrib() dispatches on the type of its first argument:
+       *   - socket file: WAttrib-style "name" / "name=value" strings
+       *   - co-expression / list / integer codes: thread/channel attrs
        */
 
+#ifdef Concurrent
       struct b_coexpr *ccp;
       struct b_list *hp;
       word base=0, q, n;
+#endif                                  /* Concurrent */
 
       if (argc == 0) runerr(130, nulldesc);
 
+#ifdef PosixFns
+      /*
+       * Socket attributes: Attrib(f, "ttl=4") sets, Attrib(f, "ttl")
+       * gets.  Same names as open() trailing attributes; join/leave add or
+       * drop multicast memberships after open.
+       */
+      if (is:file(argv[0]) && (BlkD(argv[0],File)->status & Fs_Socket)) {
+         tended struct descrip sbuf, ans;
+         struct descrip setv[64];
+         char abuf[256];
+         word i, j, nset;
+         int s, status;
+         char *p, *end, *eq;
+
+         if (argc < 2)
+            runerr(130, nulldesc);
+
+         status = BlkD(argv[0],File)->status;
+#if HAVE_LIBSSL
+         if (status & Fs_Encrypt)
+            s = SSL_get_fd(BlkD(argv[0],File)->fd.ssl);
+         else
+#endif                                  /* HAVE_LIBSSL */
+            s = BlkD(argv[0],File)->fd.fd;
+
+         /*
+          * Pass 1: apply all "name=value" assignments for each socket
+          * together via apply_sock_attrs(), same as open().  Applying
+          * them one sattrib() at a time broke iface+join (a failed
+          * iface=lo0 still let join= succeed with INADDR_ANY) and
+          * lost same-call iface→join ordering.
+          */
+         for (i = 1; i < argc; ) {
+            if (is:null(argv[i]))
+               runerr(109, argv[i]);
+            if (is:file(argv[i])) {
+               if (!(BlkD(argv[i],File)->status & Fs_Socket))
+                  runerr(174, argv[i]);
+               status = BlkD(argv[i],File)->status;
+#if HAVE_LIBSSL
+               if (status & Fs_Encrypt)
+                  s = SSL_get_fd(BlkD(argv[i],File)->fd.ssl);
+               else
+#endif                                  /* HAVE_LIBSSL */
+                  s = BlkD(argv[i],File)->fd.fd;
+               i++;
+               continue;
+               }
+            nset = 0;
+            for (j = i; j < argc && !is:file(argv[j]); j++) {
+               if (is:null(argv[j]))
+                  runerr(109, argv[j]);
+               if (!cnv:tmp_string(argv[j], sbuf))
+                  runerr(109, argv[j]);
+               p = StrLoc(sbuf);
+               end = p + StrLen(sbuf);
+               for (eq = p; eq < end; eq++)
+                  if (*eq == '=') break;
+               if (eq < end) {
+                  if (nset >= 64)
+                     runerr(1310, argv[j]);
+                  setv[nset++] = argv[j];
+                  }
+               }
+            if (nset > 0) {
+               CURTSTATE();
+               k_errornumber = 0;
+               if (!apply_sock_attrs(s, 1, setv, nset, NULL, NULL) ||
+                   !apply_sock_attrs(s, 0, setv, nset, NULL, NULL)) {
+                  if (k_errornumber == 1310)
+                     runerr(1310, setv[0]);
+                  fail;
+                  }
+               }
+            i = j;
+            }
+
+         /* Pass 2: produce values (queries and assigned set values) */
+         for (i = 1; i < argc; i++) {
+            if (is:null(argv[i]))
+               continue;
+            if (is:file(argv[i])) {
+               if (!(BlkD(argv[i],File)->status & Fs_Socket))
+                  runerr(174, argv[i]);
+               status = BlkD(argv[i],File)->status;
+#if HAVE_LIBSSL
+               if (status & Fs_Encrypt)
+                  s = SSL_get_fd(BlkD(argv[i],File)->fd.ssl);
+               else
+#endif                                  /* HAVE_LIBSSL */
+                  s = BlkD(argv[i],File)->fd.fd;
+               continue;
+               }
+            if (!cnv:tmp_string(argv[i], sbuf))
+               runerr(109, argv[i]);
+
+            p = StrLoc(sbuf);
+            end = p + StrLen(sbuf);
+            for (eq = p; eq < end; eq++)
+               if (*eq == '=') break;
+
+            {
+            long nlen = (eq < end) ? (eq - p) : StrLen(sbuf);
+            switch (sattrib(s, p, nlen, &ans, abuf)) {
+            case Failed:
+               /*
+                * join/leave/source are set-only; after a successful
+                * assignment, produce the assigned value.
+                */
+               if (eq < end) {
+                  MakeStr(eq + 1, end - (eq + 1), &ans);
+                  Protect(StrLoc(ans) = alcstr(StrLoc(ans), StrLen(ans)),
+                          runerr(0));
+                  suspend ans;
+                  }
+               continue;
+            case RunError:
+               runerr(1310, argv[i]);
+            }
+            if (is:string(ans)) {
+               Protect(StrLoc(ans) = alcstr(StrLoc(ans), StrLen(ans)),
+                       runerr(0));
+               }
+            suspend ans;
+            }
+            }
+         fail;
+         }
+#endif                                  /* PosixFns */
+
+#ifdef Concurrent
       if (is:coexpr(argv[0])) {
          if (argc == 1) runerr(130, nulldesc);
          ccp = BlkD(argv[0], Coexpr);
@@ -3144,21 +3296,15 @@ function{1} Attrib(argv[argc])
          }
 
       fail;
+#else                                   /* Concurrent */
+      runerr(121, argv[0]);
+#endif                                  /* Concurrent */
       } /* body*/
 end
 
-
-#else                                   /* Concurrent */
-
-MissingFuncV(mutex)
-MissingFuncV(lock)
-MissingFuncV(trylock)
-MissingFuncV(unlock)
-MissingFuncV(condvar)
-MissingFuncV(spawn)
-MissingFuncV(signal)
+#else                                   /* Concurrent || PosixFns */
 MissingFuncV(Attrib)
-#endif                                  /* Concurrent */
+#endif                                  /* Concurrent || PosixFns */
 
 #ifdef HAVE_LIBCL
 

--- a/src/runtime/fmisc.r
+++ b/src/runtime/fmisc.r
@@ -3148,8 +3148,8 @@ function{*} Attrib(argv[argc])
             if (nset > 0) {
                CURTSTATE();
                k_errornumber = 0;
-               if (!apply_sock_attrs(s, 1, setv, nset, NULL, NULL) ||
-                   !apply_sock_attrs(s, 0, setv, nset, NULL, NULL)) {
+               if (!apply_sock_attrs(s, 1, setv, nset, NULL, NULL, 0) ||
+                   !apply_sock_attrs(s, 0, setv, nset, NULL, NULL, 0)) {
                   if (k_errornumber == 1310)
                      runerr(1310, setv[0]);
                   fail;

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -71,6 +71,7 @@ function{0,1} close(f)
            }
 #endif                                  /* LIBSSL */
          BlkLoc(f)->File.status = 0;
+         BlkLoc(f)->File.sock_gen = 0;
          StrLoc(BlkLoc(f)->File.fname) = "closed socket";
          StrLen(BlkLoc(f)->File.fname) = 13;
          /* drop any listener-cache entries pointing at this fd */
@@ -1078,6 +1079,16 @@ Deliberate Syntax Error
             else
 #endif                                  /* HAVE_LIBSSL */
               fl->fd.fd = fd;
+#ifdef PosixFns
+            /*
+             * Remember the listener-cache generation so select()/accept
+             * can refuse a descriptor number reused by a later open.
+             */
+            if (status & Fs_Listen)
+               fl->sock_gen = sock_listener_gen(fd);
+            else
+               fl->sock_gen = 0;
+#endif                                  /* PosixFns */
 
             return file(fl);
             }

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -73,11 +73,10 @@ function{0,1} close(f)
          BlkLoc(f)->File.status = 0;
          StrLoc(BlkLoc(f)->File.fname) = "closed socket";
          StrLen(BlkLoc(f)->File.fname) = 13;
-#if NT
-         return C_integer closesocket((SOCKET)BlkLoc(f)->File.fd.fd);
-#else                                   /* NT */
-         return C_integer close(BlkLoc(f)->File.fd.fd);
-#endif                                  /* NT */
+         /* drop any listener-cache entries pointing at this fd */
+         if (sock_purge(BlkLoc(f)->File.fd.fd))
+            sock_close(BlkLoc(f)->File.fd.fd);
+         return C_integer 0;
          }
 #endif                                  /* PosixFns */
 
@@ -956,7 +955,7 @@ Deliberate Syntax Error
 
                /* "na" => listen for connections */
                DEC_NARTHREADS;
-               fd = sock_listen(fnamestr, is_udp_or_listener, af_fam);
+               fd = sock_listen(fnamestr, is_udp_or_listener, af_fam, attr, n);
                INC_NARTHREADS_CONTROLLED;
 
 #if HAVE_LIBSSL
@@ -965,7 +964,8 @@ Deliberate Syntax Error
                  ssl = SSL_new(ctx);
                   if (ssl == NULL) {
                     set_ssl_context_errortext(0, NULL);
-                    close(fd);
+                    if (sock_purge(fd))      /* fd may be a cached listener */
+                       sock_close(fd);
                     SSL_CTX_free(ctx);
                     fail;
                   }
@@ -977,7 +977,8 @@ Deliberate Syntax Error
                   /*Check for error in accept.*/
                   if (err<1) {
                     set_ssl_connection_errortext(ssl, err);
-                    close(fd);
+                    if (sock_purge(fd))      /* fd may be a cached listener */
+                       sock_close(fd);
                     SSL_free(ssl);
                     SSL_CTX_free(ctx);
                     fail;
@@ -1001,13 +1002,18 @@ Deliberate Syntax Error
 
 #if defined(Graphics) || defined(Messaging) || defined(ISQL)
                if (n > 0 && !is:null(attr[0])) {
+                  /*
+                   * A leading integer is a connection timeout; anything
+                   * else is a socket attribute handled in sock_connect().
+                   */
                   if (!cnv:C_integer(attr[0], timeout))
-                     runerr(101, attr[0]);
+                     timeout = 0;
                }
 #endif                                  /* Graphics || Messaging || ISQL */
                /* connect to a port */
                DEC_NARTHREADS;
-               fd = sock_connect(fnamestr, is_udp_or_listener == 1, timeout, af_fam);
+               fd = sock_connect(fnamestr, is_udp_or_listener == 1, timeout,
+                                 af_fam, attr, n);
                INC_NARTHREADS_CONTROLLED;
 #if HAVE_LIBSSL
                if(fd > 0 && status & Fs_Encrypt){
@@ -1015,7 +1021,7 @@ Deliberate Syntax Error
                   ssl = SSL_new(ctx);
                   if (ssl == NULL) {
                     set_ssl_context_errortext(0, NULL);
-                    close(fd);
+                    sock_close(fd);
                     SSL_CTX_free(ctx);
                     fail;
                   }
@@ -1025,7 +1031,7 @@ Deliberate Syntax Error
                   /*Check for error in connect.*/
                   if (err<1) {
                     set_ssl_connection_errortext(ssl, err);
-                    close(fd);
+                    sock_close(fd);
                     SSL_free(ssl);
                     SSL_CTX_free(ctx);
                     fail;
@@ -1047,7 +1053,13 @@ Deliberate Syntax Error
                status |= Fs_Socket | Fs_Read | Fs_Write;
 
             if (!fd) {
-               set_syserrortext(errno);
+               /*
+                * When errno is 0 a more specific &errortext was already
+                * set (bad socket attribute, getaddrinfo failure); don't
+                * overwrite it with strerror(0).
+                */
+               if (errno != 0)
+                  set_syserrortext(errno);
                fail;
                }
 

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -2348,10 +2348,20 @@ void post_if_ready(dptr ldp, dptr f, fd_set *fdsp)
        * If its a listener socket, convert it to the new connection.
        */
       if (status & Fs_Listen) {
+         int lfd = fd;
+         /*
+          * Pin the listener across accept() so a concurrent close()
+          * cannot sock_purge()+sock_close() the descriptor under us
+          * (same protocol as sock_listen()).  If pin fails, the
+          * listener was already closed between select and here.
+          */
+         if (!sock_pin(lfd))
+            return;
          fromlen = sizeof(from);
          DEC_NARTHREADS;
-         fd = accept(fd, (struct sockaddr *)&from, &fromlen);
+         fd = accept(lfd, (struct sockaddr *)&from, &fromlen);
          INC_NARTHREADS_CONTROLLED;
+         sock_release(lfd);
          if (fd < 0)
            return;
          BlkD(*f,File)->fd.fd = fd;

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -2349,23 +2349,41 @@ void post_if_ready(dptr ldp, dptr f, fd_set *fdsp)
        */
       if (status & Fs_Listen) {
          int lfd = fd;
+         word gen = BlkD(*f, File)->sock_gen;
          /*
           * Pin the listener across accept() so a concurrent close()
-          * cannot sock_purge()+sock_close() the descriptor under us
-          * (same protocol as sock_listen()).  If pin fails, the
-          * listener was already closed between select and here.
+          * cannot sock_purge()+sock_close() the descriptor under us.
+          * gen ties the pin to this File's cache entry so a reused fd
+          * number for a different listener is rejected.  gen==0 means
+          * the listener was not tracked (map full) — accept without pin.
           */
-         if (!sock_pin(lfd))
+         if (gen != 0 && !sock_pin(lfd, gen))
             return;
          fromlen = sizeof(from);
          DEC_NARTHREADS;
          fd = accept(lfd, (struct sockaddr *)&from, &fromlen);
          INC_NARTHREADS_CONTROLLED;
-         sock_release(lfd);
+         if (gen != 0)
+            sock_release(lfd);
          if (fd < 0)
            return;
+         /*
+          * Concurrent close() may have cleared this File while we were
+          * in accept(); do not resurrect it.  Drop listener ownership
+          * so the cache entry can be reused (genserve) or the nameless
+          * track entry can close.
+          */
+         if (!(BlkD(*f, File)->status & Fs_Listen)) {
+            sock_close(fd);
+            if (gen != 0)
+               sock_unclaim(lfd, gen);
+            return;
+            }
+         if (gen != 0)
+            sock_unclaim(lfd, gen);
          BlkD(*f,File)->fd.fd = fd;
          BlkLoc(*f)->File.status = Fs_Socket | Fs_Read | Fs_Write;
+         BlkLoc(*f)->File.sock_gen = 0;
          }
       c_put(ldp, f);
       }

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1000,7 +1000,7 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family){
  * set between socket() and bind(); those are applied in a "prebind"
  * pass and everything else after the socket is bound/created.
  * Attributes are applied in the order given, which matters for
- * multicast: a "iface" attribute selects the interface used by any
+ * multicast: an "iface" attribute selects the interface used by any
  * "join" attributes that follow it.
  *
  * DWIM defaults (overridable with an explicit attribute):
@@ -1097,11 +1097,11 @@ static int sock_split_group_source(char *host, char *srcbuf, size_t srcbuf_sz,
    *srcp = NULL;
    if ((at = strchr(host, '@')) == NULL)
       return 1;
-   if (at == host || at[1] == '') {
+   if (at == host || at[1] == '\0') {
       errno = EINVAL;
       return 0;
       }
-   *at = '';
+   *at = '\0';
    slen = strlen(host);
    if (slen + 1 > srcbuf_sz) {
       errno = EINVAL;
@@ -1804,6 +1804,7 @@ int sattrib(int s, char *str, long len, dptr answer, char *abuf)
       return Succeeded;
       }
    if (strcmp(name, "ttl") == 0) {
+      /* report the multicast hop limit; set writes both uni and mcast */
       if (af == AF_INET6) {
          olen = sizeof(v);
          if (getsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1008,12 +1008,15 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family){
  *     reuseport=yes where available, and reuseaddr=yes on Windows
  *   - binding a UDP socket to a multicast group address joins it (ASM);
  *     source@group:port or source= joins that group as SSM instead
+ *   - no iface=: join on all IPv4 interfaces; multicast send uses the
+ *     first non-loopback IPv4 address (else loopback).  mcastloop (on
+ *     by default) still delivers a local copy on that interface.
  *   - connecting/sending to 255.255.255.255 enables SO_BROADCAST
  */
 
 static char *sock_attr_names[] = {
    "reuseaddr", "reuseport", "broadcast", "rcvbuf", "sndbuf",
-   "join", "source", "ttl", "mcastloop", "iface", NULL
+   "join", "leave", "source", "ttl", "mcastloop", "iface", NULL
    };
 
 static char *ssl_attr_names[] = {
@@ -1094,11 +1097,11 @@ static int sock_split_group_source(char *host, char *srcbuf, size_t srcbuf_sz,
    *srcp = NULL;
    if ((at = strchr(host, '@')) == NULL)
       return 1;
-   if (at == host || at[1] == ' ') {
+   if (at == host || at[1] == '') {
       errno = EINVAL;
       return 0;
       }
-   *at = ' ';
+   *at = '';
    slen = strlen(host);
    if (slen + 1 > srcbuf_sz) {
       errno = EINVAL;
@@ -1130,11 +1133,54 @@ static int sock_split_group_source(char *host, char *srcbuf, size_t srcbuf_sz,
 #passthru #ifdef UNICON_NO_IP_MREQ_SOURCE
 #passthru struct ip_mreq_source { struct in_addr imr_multiaddr, imr_interface, imr_sourceaddr; };
 #passthru #endif
+#passthru #if !defined(IPV6_LEAVE_GROUP) && defined(IPV6_DROP_MEMBERSHIP)
+#passthru #define IPV6_LEAVE_GROUP IPV6_DROP_MEMBERSHIP
+#passthru #endif
+#passthru #ifndef IP_DROP_SOURCE_MEMBERSHIP
+#passthru #define IP_DROP_SOURCE_MEMBERSHIP -1
+#passthru #endif
+
+/*
+ * One ASM/SSM join attempt.  Already-member is success.
+ */
+static int sock_join_on_if(int s, struct in_addr g4, char *src,
+                           struct in_addr if4)
+{
+   int rc;
+
+   if (src == NULL) {
+      struct ip_mreq mreq;
+      memset(&mreq, 0, sizeof(mreq));
+      mreq.imr_multiaddr = g4;
+      mreq.imr_interface = if4;
+      rc = setsockopt(s, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                      (char *)&mreq, sizeof(mreq));
+      }
+   else {
+      struct ip_mreq_source mreqs;
+      struct in_addr s4;
+      if (inet_pton(AF_INET, src, &s4) != 1) {
+         errno = EINVAL;
+         return -1;
+         }
+      memset(&mreqs, 0, sizeof(mreqs));
+      mreqs.imr_multiaddr = g4;
+      mreqs.imr_sourceaddr = s4;
+      mreqs.imr_interface = if4;
+      rc = setsockopt(s, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
+                      (char *)&mreqs, sizeof(mreqs));
+      }
+   if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
+      return 0;
+   return rc;
+}
 
 /*
  * Join a multicast group.  grp is the group address; src, when not
  * NULL, is a source address for a source-specific (SSM) join.  if4/if6
- * select the interface to join on (INADDR_ANY/0 let the kernel choose).
+ * select the interface.  When if4 is INADDR_ANY (no iface= attribute),
+ * join on every IPv4 interface so same-host and multi-homed receives
+ * work without naming a NIC; an explicit iface= still joins only that one.
  */
 static int sock_join_group(int s, char *grp, char *src,
                            struct in_addr if4, unsigned int if6)
@@ -1144,28 +1190,37 @@ static int sock_join_group(int s, char *grp, char *src,
    int rc = -1;
 
    if (inet_pton(AF_INET, grp, &g4) == 1) {
-      if (src == NULL) {
-         struct ip_mreq mreq;
-         memset(&mreq, 0, sizeof(mreq));
-         mreq.imr_multiaddr = g4;
-         mreq.imr_interface = if4;
-         rc = setsockopt(s, IPPROTO_IP, IP_ADD_MEMBERSHIP,
-                         (char *)&mreq, sizeof(mreq));
-         }
-      else {
-         struct ip_mreq_source mreqs;
-         struct in_addr s4;
-         if (inet_pton(AF_INET, src, &s4) != 1) {
-            errno = EINVAL;
-            return -1;
+      if (if4.s_addr != htonl(INADDR_ANY))
+         return sock_join_on_if(s, g4, src, if4);
+#if UNIX
+      {
+         struct ifaddrs *ifa0 = NULL, *ifa;
+         int ok = 0, saw = 0;
+
+         if (getifaddrs(&ifa0) == 0) {
+            for (ifa = ifa0; ifa != NULL; ifa = ifa->ifa_next) {
+               struct in_addr ifa4;
+               if (ifa->ifa_addr == NULL ||
+                   ifa->ifa_addr->sa_family != AF_INET)
+                  continue;
+               if (!(ifa->ifa_flags & IFF_UP))
+                  continue;
+               ifa4 = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+               saw = 1;
+               if (sock_join_on_if(s, g4, src, ifa4) == 0)
+                  ok = 1;
+               }
+            freeifaddrs(ifa0);
             }
-         memset(&mreqs, 0, sizeof(mreqs));
-         mreqs.imr_multiaddr = g4;
-         mreqs.imr_sourceaddr = s4;
-         mreqs.imr_interface = if4;
-         rc = setsockopt(s, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
-                         (char *)&mreqs, sizeof(mreqs));
+         if (ok)
+            return 0;
+         if (saw) {
+            /* every per-iface join failed; fall through to INADDR_ANY */
+            ;
+            }
          }
+#endif                                  /* UNIX */
+      return sock_join_on_if(s, g4, src, if4);
       }
    else if (inet_pton(AF_INET6, grp, &g6) == 1 && src == NULL) {
       /* IPv6 source-specific joins (MCAST_JOIN_SOURCE_GROUP) not yet supported */
@@ -1175,19 +1230,12 @@ static int sock_join_group(int s, char *grp, char *src,
       mreq6.ipv6mr_interface = if6;
       rc = setsockopt(s, IPPROTO_IPV6, IPV6_JOIN_GROUP,
                       (char *)&mreq6, sizeof(mreq6));
+      if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
+         return 0;
+      return rc;
       }
-   else {
-      errno = EINVAL;
-      return -1;
-      }
-   /*
-    * Re-joining a group the socket already belongs to (cached listener
-    * reopen with the same join=/source@group) is success, not an error.
-    * ASM typically returns EADDRINUSE; macOS SSM returns EADDRNOTAVAIL.
-    */
-   if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
-      return 0;
-   return rc;
+   errno = EINVAL;
+   return -1;
 }
 
 /* True if host is a dotted/numeric multicast address (not a name). */
@@ -1201,6 +1249,204 @@ static int host_is_multicast(char *host)
    if (inet_pton(AF_INET6, host, &a6) == 1)
       return IN6_IS_ADDR_MULTICAST(&a6);
    return 0;
+}
+
+/*
+ * If the caller did not set iface=, pick an outbound multicast interface.
+ * Prefer a non-loopback IPv4 address so packets can leave the host;
+ * IP_MULTICAST_LOOP (kernel default on) still delivers a local copy to
+ * receivers that joined on that interface.  Fall back to 127.0.0.1 when
+ * the host has no other UP address.
+ */
+static void sock_ensure_mcast_if(int s)
+{
+   struct in_addr cur, pick;
+   unsigned int olen;
+
+   if (sock_family(s) != AF_INET)
+      return;
+   olen = sizeof(cur);
+   if (getsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
+                  (char *)&cur, &olen) == 0 &&
+       cur.s_addr != htonl(INADDR_ANY) && cur.s_addr != 0)
+      return;                           /* explicit iface= already applied */
+
+   pick.s_addr = htonl(INADDR_LOOPBACK);
+#if UNIX
+   {
+      struct ifaddrs *ifa0 = NULL, *ifa;
+      if (getifaddrs(&ifa0) == 0) {
+         for (ifa = ifa0; ifa != NULL; ifa = ifa->ifa_next) {
+            struct in_addr a;
+            if (ifa->ifa_addr == NULL ||
+                ifa->ifa_addr->sa_family != AF_INET)
+               continue;
+            if (!(ifa->ifa_flags & IFF_UP) ||
+                (ifa->ifa_flags & IFF_LOOPBACK))
+               continue;
+            a = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            if (a.s_addr == htonl(INADDR_ANY))
+               continue;
+            pick = a;
+            break;
+            }
+         freeifaddrs(ifa0);
+         }
+      }
+#endif                                  /* UNIX */
+   setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
+              (char *)&pick, sizeof(pick));
+}
+
+/*
+ * Parse an iface value: IPv4 dotted address, numeric interface index,
+ * or (on UNIX) an interface name such as "en0" / "eth0" / "lo0".
+ * On success sets *have4/*have6 and the corresponding if4/if6 values.
+ */
+static int sock_parse_iface(char *val, long ival,
+                              struct in_addr *if4, unsigned int *if6,
+                              int *have4, int *have6)
+{
+   struct in_addr a;
+
+   *have4 = *have6 = 0;
+   if (inet_pton(AF_INET, val, &a) == 1) {
+      *if4 = a;
+      *have4 = 1;
+      return 1;
+      }
+   if (val[0] != '\0' && strspn(val, "0123456789") == strlen(val)) {
+      *if6 = (unsigned int)ival;
+      *have6 = 1;
+      return 1;
+      }
+#if UNIX
+   {
+      unsigned int idx;
+      struct ifaddrs *ifa0, *ifa;
+
+      if ((idx = if_nametoindex(val)) == 0) {
+         errno = EINVAL;
+         return 0;
+         }
+      *if6 = idx;
+      *have6 = 1;
+      if (getifaddrs(&ifa0) == 0) {
+         for (ifa = ifa0; ifa != NULL; ifa = ifa->ifa_next) {
+            if (ifa->ifa_addr == NULL || ifa->ifa_name == NULL)
+               continue;
+            if (ifa->ifa_addr->sa_family != AF_INET)
+               continue;
+            if (strcmp(ifa->ifa_name, val) != 0)
+               continue;
+            *if4 = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+            *have4 = 1;
+            break;
+            }
+         freeifaddrs(ifa0);
+         }
+      return 1;
+      }
+#else                                   /* UNIX */
+   errno = EINVAL;
+   return 0;
+#endif                                  /* UNIX */
+}
+
+/*
+ * Leave a multicast group previously joined with sock_join_group().
+ * DROP must use the same interface as the matching join; when the
+ * caller omits iface= and getsockopt(IP_MULTICAST_IF) did not recover
+ * it (seen on some Linux/musl builds), retry INADDR_ANY and each local
+ * IPv4 address.  Already-not-a-member is success.
+ */
+static int sock_leave_group(int s, char *grp, char *src,
+                            struct in_addr if4, unsigned int if6)
+{
+   struct in_addr g4;
+   struct in6_addr g6;
+   int rc = -1;
+
+   if (inet_pton(AF_INET, grp, &g4) == 1) {
+      if (src == NULL) {
+         struct ip_mreq mreq;
+         memset(&mreq, 0, sizeof(mreq));
+         mreq.imr_multiaddr = g4;
+         mreq.imr_interface = if4;
+         rc = setsockopt(s, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+                         (char *)&mreq, sizeof(mreq));
+         if (rc < 0 && if4.s_addr != htonl(INADDR_ANY)) {
+            mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+            rc = setsockopt(s, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+                            (char *)&mreq, sizeof(mreq));
+            }
+#if UNIX
+         /*
+          * Drop on every iface: a no-iface join membership may exist on
+          * several NICs, and a mismatched single DROP looks like failure.
+          */
+         {
+            struct ifaddrs *ifa0 = NULL, *ifa;
+            int ok = (rc == 0);
+            if (getifaddrs(&ifa0) == 0) {
+               for (ifa = ifa0; ifa != NULL; ifa = ifa->ifa_next) {
+                  if (ifa->ifa_addr == NULL ||
+                      ifa->ifa_addr->sa_family != AF_INET)
+                     continue;
+                  mreq.imr_interface =
+                     ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+                  if (setsockopt(s, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+                                 (char *)&mreq, sizeof(mreq)) == 0)
+                     ok = 1;
+                  }
+               freeifaddrs(ifa0);
+               }
+            if (ok)
+               rc = 0;
+            }
+#endif                                  /* UNIX */
+         }
+      else {
+         struct ip_mreq_source mreqs;
+         struct in_addr s4;
+         if (inet_pton(AF_INET, src, &s4) != 1) {
+            errno = EINVAL;
+            return -1;
+            }
+         memset(&mreqs, 0, sizeof(mreqs));
+         mreqs.imr_multiaddr = g4;
+         mreqs.imr_sourceaddr = s4;
+         mreqs.imr_interface = if4;
+         rc = setsockopt(s, IPPROTO_IP, IP_DROP_SOURCE_MEMBERSHIP,
+                         (char *)&mreqs, sizeof(mreqs));
+         if (rc < 0 && if4.s_addr != htonl(INADDR_ANY)) {
+            mreqs.imr_interface.s_addr = htonl(INADDR_ANY);
+            rc = setsockopt(s, IPPROTO_IP, IP_DROP_SOURCE_MEMBERSHIP,
+                            (char *)&mreqs, sizeof(mreqs));
+            }
+         }
+      }
+   else if (inet_pton(AF_INET6, grp, &g6) == 1 && src == NULL) {
+      struct ipv6_mreq mreq6;
+      memset(&mreq6, 0, sizeof(mreq6));
+      mreq6.ipv6mr_multiaddr = g6;
+      mreq6.ipv6mr_interface = if6;
+      rc = setsockopt(s, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
+                      (char *)&mreq6, sizeof(mreq6));
+      if (rc < 0 && if6 != 0) {
+         mreq6.ipv6mr_interface = 0;
+         rc = setsockopt(s, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
+                         (char *)&mreq6, sizeof(mreq6));
+         }
+      }
+   else {
+      errno = EINVAL;
+      return -1;
+      }
+
+   if (rc < 0 && (errno == EADDRNOTAVAIL || errno == EADDRINUSE))
+      return 0;
+   return rc;
 }
 
 /*
@@ -1256,9 +1502,20 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
    int a, rc, on, is_pre, saw_join = 0, saw_source = 0;
    C_integer tmpint;
    struct in_addr mcif4;
-   unsigned int mcif6 = 0;
+   unsigned int mcif6 = 0, olen;
 
+   /*
+    * Seed the join interface from the socket's current iface, so a
+    * prior Attrib(f, "iface=...") (or setsockopt) is honored by a
+    * later join= in a separate apply_sock_attrs() call.
+    */
    mcif4.s_addr = htonl(INADDR_ANY);
+   olen = sizeof(mcif4);
+   if (getsockopt(s, IPPROTO_IP, IP_MULTICAST_IF, (char *)&mcif4, &olen) < 0)
+      mcif4.s_addr = htonl(INADDR_ANY);
+   olen = sizeof(mcif6);
+   if (getsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF, (char *)&mcif6, &olen) < 0)
+      mcif6 = 0;
 
    for (a = 0; a < nattr; a++) {
       if (is:null(attr[a]))
@@ -1367,19 +1624,38 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
          }
       else if (strcmp(abuf, "iface") == 0) {
          struct in_addr ifa;
-         if (inet_pton(AF_INET, val, &ifa) == 1) {
-            mcif4 = ifa;                /* also used by subsequent joins */
-            rc = setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
-                            (char *)&ifa, sizeof(ifa));
-            }
-         else if (strspn(val, "0123456789") == strlen(val)) {
-            mcif6 = ival;               /* IPv6 interface index */
-            rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF,
-                            (char *)&mcif6, sizeof(mcif6));
-            }
-         else {
+         unsigned int ifx = 0;
+         int have4 = 0, have6 = 0;
+
+         if (!sock_parse_iface(val, ival, &ifa, &ifx, &have4, &have6)) {
             errno = EINVAL;
             rc = -1;
+            }
+         else {
+            if (have4)
+               mcif4 = ifa;             /* also used by subsequent joins */
+            if (have6)
+               mcif6 = ifx;
+            if (sock_family(s) == AF_INET6) {
+               if (!have6) {
+                  errno = EINVAL;
+                  rc = -1;
+                  }
+               else
+                  rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                                  (char *)&mcif6, sizeof(mcif6));
+               }
+            else if (have4)
+               rc = setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
+                               (char *)&ifa, sizeof(ifa));
+            else if (have6)
+               /* bare numeric index on an IPv4 socket */
+               rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                               (char *)&mcif6, sizeof(mcif6));
+            else {
+               errno = EINVAL;
+               rc = -1;
+               }
             }
          }
       else if (strcmp(abuf, "join") == 0) {
@@ -1387,6 +1663,11 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
          if ((src = strchr(val, ',')) != NULL)
             *src++ = '\0';
          rc = sock_join_group(s, val, src, mcif4, mcif6);
+         }
+      else if (strcmp(abuf, "leave") == 0) {
+         if ((src = strchr(val, ',')) != NULL)
+            *src++ = '\0';
+         rc = sock_leave_group(s, val, src, mcif4, mcif6);
          }
       else if (strcmp(abuf, "source") == 0) {
          /*
@@ -1431,6 +1712,153 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
          }
       }
    return 1;
+}
+
+/*
+ * sattrib - get or set a socket attribute, WAttrib-style.
+ *   str with '=' sets; without '=' queries.
+ * Writes the result into *answer (string or integer) using abuf for
+ * string results.  Returns Succeeded, Failed, or RunError.
+ * Membership attributes (join/leave/source) are set-only.
+ */
+int sattrib(int s, char *str, long len, dptr answer, char *abuf)
+{
+   tended struct descrip attrd;
+   char name[256], *eq;
+   int on, v, af;
+   unsigned int u, olen;
+   unsigned char uc;
+   struct in_addr ifa;
+
+   if (len < 1 || len >= (long)sizeof(name))
+      return RunError;
+   memcpy(name, str, (size_t)len);
+   name[len] = '\0';
+
+   if ((eq = strchr(name, '=')) != NULL) {
+      /*
+       * Set: reuse apply_sock_attrs() so open() and Attrib() share one
+       * implementation.  Both passes run so reuse* (pre-bind) and the
+       * post-bind options are all reachable.  Bad names/values are
+       * RunError (error 1310); setsockopt failures are Failed.
+       */
+      MakeStr(str, len, &attrd);
+      {
+      CURTSTATE();
+      k_errornumber = 0;
+      if (!apply_sock_attrs(s, 1, &attrd, 1, NULL, NULL) ||
+          !apply_sock_attrs(s, 0, &attrd, 1, NULL, NULL)) {
+         if (k_errornumber == 1310)
+            return RunError;
+         return Failed;
+         }
+      }
+      return Succeeded;
+      }
+
+   /* query */
+   if (!is_sock_attr(name))
+      return RunError;
+   if (strcmp(name, "join") == 0 || strcmp(name, "leave") == 0 ||
+       strcmp(name, "source") == 0)
+      return Failed;                    /* memberships are not readable */
+
+   af = sock_family(s);
+
+   if (strcmp(name, "reuseaddr") == 0) {
+      olen = sizeof(on);
+      if (getsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, &olen) < 0)
+         return Failed;
+      strcpy(abuf, on ? "yes" : "no");
+      MakeStr(abuf, strlen(abuf), answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "reuseport") == 0) {
+      olen = sizeof(on);
+      if (getsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&on, &olen) < 0)
+         return Failed;
+      strcpy(abuf, on ? "yes" : "no");
+      MakeStr(abuf, strlen(abuf), answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "broadcast") == 0) {
+      olen = sizeof(on);
+      if (getsockopt(s, SOL_SOCKET, SO_BROADCAST, (char *)&on, &olen) < 0)
+         return Failed;
+      strcpy(abuf, on ? "yes" : "no");
+      MakeStr(abuf, strlen(abuf), answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "rcvbuf") == 0) {
+      olen = sizeof(v);
+      if (getsockopt(s, SOL_SOCKET, SO_RCVBUF, (char *)&v, &olen) < 0)
+         return Failed;
+      MakeInt(v, answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "sndbuf") == 0) {
+      olen = sizeof(v);
+      if (getsockopt(s, SOL_SOCKET, SO_SNDBUF, (char *)&v, &olen) < 0)
+         return Failed;
+      MakeInt(v, answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "ttl") == 0) {
+      if (af == AF_INET6) {
+         olen = sizeof(v);
+         if (getsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
+                        (char *)&v, &olen) < 0)
+            return Failed;
+         MakeInt(v, answer);
+         }
+      else {
+         olen = sizeof(uc);
+         if (getsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL,
+                        (char *)&uc, &olen) < 0)
+            return Failed;
+         MakeInt((word)uc, answer);
+         }
+      return Succeeded;
+      }
+   if (strcmp(name, "mcastloop") == 0) {
+      if (af == AF_INET6) {
+         olen = sizeof(u);
+         if (getsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
+                        (char *)&u, &olen) < 0)
+            return Failed;
+         on = u;
+         }
+      else {
+         olen = sizeof(uc);
+         if (getsockopt(s, IPPROTO_IP, IP_MULTICAST_LOOP,
+                        (char *)&uc, &olen) < 0)
+            return Failed;
+         on = uc;
+         }
+      strcpy(abuf, on ? "yes" : "no");
+      MakeStr(abuf, strlen(abuf), answer);
+      return Succeeded;
+      }
+   if (strcmp(name, "iface") == 0) {
+      if (af == AF_INET6) {
+         olen = sizeof(u);
+         if (getsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                        (char *)&u, &olen) < 0)
+            return Failed;
+         MakeInt((word)u, answer);
+         }
+      else {
+         olen = sizeof(ifa);
+         if (getsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
+                        (char *)&ifa, &olen) < 0)
+            return Failed;
+         if (inet_ntop(AF_INET, &ifa, abuf, 64) == NULL)
+            return Failed;
+         MakeStr(abuf, strlen(abuf), answer);
+         }
+      return Succeeded;
+      }
+   return RunError;
 }
 
 /*
@@ -1547,6 +1975,13 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam,
          freeaddrinfo(saddrinfo);
          return 0;
       }
+
+      /*
+       * Multicast UDP send without iface=: choose a local interface so
+       * the first writes() is not ENETUNREACH (no multicast route).
+       */
+      if (is_udp && sockaddr_is_multicast(sa))
+         sock_ensure_mcast_if(s);
    }
    else {
       /* UNIX domain socket */

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -19,6 +19,22 @@
       StrLen(d) = len;              \
 } while (0)
 
+/*
+ * Close a socket without clobbering errno.  On Windows, SOCKET handles
+ * must be released with closesocket(); plain close() fails with EBADF
+ * and would overwrite a more specific error (e.g. bad socket attribute).
+ */
+void sock_close(int fd)
+{
+   int hold = errno;
+#if NT
+   closesocket(fd);
+#else                                   /* NT */
+   close(fd);
+#endif                                  /* NT */
+   errno = hold;
+}
+
 /* Padding for machines that have opcodes smaller than words */
 #if IntBits != WordBits
 #define ipad(wp)  do *(wp).op++ = Op_Noop; while (0)
@@ -861,7 +877,7 @@ dptr rec_structor(char *name)
  */
 
 static int sock_get (char *);
-static void sock_put (char *, int);
+static int sock_put (char *, int);
 
 /*
  * We also stash the sockaddr structs we created with host and port info for
@@ -977,6 +993,386 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family){
  }
 
 /*
+ * Socket attribute support.  Trailing arguments to open() on network
+ * modes may be "name=value" strings which are applied to the socket
+ * with setsockopt().  Two passes are made over the attribute list,
+ * because some options (the reuse flags) only have effect if they are
+ * set between socket() and bind(); those are applied in a "prebind"
+ * pass and everything else after the socket is bound/created.
+ * Attributes are applied in the order given, which matters for
+ * multicast: a "iface" attribute selects the interface used by any
+ * "join" attributes that follow it.
+ *
+ * DWIM defaults (overridable with an explicit attribute):
+ *   - listeners get reuseaddr=yes (UNIX); multicast binds also get
+ *     reuseport=yes where available, and reuseaddr=yes on Windows
+ *   - binding a UDP socket to a multicast group address joins it
+ *   - connecting/sending to 255.255.255.255 enables SO_BROADCAST
+ */
+
+static char *sock_attr_names[] = {
+   "reuseaddr", "reuseport", "broadcast", "rcvbuf", "sndbuf",
+   "join", "ttl", "mcastloop", "iface", NULL
+   };
+
+static char *ssl_attr_names[] = {
+   "cert", "key", "password", "ca", "caDir", "caStore", "ciphers",
+   "ciphers1.3", "minProto", "maxProto", "verifyPeer", NULL
+   };
+
+int is_sock_attr(char *name)
+{
+   int i;
+   for (i = 0; sock_attr_names[i]; i++)
+      if (strcmp(name, sock_attr_names[i]) == 0)
+         return 1;
+   return 0;
+}
+
+static int is_ssl_attr(char *name)
+{
+   int i;
+   for (i = 0; ssl_attr_names[i]; i++)
+      if (strcmp(name, ssl_attr_names[i]) == 0)
+         return 1;
+   return 0;
+}
+
+/*
+ * Boolean attribute values follow the verifyPeer convention: exactly
+ * "yes" or "no".  Returns 1/0, or -1 for anything else.
+ */
+static int sock_attr_bool(char *val)
+{
+   if (strcmp(val, "yes") == 0)
+      return 1;
+   if (strcmp(val, "no") == 0)
+      return 0;
+   return -1;
+}
+
+/*
+ * Address family of a socket.  Works on unbound sockets too, since the
+ * family is fixed at socket creation.
+ */
+static int sock_family(int s)
+{
+   struct sockaddr_storage ss;
+   unsigned int sslen = sizeof(ss);
+   memset(&ss, 0, sizeof(ss));
+   if (getsockname(s, (struct sockaddr *)&ss, &sslen) < 0)
+      return AF_INET;
+   return ss.ss_family;
+}
+
+/*
+ * Is this a multicast group address?
+ */
+static int sockaddr_is_multicast(struct sockaddr *sa)
+{
+   if (sa->sa_family == AF_INET)
+      return IN_MULTICAST(ntohl(((struct sockaddr_in *)sa)->sin_addr.s_addr));
+   if (sa->sa_family == AF_INET6)
+      return IN6_IS_ADDR_MULTICAST(&((struct sockaddr_in6 *)sa)->sin6_addr);
+   return 0;
+}
+
+/*
+ * These conditionals test macros from system headers, which rtt's
+ * preprocessor cannot see; pass them through to the C compiler.
+ * (#passthru only keeps its position at file scope, so options that
+ * may be missing are defined to -1 here rather than #ifdef'ed in the
+ * function bodies; setsockopt(-1) fails cleanly at run time.)
+ */
+#passthru #if !defined(IPV6_JOIN_GROUP) && defined(IPV6_ADD_MEMBERSHIP)
+#passthru #define IPV6_JOIN_GROUP IPV6_ADD_MEMBERSHIP
+#passthru #endif
+#passthru #ifndef SO_REUSEPORT
+#passthru #define SO_REUSEPORT -1
+#passthru #endif
+#passthru #ifndef IP_ADD_SOURCE_MEMBERSHIP
+#passthru #define IP_ADD_SOURCE_MEMBERSHIP -1
+#passthru #define UNICON_NO_IP_MREQ_SOURCE 1
+#passthru #endif
+#passthru #ifdef UNICON_NO_IP_MREQ_SOURCE
+#passthru struct ip_mreq_source { struct in_addr imr_multiaddr, imr_interface, imr_sourceaddr; };
+#passthru #endif
+
+/*
+ * Join a multicast group.  grp is the group address; src, when not
+ * NULL, is a source address for a source-specific (SSM) join.  if4/if6
+ * select the interface to join on (INADDR_ANY/0 let the kernel choose).
+ */
+static int sock_join_group(int s, char *grp, char *src,
+                           struct in_addr if4, unsigned int if6)
+{
+   struct in_addr g4;
+   struct in6_addr g6;
+   int rc = -1;
+
+   if (inet_pton(AF_INET, grp, &g4) == 1) {
+      if (src == NULL) {
+         struct ip_mreq mreq;
+         memset(&mreq, 0, sizeof(mreq));
+         mreq.imr_multiaddr = g4;
+         mreq.imr_interface = if4;
+         rc = setsockopt(s, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                         (char *)&mreq, sizeof(mreq));
+         }
+      else {
+         struct ip_mreq_source mreqs;
+         struct in_addr s4;
+         if (inet_pton(AF_INET, src, &s4) != 1) {
+            errno = EINVAL;
+            return -1;
+            }
+         memset(&mreqs, 0, sizeof(mreqs));
+         mreqs.imr_multiaddr = g4;
+         mreqs.imr_sourceaddr = s4;
+         mreqs.imr_interface = if4;
+         rc = setsockopt(s, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
+                         (char *)&mreqs, sizeof(mreqs));
+         }
+      }
+   else if (inet_pton(AF_INET6, grp, &g6) == 1 && src == NULL) {
+      /* IPv6 source-specific joins (MCAST_JOIN_SOURCE_GROUP) not yet supported */
+      struct ipv6_mreq mreq6;
+      memset(&mreq6, 0, sizeof(mreq6));
+      mreq6.ipv6mr_multiaddr = g6;
+      mreq6.ipv6mr_interface = if6;
+      rc = setsockopt(s, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+                      (char *)&mreq6, sizeof(mreq6));
+      }
+   else {
+      errno = EINVAL;
+      return -1;
+      }
+   /*
+    * Re-joining a group the socket already belongs to (cached listener
+    * reopen with the same join=/source@group) is success, not an error.
+    * ASM typically returns EADDRINUSE; macOS SSM returns EADDRNOTAVAIL.
+    */
+   if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
+      return 0;
+   return rc;
+}
+
+/* True if host is a dotted/numeric multicast address (not a name). */
+static int host_is_multicast(char *host)
+{
+   struct in_addr a4;
+   struct in6_addr a6;
+
+   if (inet_pton(AF_INET, host, &a4) == 1)
+      return IN_MULTICAST(ntohl(a4.s_addr));
+   if (inet_pton(AF_INET6, host, &a6) == 1)
+      return IN6_IS_ADDR_MULTICAST(&a6);
+   return 0;
+}
+
+/*
+ * When open() is not given an explicit "4" or "6" flag but a join
+ * attribute is present, the group address determines what kind of
+ * socket must be created (an IPv4 join on an IPv6 wildcard socket
+ * fails with EINVAL).  Returns AF_INET/AF_INET6/AF_UNSPEC.
+ */
+int sock_attrs_af(dptr attr, int nattr)
+{
+   tended char *tmps;
+   char grp[64], *e;
+   struct in_addr g4;
+   struct in6_addr g6;
+   int a;
+
+   for (a = 0; a < nattr; a++) {
+      if (is:null(attr[a]))
+         continue;
+      if (!cnv:C_string(attr[a], tmps))
+         continue;
+      if (strncmp(tmps, "join=", 5) != 0)
+         continue;
+      SAFE_strncpy(grp, tmps+5, sizeof(grp));
+      if ((e = strchr(grp, ',')) != NULL)
+         *e = '\0';
+      if (inet_pton(AF_INET, grp, &g4) == 1)
+         return AF_INET;
+      if (inet_pton(AF_INET6, grp, &g6) == 1)
+         return AF_INET6;
+      }
+   return AF_UNSPEC;
+}
+
+/*
+ * Parse and apply "name=value" socket attributes from open()'s trailing
+ * arguments to socket s.  Attributes belonging to the other pass, SSL
+ * attributes, and a leading integer timeout argument are skipped.
+ * autojoin, when not NULL, is a multicast group the socket was bound to:
+ * it is joined after the post-bind attributes, honoring any iface
+ * among them, unless an explicit join attribute takes over memberships.
+ * Returns 1 on success; returns 0 with &errortext/errno set on failure.
+ */
+int apply_sock_attrs(int s, int prebind, dptr attr, int nattr, char *autojoin)
+{
+   tended char *tmps;
+   char abuf[256], *val, *src;
+   long ival;
+   int a, rc, on, is_pre, saw_join = 0;
+   C_integer tmpint;
+   struct in_addr mcif4;
+   unsigned int mcif6 = 0;
+
+   mcif4.s_addr = htonl(INADDR_ANY);
+
+   for (a = 0; a < nattr; a++) {
+      if (is:null(attr[a]))
+         continue;
+      /* the first extra argument may be an integer connection timeout */
+      if (a == 0 && cnv:C_integer(attr[a], tmpint))
+         continue;
+      if (!cnv:C_string(attr[a], tmps)) {
+         errno = 0;                     /* &errortext carries the error */
+         set_errortext(1310);
+         return 0;
+         }
+
+      /*
+       * Attributes have the form name=value; same sanity checks as the
+       * SSL attribute parser.  Split a private copy: cnv:C_string can
+       * return the caller's own string storage (see cnv_c_str), which
+       * must not be mutated because later passes parse it again.
+       */
+      if (strlen(tmps) < 3 || strlen(tmps) >= sizeof(abuf) ||
+          tmps[0] == '=' || tmps[strlen(tmps)-1] == '=' ||
+          strchr(tmps, '=') == NULL) {
+         errno = 0;                     /* &errortext carries the error */
+         set_errortext_with_val(1310, tmps);
+         return 0;
+         }
+      strcpy(abuf, tmps);
+      val = strchr(abuf, '=');
+      *val++ = '\0';
+
+      if (!is_sock_attr(abuf)) {
+         if (is_ssl_attr(abuf))
+            continue;                   /* handled by create_ssl_context() */
+         errno = 0;                     /* &errortext carries the error */
+         set_errortext_with_val(1310, tmps);
+         return 0;
+         }
+
+      /* skip attributes that belong to the other pass */
+      is_pre = (strcmp(abuf, "reuseaddr") == 0 ||
+                strcmp(abuf, "reuseport") == 0);
+      if (is_pre != (prebind != 0))
+         continue;
+
+      /* boolean attributes take yes/no, like verifyPeer */
+      if (strcmp(abuf, "reuseaddr") == 0 || strcmp(abuf, "reuseport") == 0 ||
+          strcmp(abuf, "broadcast") == 0 || strcmp(abuf, "mcastloop") == 0) {
+         if ((on = sock_attr_bool(val)) < 0) {
+            errno = 0;
+            set_errortext_with_val(1310, tmps);
+            return 0;
+            }
+         }
+
+      ival = atol(val);
+      rc = 0;
+
+      if (strcmp(abuf, "reuseaddr") == 0)
+         rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));
+      else if (strcmp(abuf, "reuseport") == 0)
+         rc = setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&on, sizeof(on));
+      else if (strcmp(abuf, "broadcast") == 0)
+         rc = setsockopt(s, SOL_SOCKET, SO_BROADCAST, (char *)&on, sizeof(on));
+      else if (strcmp(abuf, "rcvbuf") == 0) {
+         int sz = ival;
+         rc = setsockopt(s, SOL_SOCKET, SO_RCVBUF, (char *)&sz, sizeof(sz));
+         }
+      else if (strcmp(abuf, "sndbuf") == 0) {
+         int sz = ival;
+         rc = setsockopt(s, SOL_SOCKET, SO_SNDBUF, (char *)&sz, sizeof(sz));
+         }
+      else if (strcmp(abuf, "ttl") == 0) {
+         /*
+          * Set both unicast and multicast hop limits.  The stack uses
+          * whichever matches the destination; one attr covers UDP/raw.
+          */
+         if (sock_family(s) == AF_INET6) {
+            int hops = ival;
+            rc = setsockopt(s, IPPROTO_IPV6, IPV6_UNICAST_HOPS,
+                            (char *)&hops, sizeof(hops));
+            if (rc == 0)
+               rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
+                               (char *)&hops, sizeof(hops));
+            }
+         else {
+            int ttl4 = ival;
+            unsigned char mttl = ival;
+            rc = setsockopt(s, IPPROTO_IP, IP_TTL,
+                            (char *)&ttl4, sizeof(ttl4));
+            if (rc == 0)
+               rc = setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL,
+                               (char *)&mttl, sizeof(mttl));
+            }
+         }
+      else if (strcmp(abuf, "mcastloop") == 0) {
+         if (sock_family(s) == AF_INET6) {
+            unsigned int loop6 = on;
+            rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
+                            (char *)&loop6, sizeof(loop6));
+            }
+         else {
+            unsigned char loop4 = on;
+            rc = setsockopt(s, IPPROTO_IP, IP_MULTICAST_LOOP,
+                            (char *)&loop4, sizeof(loop4));
+            }
+         }
+      else if (strcmp(abuf, "iface") == 0) {
+         struct in_addr ifa;
+         if (inet_pton(AF_INET, val, &ifa) == 1) {
+            mcif4 = ifa;                /* also used by subsequent joins */
+            rc = setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF,
+                            (char *)&ifa, sizeof(ifa));
+            }
+         else if (strspn(val, "0123456789") == strlen(val)) {
+            mcif6 = ival;               /* IPv6 interface index */
+            rc = setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                            (char *)&mcif6, sizeof(mcif6));
+            }
+         else {
+            errno = EINVAL;
+            rc = -1;
+            }
+         }
+      else if (strcmp(abuf, "join") == 0) {
+         saw_join = 1;
+         if ((src = strchr(val, ',')) != NULL)
+            *src++ = '\0';
+         rc = sock_join_group(s, val, src, mcif4, mcif6);
+         }
+
+      if (rc < 0) {
+         set_syserrortext(errno);
+         return 0;
+         }
+      }
+
+   /*
+    * A socket bound to a multicast group address implicitly joins that
+    * group; explicit join attributes take manual control of memberships
+    * and suppress the implicit one.
+    */
+   if (autojoin != NULL && !prebind && !saw_join) {
+      if (sock_join_group(s, autojoin, NULL, mcif4, mcif6) < 0) {
+         set_syserrortext(errno);
+         return 0;
+         }
+      }
+   return 1;
+}
+
+/*
  * Empty handler for connection alarm signals (used for timeouts).
  */
 /* static void on_alarm(int x)
@@ -984,7 +1380,8 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family){
 }
 */
 
-int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
+int sock_connect(char *fn, int is_udp, int timeout, int af_fam,
+                 dptr attr, int nattr)
 {
   int saveflags, rc, s, len;
    struct sockaddr *sa;
@@ -1021,7 +1418,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
 
         /*
         if (connect(s, res->ai_addr, res->ai_addrlen) < 0) {
-          close(s);
+          sock_close(s);
           s = -1;
           continue;
         }
@@ -1057,6 +1454,28 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
           freeaddrinfo(res);
         }
       }
+
+      /*
+       * Sending to the limited broadcast address is unambiguous intent;
+       * default SO_BROADCAST to on so the first write doesn't fail with
+       * EACCES.  An explicit broadcast=no attribute overrides it below.
+       */
+      if (is_udp && sa->sa_family == AF_INET &&
+          ((struct sockaddr_in *)sa)->sin_addr.s_addr == htonl(INADDR_BROADCAST)) {
+         int on = 1;
+         setsockopt(s, SOL_SOCKET, SO_BROADCAST, (char *)&on, sizeof(on));
+      }
+
+      /*
+       * Apply any socket attributes.  Client sockets are never bound
+       * explicitly, so both attribute passes run back to back here.
+       */
+      if (!apply_sock_attrs(s, 1, attr, nattr, NULL) ||
+          !apply_sock_attrs(s, 0, attr, nattr, NULL)) {
+         sock_close(s);
+         freeaddrinfo(saddrinfo);
+         return 0;
+      }
    }
    else {
       /* UNIX domain socket */
@@ -1084,7 +1503,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
       /* save the sockaddr struct */
       saddrs = realloc(saddrs, (s+1) * (sizeof(struct addrinfo *)));
       if (saddrs == NULL) {
-         close(s);
+         sock_close(s);
          return 0;
          }
       saddrs[s] = saddrinfo;
@@ -1096,13 +1515,13 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
       /* Save existing flags for restore later */
       saveflags = fcntl(s, F_GETFL, 0);
       if (saveflags < 0) {
-         close(s);
+         sock_close(s);
          return 0;
       }
       /* Turn on non-blocking flag - this will make connect
          return immediately.  */
       if (fcntl(s, F_SETFL, saveflags|O_NONBLOCK) < 0) {
-         close(s);
+         sock_close(s);
          return 0;
       }
 #endif                                  /* UNIX */
@@ -1111,7 +1530,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
       unsigned long imode = 1;
       if (ioctlsocket(s, FIONBIO, &imode) < 0) {
          errno = WSAGetLastError();
-         closesocket(s);
+         sock_close(s);
          return 0;
       }
 #endif                                  /* NT */
@@ -1124,7 +1543,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
       /* Reset the old flags, but avoiding overwriting the value of errno */
       int connect_err = errno;
       if (fcntl(s, F_SETFL, saveflags) < 0) {
-         close(s);
+         sock_close(s);
          return 0;
       }
       errno = connect_err;
@@ -1149,21 +1568,21 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
           * and that can be used to distinguish from another error condition.
           */
          if (sc <= 0) {
-            close(s);
+            sock_close(s);
             return 0;
             }
 
          /* Get the error code of the connect */
          cclen = sizeof(cc);
          if (getsockopt(s, SOL_SOCKET, SO_ERROR, &cc, &cclen) < 0) {
-            close(s);
+            sock_close(s);
             return 0;
          }
 
          if (cc != 0) {
             /* There was an error, so set errno and fail */
             errno = cc;
-            close(s);
+            sock_close(s);
             return 0;
          }
 
@@ -1176,7 +1595,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
       unsigned long imode = 0;
       if (ioctlsocket(s, FIONBIO, &imode) < 0) {
          errno = WSAGetLastError();
-         closesocket(s);
+         sock_close(s);
          return 0;
       }
       errno = connect_err;
@@ -1199,7 +1618,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
             and that can be used to distinguish from another error condition. */
          if (sc <= 0) {
             errno = WSAGetLastError();
-            closesocket(s);
+            sock_close(s);
             return 0;
          }
 
@@ -1207,14 +1626,14 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
          cclen = sizeof(cc);
          if (getsockopt(s, SOL_SOCKET, SO_ERROR, (char*)&cc, &cclen) < 0) {
             errno = WSAGetLastError();
-            closesocket(s);
+            sock_close(s);
             return 0;
          }
 
          if (cc != 0) {
             /* There was an error, so set errno and fail */
             errno = cc;
-            closesocket(s);
+            sock_close(s);
             return 0;
          }
 
@@ -1224,7 +1643,7 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam)
    }
 
    if (rc < 0) {
-      close(s);
+      sock_close(s);
       return 0;
    }
 
@@ -1249,17 +1668,22 @@ ip_version(const char *src) {
  * including UDP sockets and non-blocking "listener" sockets on which a
  * later select() may turn up an accept.
  */
-int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
+int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
+                dptr attr, int nattr)
 {
   int fd, s, len;
    struct addrinfo *res0, *res;
    struct sockaddr *sa;
    unsigned int fromlen;
    struct sockaddr_storage from;
+   int created = 0, uncached = 0;
 
 
+   /* sock_get pins a cached fd until sock_release below */
    if ((s = sock_get(addr)) < 0) {
-     char *p, fname[BUFSIZ];
+     char *p, fname[BUFSIZ], group[INET6_ADDRSTRLEN];
+     int on, is_mc = 0;
+     created = 1;
 
      /*
       * If the first argument is just a name, it's a unix domain socket.
@@ -1268,6 +1692,10 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
       */
 
       SAFE_strncpy(fname,addr, sizeof(fname));
+
+      /* let a join attribute's group address pick the family */
+      if (af_fam == AF_UNSPEC)
+         af_fam = sock_attrs_af(attr, nattr);
 
       if ((p=strrchr(fname, ':')) != NULL) {
          *p = 0;
@@ -1285,8 +1713,88 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
              continue;
            }
 
-           if (bind(s, res->ai_addr, res->ai_addrlen) < 0) {
-             close(s);
+           is_mc = sockaddr_is_multicast(res->ai_addr);
+
+           /*
+            * Listeners default to reuseaddr=yes so a restarted server
+            * can rebind through TIME_WAIT; an explicit reuseaddr=no
+            * attribute overrides it below.  On Windows SO_REUSEADDR
+            * instead allows a second live bind of a busy port, so only
+            * multicast receivers, which must share their port, get it
+            * there.  Multicast receivers also get reuseport where
+            * available (needed on BSD/macOS to share a group address);
+            * both defaults are best effort.
+            */
+           on = 1;
+#if UNIX
+           setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));
+           if (is_mc)
+              setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&on, sizeof(on));
+#else                                   /* UNIX */
+           if (is_mc)
+              setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));
+#endif                                  /* UNIX */
+
+           /* reuse flags et al. only take effect before bind() */
+           if (!apply_sock_attrs(s, 1, attr, nattr, NULL)) {
+             sock_close(s);
+             freeaddrinfo(res0);
+             return 0;
+           }
+
+           /*
+            * Windows rejects bind() to a multicast group address
+            * (WSAEADDRNOTAVAIL / "not valid in its context").  Bind the
+            * wildcard instead; the group is still joined below via the
+            * implicit autojoin (or an explicit join=/source= attribute).
+            * UNIX stacks accept a group bind and use it as a filter.
+            */
+           if (is_mc) {
+#if NT
+              if (res->ai_family == AF_INET) {
+                 struct sockaddr_in any4;
+                 memcpy(&any4, res->ai_addr, sizeof(any4));
+                 any4.sin_addr.s_addr = htonl(INADDR_ANY);
+                 if (bind(s, (struct sockaddr *)&any4, sizeof(any4)) < 0) {
+                    sock_close(s);
+                    s = -1;
+                    continue;
+                    }
+                 }
+              else if (res->ai_family == AF_INET6) {
+                 struct sockaddr_in6 any6;
+                 memcpy(&any6, res->ai_addr, sizeof(any6));
+                 any6.sin6_addr = in6addr_any;
+                 if (bind(s, (struct sockaddr *)&any6, sizeof(any6)) < 0) {
+                    sock_close(s);
+                    s = -1;
+                    continue;
+                    }
+                 }
+              else {
+                 sock_close(s);
+                 s = -1;
+                 continue;
+                 }
+#else                                   /* NT */
+              if (bind(s, res->ai_addr, res->ai_addrlen) < 0) {
+                 sock_close(s);
+                 s = -1;
+                 continue;
+                 }
+#endif                                  /* NT */
+              /* remember the group address for the implicit join below */
+              if (res->ai_family == AF_INET6)
+                 inet_ntop(AF_INET6,
+                           &((struct sockaddr_in6 *)res->ai_addr)->sin6_addr,
+                           group, sizeof(group));
+              else
+                 inet_ntop(AF_INET,
+                           &((struct sockaddr_in *)res->ai_addr)->sin_addr,
+                           group, sizeof(group));
+              }
+           else if (bind(s, res->ai_addr, res->ai_addrlen) < 0) {
+             sock_close(s);
              s = -1;
              continue;
            }
@@ -1297,7 +1805,29 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
          if (res0)
            freeaddrinfo(res0);
          if (s < 0) {
-           return 0;  // failed to bind to any address
+#if NT
+           /*
+            * Winsock failures often leave errno 0; map WSAGetLastError
+            * so open() does not report the leftover strerror(0) "Success".
+            */
+           if (errno == 0) {
+              int wsa = WSAGetLastError();
+              if (wsa != 0)
+                 errno = wsa;
+              }
+#endif                                  /* NT */
+           if (errno != 0)
+              set_syserrortext(errno);
+           return 0;  /* failed to bind to any address */
+         }
+
+         /*
+          * Multicast joins and other post-bind socket attributes.  A
+          * socket bound to a multicast group joins it implicitly.
+          */
+         if (!apply_sock_attrs(s, 0, attr, nattr, is_mc ? group : NULL)) {
+           sock_close(s);
+           return 0;
          }
 
       }
@@ -1330,22 +1860,100 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam)
            return 0;
          }
       }
+      /*
+       * Cache only after listen() succeeds (below).  Putting a bound
+       * but non-listening socket in the map left later opens stuck on
+       * a failed listener.
+       */
    }
-   /* No need to listen on UDP sockets */
-   if (is_udp_or_listener != 1)
-     if (listen(s, SOMAXCONN) < 0)
-       return 0;
-   /* Save s for future calls to listen */
-   sock_put(addr, s);
+   else {
+      /*
+       * Cache hit: still apply this open()'s attributes so a later
+       * open with different join=/iface=/etc. is not ignored.
+       * Pass the bind host as autojoin when it is a multicast group so
+       * source= works; sock_join_group treats already-member as OK.
+       */
+      char hit_fname[BUFSIZ];
+      char *hit_group = NULL, *hit_colon;
 
-   if (is_udp_or_listener)
+      SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
+      if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
+         *hit_colon = '\0';
+         if (host_is_multicast(hit_fname))
+            hit_group = hit_fname;
+         }
+      if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
+          !apply_sock_attrs(s, 0, attr, nattr, hit_group, NULL)) {
+         sock_release(s);
+         return 0;
+         }
+      }
+   /*
+    * Cached listeners are already pinned by sock_get.  Newly created
+    * sockets are not in the map yet, so close cannot race listen.
+    */
+   if (is_udp_or_listener != 1) {
+     if (listen(s, SOMAXCONN) < 0) {
+       /*
+        * Not yet in sock_map when created==1, so a failed listen cannot
+        * leave a stale cached descriptor.
+        */
+       if (created)
+          sock_close(s);
+       else
+          sock_release(s);
+       return 0;
+       }
+     }
+
+   if (created) {
+      int put;
+      /*
+       * Another thread may have registered the same address first
+       * (SO_REUSEADDR).  Drop our socket and use the cached listener.
+       * Cache full (-1): keep this listener uncached rather than
+       * closing a valid socket.
+       */
+      put = sock_put(addr, s);
+      if (put == 0) {
+         char hit_fname[BUFSIZ];
+         char *hit_group = NULL, *hit_colon;
+
+         sock_close(s);
+         if ((s = sock_get(addr)) < 0)
+            return 0;
+         /* attrs were applied to the discarded socket; redo on cached */
+         SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
+         if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
+            *hit_colon = '\0';
+            if (host_is_multicast(hit_fname))
+               hit_group = hit_fname;
+            }
+         if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
+             !apply_sock_attrs(s, 0, attr, nattr, hit_group, NULL)) {
+            sock_release(s);
+            return 0;
+            }
+         }
+      else if (put < 0)
+         uncached = 1;
+      }
+
+   if (is_udp_or_listener) {
+     if (!uncached)
+        sock_release(s);
      return s;
+     }
 
    fromlen = sizeof(from);
    DEC_NARTHREADS;
    if ((fd = accept(s, (struct sockaddr*) &from, &fromlen)) < 0) fd = 0;
    INC_NARTHREADS_CONTROLLED;
 
+   if (uncached)
+      sock_close(s);                    /* not retained in the cache */
+   else
+      sock_release(s);
    return fd;
 }
 
@@ -1460,7 +2068,7 @@ int sock_send(char *adr, char *msg, int msglen, int af_fam)
 
    if (s > 0) {
      rc =sendto(s, msg, msglen, 0, res->ai_addr, res->ai_addrlen);
-     close(s);
+     sock_close(s);
      freeaddrinfo(res0);
      if (rc >= 0)
        return 1 ;
@@ -1546,29 +2154,133 @@ int sock_write(int f, char *msg, int n)
 static struct {
    char *name;
    int fd;
-} sock_map[64] = { {0, 0} };
+   int pins;            /* sock_get / sock_pin holds across listen/accept */
+   int closing;         /* close deferred until pins drop to 0 */
+} sock_map[64] = { {0, 0, 0, 0} };
 static int nsock = 0;
 
 /*
- * lookup a socket by name
+ * Lookup a socket by name and pin it.  Caller must sock_release().
  */
 static int sock_get(char *s)
 {
-   int i;
+   int i, fd = -1;
+   MUTEX_LOCKID(MTX_SOCK_MAP);
    for (i = 0; i < nsock; i++)
-      if (strcmp(s, sock_map[i].name) == 0)
-         return sock_map[i].fd;
-   return -1;
+      if (sock_map[i].name != NULL && strcmp(s, sock_map[i].name) == 0) {
+         fd = sock_map[i].fd;
+         sock_map[i].pins++;
+         break;
+         }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return fd;
 }
 
-static void sock_put(char *s, int fd)
+/*
+ * Register a listener and pin it.
+ *   1  installed (pinned)
+ *   0  addr already cached — caller should close fd and sock_get()
+ *  -1  cache full — caller may keep using fd uncached
+ */
+static int sock_put(char *s, int fd)
 {
+   int i;
    MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++)
+      if (sock_map[i].name != NULL && strcmp(s, sock_map[i].name) == 0) {
+         MUTEX_UNLOCKID(MTX_SOCK_MAP);
+         return 0;
+         }
+   if (nsock >= (int)(sizeof(sock_map) / sizeof(sock_map[0]))) {
+      MUTEX_UNLOCKID(MTX_SOCK_MAP);
+      return -1;
+      }
    sock_map[nsock].fd = fd;
    sock_map[nsock].name = (char*) malloc(strlen(s) + 1);
    strcpy(sock_map[nsock].name, s);
+   sock_map[nsock].pins = 1;           /* installed and pinned */
+   sock_map[nsock].closing = 0;
    nsock++;
    MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return 1;
+}
+
+/*
+ * Pin a live cached listener.  Returns 1 if pinned, or 0 if the fd is
+ * not in the map (already purged/closed) — callers must not use the fd.
+ */
+int sock_pin(int fd)
+{
+   int i, ok = 0;
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++)
+      if (sock_map[i].fd == fd && sock_map[i].name != NULL) {
+         sock_map[i].pins++;
+         ok = 1;
+         break;
+         }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return ok;
+}
+
+/*
+ * Drop a pin.  If a close was deferred while pinned, close the fd now.
+ */
+void sock_release(int fd)
+{
+   int i, j;
+   int do_close = 0;
+
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++) {
+      if (sock_map[i].fd != fd)
+         continue;
+      if (sock_map[i].pins > 0)
+         sock_map[i].pins--;
+      if (sock_map[i].pins == 0 && sock_map[i].closing) {
+         free(sock_map[i].name);
+         for (j = i + 1; j < nsock; j++)
+            sock_map[j - 1] = sock_map[j];
+         nsock--;
+         do_close = 1;
+         }
+      break;
+      }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   if (do_close)
+      sock_close(fd);
+}
+
+/*
+ * Drop listener-cache entries for fd so a later open() of the same
+ * address does not reuse a stale descriptor.  Returns 1 if the caller
+ * should close fd now, or 0 if a pin is still held (close runs from
+ * sock_release when the pin drops).
+ */
+int sock_purge(int fd)
+{
+   int i, j;
+   int defer = 0;
+
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = j = 0; i < nsock; i++) {
+      if (sock_map[i].fd != fd) {
+         sock_map[j++] = sock_map[i];
+         continue;
+         }
+      if (sock_map[i].pins > 0) {
+         free(sock_map[i].name);
+         sock_map[i].name = NULL;       /* hidden from sock_get */
+         sock_map[i].closing = 1;
+         sock_map[j++] = sock_map[i];
+         defer = 1;
+         }
+      else
+         free(sock_map[i].name);
+      }
+   nsock = j;
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return !defer;
 }
 
 
@@ -1609,16 +2321,19 @@ SSL_CTX * create_ssl_context(dptr attr, int n, int type ) {
         *  - under 3 characters
         *  - starts or ends with '='
         */
-       if (strlen(tmps) < 3 || tmps[0] == '=' || tmps[strlen(tmps)-1] == '=') {
-         set_errortext_with_val(1302, tmps);
-         return NULL;
-       }
+      if (strlen(tmps) < 3 || tmps[0] == '=' || tmps[strlen(tmps)-1] == '=') {
+        set_errortext_with_val(1302, tmps);
+        return NULL;
+      }
 
-       /*
-        * split the attribute at the '=' sign
-        * attrib name up to '=', val is whatever comes after '='
-        */
-       val = strchr(tmps,'=');
+      /*
+       * Split a private copy at the '=' sign: cnv:C_string can return
+       * the caller's own string storage (see cnv_c_str), which must not
+       * be mutated because apply_sock_attrs() parses it again.
+       * attrib name up to '=', val is whatever comes after '='
+       */
+      Protect(tmps = alcstr(tmps, (word)strlen(tmps)+1), fatalerr(0,NULL));
+      val = strchr(tmps,'=');
        if (val != NULL) {
          *val = '\0';
          val++;
@@ -1649,6 +2364,8 @@ SSL_CTX * create_ssl_context(dptr attr, int n, int type ) {
            max_proto = val;
          else if (strcmp(tmps, "verifyPeer") == 0)
            verifyPeer = val;
+         else if (is_sock_attr(tmps))
+           ; /* socket attribute: applied by apply_sock_attrs() */
          else  {
            set_errortext_with_val(1302, tmps);
            return NULL;

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -878,6 +878,8 @@ dptr rec_structor(char *name)
 
 static int sock_get (char *);
 static int sock_put (char *, int);
+static int sock_claim (int);
+static int sock_track (int);
 
 /*
  * We also stash the sockaddr structs we created with host and port info for
@@ -1139,6 +1141,104 @@ static int sock_split_group_source(char *host, char *srcbuf, size_t srcbuf_sz,
 #passthru #ifndef IP_DROP_SOURCE_MEMBERSHIP
 #passthru #define IP_DROP_SOURCE_MEMBERSHIP -1
 #passthru #endif
+#passthru #ifndef MCAST_JOIN_SOURCE_GROUP
+#passthru #define MCAST_JOIN_SOURCE_GROUP -1
+#passthru #define MCAST_LEAVE_SOURCE_GROUP -1
+#passthru #define UNICON_NO_GROUP_SOURCE_REQ 1
+#passthru #endif
+#passthru #ifdef UNICON_NO_GROUP_SOURCE_REQ
+#passthru struct group_source_req {
+#passthru    unsigned int gsr_interface;
+#passthru    struct sockaddr_storage gsr_group;
+#passthru    struct sockaddr_storage gsr_source;
+#passthru };
+#passthru #endif
+
+/*
+ * Fill a group_source_req for an IPv6 SSM join/leave.
+ */
+static int sock_fill_gsr6(struct group_source_req *gsr, char *grp, char *src,
+                          unsigned int if6)
+{
+   struct sockaddr_in6 *g6, *s6;
+
+   if (src == NULL)
+      return -1;
+   memset(gsr, 0, sizeof(*gsr));
+   gsr->gsr_interface = if6;
+   g6 = (struct sockaddr_in6 *)&gsr->gsr_group;
+   s6 = (struct sockaddr_in6 *)&gsr->gsr_source;
+   g6->sin6_family = AF_INET6;
+   s6->sin6_family = AF_INET6;
+   /*
+    * sin6_len exists on BSD/macOS.  Use config macros rtt can see,
+    * not SIN6_LEN: #passthru ifdefs do not wrap following statements
+    * inside functions (file-scope only).
+    */
+#if defined(BSD_4_4_LITE) || defined(MacOS)
+   g6->sin6_len = sizeof(*g6);
+   s6->sin6_len = sizeof(*s6);
+#endif                                  /* BSD_4_4_LITE || MacOS */
+   if (inet_pton(AF_INET6, grp, &g6->sin6_addr) != 1 ||
+       inet_pton(AF_INET6, src, &s6->sin6_addr) != 1) {
+      errno = EINVAL;
+      return -1;
+      }
+   return 0;
+}
+
+/*
+ * Winsock socket calls often leave errno 0; pull WSAGetLastError() so
+ * soft-success checks and set_syserrortext() see the real code.
+ */
+static void sock_winsock_errno(void)
+{
+#if NT
+   if (errno == 0) {
+      int wsa = WSAGetLastError();
+      if (wsa != 0)
+         errno = wsa;
+      }
+#endif                                  /* NT */
+}
+
+/*
+ * True if errno means an idempotent multicast membership change
+ * (already a member / already not a member).  CRT EINVAL (22) and
+ * WSAEINVAL (10022) are different values on Windows.
+ */
+static int sock_mcast_idempotent_err(void)
+{
+   sock_winsock_errno();
+   if (errno == EADDRINUSE || errno == EADDRNOTAVAIL || errno == EINVAL)
+      return 1;
+#if NT
+   if (errno == WSAEINVAL)
+      return 1;
+#endif                                  /* NT */
+   return 0;
+}
+
+/*
+ * IPv6 SSM join or leave via MCAST_JOIN/LEAVE_SOURCE_GROUP.
+ * One setsockopt only: no multi-iface walks or ifindex retries.
+ * Those patterns have triggered macOS kernel panics in IPv6 source
+ * filter teardown (in6_mcast).  Prefer an explicit iface= so if6 is
+ * non-zero; already-member / already-gone is success.
+ */
+static int sock_ssm6(int s, char *grp, char *src, unsigned int if6, int join)
+{
+   struct group_source_req gsr;
+   int rc, opt;
+
+   if (sock_fill_gsr6(&gsr, grp, src, if6) < 0)
+      return -1;
+   opt = join ? MCAST_JOIN_SOURCE_GROUP : MCAST_LEAVE_SOURCE_GROUP;
+   rc = setsockopt(s, IPPROTO_IPV6, opt, (char *)&gsr, sizeof(gsr));
+   if (rc < 0 && sock_mcast_idempotent_err())
+      return 0;
+   return rc;
+}
 
 /*
  * One ASM/SSM join attempt.  Already-member is success.
@@ -1170,7 +1270,7 @@ static int sock_join_on_if(int s, struct in_addr g4, char *src,
       rc = setsockopt(s, IPPROTO_IP, IP_ADD_SOURCE_MEMBERSHIP,
                       (char *)&mreqs, sizeof(mreqs));
       }
-   if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
+   if (rc < 0 && sock_mcast_idempotent_err())
       return 0;
    return rc;
 }
@@ -1222,17 +1322,22 @@ static int sock_join_group(int s, char *grp, char *src,
 #endif                                  /* UNIX */
       return sock_join_on_if(s, g4, src, if4);
       }
-   else if (inet_pton(AF_INET6, grp, &g6) == 1 && src == NULL) {
-      /* IPv6 source-specific joins (MCAST_JOIN_SOURCE_GROUP) not yet supported */
+   else if (inet_pton(AF_INET6, grp, &g6) == 1) {
+      if (src != NULL)
+         return sock_ssm6(s, grp, src, if6, 1);
+      {
       struct ipv6_mreq mreq6;
       memset(&mreq6, 0, sizeof(mreq6));
       mreq6.ipv6mr_multiaddr = g6;
       mreq6.ipv6mr_interface = if6;
       rc = setsockopt(s, IPPROTO_IPV6, IPV6_JOIN_GROUP,
                       (char *)&mreq6, sizeof(mreq6));
-      if (rc < 0 && (errno == EADDRINUSE || errno == EADDRNOTAVAIL))
+      if (rc < 0 && sock_mcast_idempotent_err())
          return 0;
+      if (rc < 0)
+         sock_winsock_errno();
       return rc;
+      }
       }
    errno = EINVAL;
    return -1;
@@ -1300,7 +1405,9 @@ static void sock_ensure_mcast_if(int s)
 
 /*
  * Parse an iface value: IPv4 dotted address, numeric interface index,
- * or (on UNIX) an interface name such as "en0" / "eth0" / "lo0".
+ * or an interface name ("en0" / "eth0" / "lo0" on UNIX; "loopback_0"
+ * etc. on Windows).  "lo" and "lo0" are accepted as the IPv6 loopback
+ * interface on Windows too (mapped via if_nametoindex("loopback_0")).
  * On success sets *have4/*have6 and the corresponding if4/if6 values.
  */
 static int sock_parse_iface(char *val, long ival,
@@ -1308,6 +1415,7 @@ static int sock_parse_iface(char *val, long ival,
                               int *have4, int *have6)
 {
    struct in_addr a;
+   unsigned int idx;
 
    *have4 = *have6 = 0;
    if (inet_pton(AF_INET, val, &a) == 1) {
@@ -1320,17 +1428,25 @@ static int sock_parse_iface(char *val, long ival,
       *have6 = 1;
       return 1;
       }
+   idx = if_nametoindex(val);
+#if NT
+   /*
+    * UNIX-style loopback names show up in portable examples/tests;
+    * Windows exports the NDIS name "loopback_0" instead.
+    */
+   if (idx == 0 && (strcmp(val, "lo") == 0 || strcmp(val, "lo0") == 0))
+      idx = if_nametoindex("loopback_0");
+#endif                                  /* NT */
+   if (idx == 0) {
+      errno = EINVAL;
+      return 0;
+      }
+   *if6 = idx;
+   *have6 = 1;
 #if UNIX
    {
-      unsigned int idx;
       struct ifaddrs *ifa0, *ifa;
 
-      if ((idx = if_nametoindex(val)) == 0) {
-         errno = EINVAL;
-         return 0;
-         }
-      *if6 = idx;
-      *have6 = 1;
       if (getifaddrs(&ifa0) == 0) {
          for (ifa = ifa0; ifa != NULL; ifa = ifa->ifa_next) {
             if (ifa->ifa_addr == NULL || ifa->ifa_name == NULL)
@@ -1345,12 +1461,9 @@ static int sock_parse_iface(char *val, long ival,
             }
          freeifaddrs(ifa0);
          }
-      return 1;
       }
-#else                                   /* UNIX */
-   errno = EINVAL;
-   return 0;
 #endif                                  /* UNIX */
+   return 1;
 }
 
 /*
@@ -1426,7 +1539,10 @@ static int sock_leave_group(int s, char *grp, char *src,
             }
          }
       }
-   else if (inet_pton(AF_INET6, grp, &g6) == 1 && src == NULL) {
+   else if (inet_pton(AF_INET6, grp, &g6) == 1) {
+      if (src != NULL)
+         return sock_ssm6(s, grp, src, if6, 0);
+      {
       struct ipv6_mreq mreq6;
       memset(&mreq6, 0, sizeof(mreq6));
       mreq6.ipv6mr_multiaddr = g6;
@@ -1439,13 +1555,25 @@ static int sock_leave_group(int s, char *grp, char *src,
                          (char *)&mreq6, sizeof(mreq6));
          }
       }
+      }
    else {
       errno = EINVAL;
       return -1;
       }
 
-   if (rc < 0 && (errno == EADDRNOTAVAIL || errno == EADDRINUSE))
+   /*
+    * Already-not-a-member: success.  Linux uses EADDRNOTAVAIL; some
+    * stacks (macOS) report EINVAL for DROP when the group was never
+    * joined; Windows often reports WSAEINVAL, or fails with errno left
+    * at 0 and nothing useful in WSAGetLastError().
+    */
+   if (rc < 0 && sock_mcast_idempotent_err())
       return 0;
+   if (rc < 0) {
+      sock_winsock_errno();
+      if (errno == 0)
+         return 0;
+      }
    return rc;
 }
 
@@ -1482,6 +1610,37 @@ int sock_attrs_af(dptr attr, int nattr)
 }
 
 /*
+ * True if open() was given at least one socket attribute (not SSL and
+ * not a leading timeout integer).  Used to decide whether a cache hit
+ * can be a pure File alias or needs an independent socket.
+ */
+static int sock_open_has_attrs(dptr attr, int nattr)
+{
+   tended char *tmps;
+   char abuf[256], *eq;
+   int a;
+   C_integer tmpint;
+
+   for (a = 0; a < nattr; a++) {
+      if (is:null(attr[a]))
+         continue;
+      if (a == 0 && cnv:C_integer(attr[a], tmpint))
+         continue;
+      if (!cnv:C_string(attr[a], tmps))
+         continue;
+      if (strlen(tmps) < 3 || strlen(tmps) >= sizeof(abuf))
+         continue;
+      strcpy(abuf, tmps);
+      if ((eq = strchr(abuf, '=')) == NULL || eq == abuf || eq[1] == '\0')
+         continue;
+      *eq = '\0';
+      if (is_sock_attr(abuf))
+         return 1;
+      }
+   return 0;
+}
+
+/*
  * Parse and apply "name=value" socket attributes from open()'s trailing
  * arguments to socket s.  Attributes belonging to the other pass, SSL
  * attributes, and a leading integer timeout argument are skipped.
@@ -1494,7 +1653,7 @@ int sock_attrs_af(dptr attr, int nattr)
  * &errortext/errno set on failure.
  */
 int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
-                     char *autojoin, char *autosource)
+                     char *autojoin, char *autosource, int join_only)
 {
    tended char *tmps;
    char abuf[256], *val, *src;
@@ -1550,6 +1709,18 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
          if (is_ssl_attr(abuf))
             continue;                   /* handled by create_ssl_context() */
          errno = 0;                     /* &errortext carries the error */
+         set_errortext_with_val(1310, tmps);
+         return 0;
+         }
+
+      /*
+       * Cache-hit opens share the kernel socket with earlier aliases.
+       * Only additive membership (join=/source=) is allowed; leave= and
+       * option changes would retune traffic for every live File.
+       */
+      if (join_only &&
+          strcmp(abuf, "join") != 0 && strcmp(abuf, "source") != 0) {
+         errno = 0;
          set_errortext_with_val(1310, tmps);
          return 0;
          }
@@ -1685,6 +1856,7 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
          }
 
       if (rc < 0) {
+         sock_winsock_errno();
          set_syserrortext(errno);
          return 0;
          }
@@ -1746,8 +1918,8 @@ int sattrib(int s, char *str, long len, dptr answer, char *abuf)
       {
       CURTSTATE();
       k_errornumber = 0;
-      if (!apply_sock_attrs(s, 1, &attrd, 1, NULL, NULL) ||
-          !apply_sock_attrs(s, 0, &attrd, 1, NULL, NULL)) {
+      if (!apply_sock_attrs(s, 1, &attrd, 1, NULL, NULL, 0) ||
+          !apply_sock_attrs(s, 0, &attrd, 1, NULL, NULL, 0)) {
          if (k_errornumber == 1310)
             return RunError;
          return Failed;
@@ -1970,8 +2142,8 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam,
        * Apply any socket attributes.  Client sockets are never bound
        * explicitly, so both attribute passes run back to back here.
        */
-      if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
-          !apply_sock_attrs(s, 0, attr, nattr, NULL, NULL)) {
+      if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL, 0) ||
+          !apply_sock_attrs(s, 0, attr, nattr, NULL, NULL, 0)) {
          sock_close(s);
          freeaddrinfo(saddrinfo);
          return 0;
@@ -2183,11 +2355,30 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
    struct sockaddr *sa;
    unsigned int fromlen;
    struct sockaddr_storage from;
-   int created = 0, uncached = 0;
+   int created = 0, uncached = 0, parallel = 0, retried = 0;
+   int has_attrs = sock_open_has_attrs(attr, nattr);
 
+again:
+   created = 0;
+   uncached = 0;
 
-   /* sock_get pins a cached fd until sock_release below */
-   if ((s = sock_get(addr)) < 0) {
+   /*
+    * Cache hit with no socket attributes: pure File alias of the
+    * shared listener (owner refcount).  Cache hit with attributes:
+    * release the pin and create an independent socket so join/leave/
+    * ttl/iface/etc. cannot retune earlier aliases (reuseaddr lets the
+    * second bind succeed).  sock_get pins until claim/release below.
+    * After a failed claim (entry closing under us), retried!=0 forces
+    * a fresh create rather than failing open().
+    */
+   s = sock_get(addr);
+   if (s >= 0 && (has_attrs || retried)) {
+      sock_release(s);
+      parallel = 1;
+      s = -1;
+      }
+
+   if (s < 0) {
      char *p, *mcsrc, fname[BUFSIZ], group[INET6_ADDRSTRLEN];
      char srcbuf[INET6_ADDRSTRLEN];
      int on, is_mc = 0;
@@ -2232,25 +2423,29 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
            /*
             * Listeners default to reuseaddr=yes so a restarted server
             * can rebind through TIME_WAIT; an explicit reuseaddr=no
-            * attribute overrides it below.  On Windows SO_REUSEADDR
-            * instead allows a second live bind of a busy port, so only
-            * multicast receivers, which must share their port, get it
-            * there.  Multicast receivers also get reuseport where
-            * available (needed on BSD/macOS to share a group address);
-            * both defaults are best effort.
+            * attribute overrides it below.  On UNIX also set reuseport
+            * (best effort): BSD/macOS need it on every sharer to bind the
+            * same UDP port, including a later parallel open with attrs
+            * beside a cached listener.  On Windows SO_REUSEADDR instead
+            * allows a second live bind, so only multicast receivers and
+            * parallel opens get it there.
             */
            on = 1;
 #if UNIX
            setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));
-           if (is_mc)
-              setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&on, sizeof(on));
+           setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char *)&on, sizeof(on));
 #else                                   /* UNIX */
-           if (is_mc)
+           /*
+            * Windows: REUSEADDR on every UDP listener so a later
+            * parallel/attr open can bind the same port.  Also for
+            * multicast binds and any parallel create (TCP or UDP).
+            */
+           if (is_mc || parallel || is_udp_or_listener == 1)
               setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));
 #endif                                  /* UNIX */
 
            /* reuse flags et al. only take effect before bind() */
-           if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL)) {
+           if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL, 0)) {
              sock_close(s);
              freeaddrinfo(res0);
              return 0;
@@ -2341,7 +2536,7 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
           * or SSM when the address was source@group / source=).
           */
          if (!apply_sock_attrs(s, 0, attr, nattr,
-                               is_mc ? group : NULL, is_mc ? mcsrc : NULL)) {
+                               is_mc ? group : NULL, is_mc ? mcsrc : NULL, 0)) {
            sock_close(s);
            return 0;
          }
@@ -2382,30 +2577,6 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
        * a failed listener.
        */
    }
-   else {
-      /*
-       * Cache hit: still apply this open()'s attributes so a later
-       * open with different join=/iface=/etc. is not ignored.
-       * Pass the bind host as autojoin when it is a multicast group so
-       * source= works; sock_join_group treats already-member as OK.
-       */
-      char hit_fname[BUFSIZ], hit_srcbuf[INET6_ADDRSTRLEN];
-      char *hit_group = NULL, *hit_src = NULL, *hit_colon;
-
-      SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
-      if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
-         *hit_colon = '\0';
-         if (sock_split_group_source(hit_fname, hit_srcbuf, sizeof(hit_srcbuf),
-                                     &hit_src) &&
-             host_is_multicast(hit_fname))
-            hit_group = hit_fname;
-         }
-      if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
-          !apply_sock_attrs(s, 0, attr, nattr, hit_group, hit_src)) {
-         sock_release(s);
-         return 0;
-         }
-      }
    /*
     * Cached listeners are already pinned by sock_get.  Newly created
     * sockets are not in the map yet, so close cannot race listen.
@@ -2416,6 +2587,13 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
         * Not yet in sock_map when created==1, so a failed listen cannot
         * leave a stale cached descriptor.
         */
+#if NT
+       if (errno == 0) {
+          int wsa = WSAGetLastError();
+          if (wsa != 0)
+             errno = wsa;
+          }
+#endif                                  /* NT */
        if (created)
           sock_close(s);
        else
@@ -2428,31 +2606,26 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
       int put;
       /*
        * Another thread may have registered the same address first
-       * (SO_REUSEADDR).  Drop our socket and use the cached listener.
+       * (SO_REUSEADDR).  For a plain open (no attrs), drop our socket
+       * and use the cached listener.  When this open requested socket
+       * attributes (parallel), keep our configured socket uncached so
+       * those attrs stay independent of the cached aliases.
        * Cache full (-1): keep this listener uncached rather than
        * closing a valid socket.
        */
       put = sock_put(addr, s);
       if (put == 0) {
-         char hit_fname[BUFSIZ], hit_srcbuf[INET6_ADDRSTRLEN];
-         char *hit_group = NULL, *hit_src = NULL, *hit_colon;
-
-         sock_close(s);
-         if ((s = sock_get(addr)) < 0)
-            return 0;
-         /* attrs were applied to the discarded socket; redo on cached */
-         SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
-         if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
-            *hit_colon = '\0';
-            if (sock_split_group_source(hit_fname, hit_srcbuf,
-                                        sizeof(hit_srcbuf), &hit_src) &&
-                host_is_multicast(hit_fname))
-               hit_group = hit_fname;
-            }
-         if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
-             !apply_sock_attrs(s, 0, attr, nattr, hit_group, hit_src)) {
-            sock_release(s);
-            return 0;
+         if (parallel || has_attrs)
+            uncached = 1;
+         else {
+            sock_close(s);
+            if ((s = sock_get(addr)) < 0) {
+               if (retried)
+                  return 0;
+               retried = 1;
+               parallel = 1;
+               goto again;
+               }
             }
          }
       else if (put < 0)
@@ -2460,8 +2633,30 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
       }
 
    if (is_udp_or_listener) {
-     if (!uncached)
-        sock_release(s);
+     if (!uncached) {
+        /*
+         * Convert the sock_get/sock_put pin into File ownership under
+         * the cache lock.  If claim fails the entry is closing or gone:
+         * drop the pin (may finish the close) and retry once with a
+         * replacement listener instead of failing a valid open().
+         */
+        if (!sock_claim(s)) {
+           sock_release(s);
+           if (retried)
+              return 0;
+           retried = 1;
+           parallel = 1;
+           goto again;
+           }
+        }
+     else if (!sock_track(s)) {
+        /*
+         * Cannot track for select()/accept pin protection.  Do not
+         * return a gen-0 listener that accept() would use unpinned.
+         */
+        sock_close(s);
+        return 0;
+        }
      return s;
      }
 
@@ -2469,6 +2664,13 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
    DEC_NARTHREADS;
    if ((fd = accept(s, (struct sockaddr*) &from, &fromlen)) < 0) fd = 0;
    INC_NARTHREADS_CONTROLLED;
+#if NT
+   if (fd == 0 && errno == 0) {
+      int wsa = WSAGetLastError();
+      if (wsa != 0)
+         errno = wsa;
+      }
+#endif                                  /* NT */
 
    if (uncached)
       sock_close(s);                    /* not retained in the cache */
@@ -2674,10 +2876,13 @@ int sock_write(int f, char *msg, int n)
 static struct {
    char *name;
    int fd;
+   unsigned gen;        /* identity; distinguishes fd number reuse */
    int pins;            /* sock_get / sock_pin holds across listen/accept */
+   int owners;          /* File objects holding this cached listener */
    int closing;         /* close deferred until pins drop to 0 */
-} sock_map[64] = { {0, 0, 0, 0} };
+} sock_map[64] = { {0, 0, 0, 0, 0, 0} };
 static int nsock = 0;
+static unsigned sock_gen_seq = 1;       /* 0 reserved for "not cached" */
 
 /*
  * Lookup a socket by name and pin it.  Caller must sock_release().
@@ -2718,7 +2923,11 @@ static int sock_put(char *s, int fd)
    sock_map[nsock].fd = fd;
    sock_map[nsock].name = (char*) malloc(strlen(s) + 1);
    strcpy(sock_map[nsock].name, s);
+   if (sock_gen_seq == 0)
+      sock_gen_seq = 1;                /* skip 0 after wrap */
+   sock_map[nsock].gen = sock_gen_seq++;
    sock_map[nsock].pins = 1;           /* installed and pinned */
+   sock_map[nsock].owners = 0;
    sock_map[nsock].closing = 0;
    nsock++;
    MUTEX_UNLOCKID(MTX_SOCK_MAP);
@@ -2726,21 +2935,162 @@ static int sock_put(char *s, int fd)
 }
 
 /*
- * Pin a live cached listener.  Returns 1 if pinned, or 0 if the fd is
- * not in the map (already purged/closed) — callers must not use the fd.
+ * Generation of a live tracked listener fd (named cache or nameless
+ * track entry), or 0 if not in the map.  Stored on the File at open so
+ * sock_pin can reject a reused fd number.
  */
-int sock_pin(int fd)
+word sock_listener_gen(int fd)
 {
-   int i, ok = 0;
+   int i;
+   word gen = 0;
+
    MUTEX_LOCKID(MTX_SOCK_MAP);
    for (i = 0; i < nsock; i++)
-      if (sock_map[i].fd == fd && sock_map[i].name != NULL) {
+      if (sock_map[i].fd == fd && !sock_map[i].closing) {
+         gen = (word)sock_map[i].gen;
+         break;
+         }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return gen;
+}
+
+/*
+ * Convert a temporary pin into File ownership.  Returns 1 on success.
+ * Fails (0) if the entry is closing or no longer visible — caller must
+ * sock_release() the pin and not use the fd.  Doing owners++ and pins--
+ * under one lock avoids release-then-own closing the descriptor when the
+ * last prior File is purged concurrently.
+ */
+static int sock_claim(int fd)
+{
+   int i, ok = 0;
+
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++) {
+      if (sock_map[i].fd != fd)
+         continue;
+      if (sock_map[i].name == NULL || sock_map[i].closing)
+         break;
+      sock_map[i].owners++;
+      if (sock_map[i].pins > 0)
+         sock_map[i].pins--;
+      ok = 1;
+      break;
+      }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   return ok;
+}
+
+/*
+ * Track an uncached listener (parallel/attr or map-full) so select()
+ * can pin it.  Hidden from sock_get (name NULL).  owners starts at 1.
+ * If the map is full, reclaim an idle named entry (owners==0, pins==0)
+ * left after select()-accept (genserve).  Returns 1 if tracked, 0 if
+ * no slot can be freed.
+ */
+static int sock_track(int fd)
+{
+   int i, j;
+   int victim = -1;
+   int do_close = 0;
+   int oldfd = -1;
+
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   if (nsock >= (int)(sizeof(sock_map) / sizeof(sock_map[0]))) {
+      for (i = 0; i < nsock; i++)
+         if (sock_map[i].name != NULL && sock_map[i].owners == 0 &&
+             sock_map[i].pins == 0 && !sock_map[i].closing) {
+            victim = i;
+            break;
+            }
+      if (victim < 0) {
+         MUTEX_UNLOCKID(MTX_SOCK_MAP);
+         return 0;
+         }
+      oldfd = sock_map[victim].fd;
+      free(sock_map[victim].name);
+      for (j = victim + 1; j < nsock; j++)
+         sock_map[j - 1] = sock_map[j];
+      nsock--;
+      do_close = 1;
+      }
+   sock_map[nsock].fd = fd;
+   sock_map[nsock].name = NULL;
+   if (sock_gen_seq == 0)
+      sock_gen_seq = 1;
+   sock_map[nsock].gen = sock_gen_seq++;
+   sock_map[nsock].pins = 0;
+   sock_map[nsock].owners = 1;
+   sock_map[nsock].closing = 0;
+   nsock++;
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   if (do_close)
+      sock_close(oldfd);
+   return 1;
+}
+
+/*
+ * Pin a live tracked listener that still matches gen (from open /
+ * sock_listener_gen).  Returns 1 if pinned.  Fails if the fd was closed
+ * and the number reused for a different cache entry, or if gen is 0.
+ * Named and nameless (sock_track) entries are both eligible.
+ */
+int sock_pin(int fd, word gen)
+{
+   int i, ok = 0;
+
+   if (gen == 0)
+      return 0;
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++)
+      if (sock_map[i].fd == fd && !sock_map[i].closing &&
+          sock_map[i].gen == (unsigned)gen) {
          sock_map[i].pins++;
          ok = 1;
          break;
          }
    MUTEX_UNLOCKID(MTX_SOCK_MAP);
    return ok;
+}
+
+/*
+ * Drop File ownership after select() converts a listener File into an
+ * accepted connection.  Named cache entries with owners==0 stay in the
+ * map for the next open() (genserve).  Nameless track entries are
+ * closed when the last owner and pin drop — nothing else references them.
+ */
+void sock_unclaim(int fd, word gen)
+{
+   int i, j;
+   int do_close = 0;
+
+   if (gen == 0)
+      return;
+   MUTEX_LOCKID(MTX_SOCK_MAP);
+   for (i = 0; i < nsock; i++) {
+      if (sock_map[i].fd != fd || sock_map[i].gen != (unsigned)gen)
+         continue;
+      if (sock_map[i].owners > 0)
+         sock_map[i].owners--;
+      if (sock_map[i].owners > 0)
+         break;
+      if (sock_map[i].pins > 0) {
+         if (sock_map[i].name == NULL)
+            sock_map[i].closing = 1;    /* release() will close */
+         break;
+         }
+      if (sock_map[i].name != NULL)
+         break;                         /* stay cached for sock_get */
+      /* nameless track entry: remove and close */
+      for (j = i + 1; j < nsock; j++)
+         sock_map[j - 1] = sock_map[j];
+      nsock--;
+      do_close = 1;
+      break;
+      }
+   MUTEX_UNLOCKID(MTX_SOCK_MAP);
+   if (do_close)
+      sock_close(fd);
 }
 
 /*
@@ -2772,10 +3122,9 @@ void sock_release(int fd)
 }
 
 /*
- * Drop listener-cache entries for fd so a later open() of the same
- * address does not reuse a stale descriptor.  Returns 1 if the caller
- * should close fd now, or 0 if a pin is still held (close runs from
- * sock_release when the pin drops).
+ * Drop one File ownership of a cached listener.  Returns 1 if the
+ * caller should close fd now, or 0 if other owners remain or a pin is
+ * still held (close runs from sock_release when the last pin drops).
  */
 int sock_purge(int fd)
 {
@@ -2786,6 +3135,14 @@ int sock_purge(int fd)
    for (i = j = 0; i < nsock; i++) {
       if (sock_map[i].fd != fd) {
          sock_map[j++] = sock_map[i];
+         continue;
+         }
+      if (sock_map[i].owners > 0)
+         sock_map[i].owners--;
+      if (sock_map[i].owners > 0) {
+         /* other live File aliases still use this descriptor */
+         sock_map[j++] = sock_map[i];
+         defer = 1;
          continue;
          }
       if (sock_map[i].pins > 0) {

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -1006,13 +1006,14 @@ struct addrinfo *uni_getaddrinfo(char* addr, char* p, int is_udp, int family){
  * DWIM defaults (overridable with an explicit attribute):
  *   - listeners get reuseaddr=yes (UNIX); multicast binds also get
  *     reuseport=yes where available, and reuseaddr=yes on Windows
- *   - binding a UDP socket to a multicast group address joins it
+ *   - binding a UDP socket to a multicast group address joins it (ASM);
+ *     source@group:port or source= joins that group as SSM instead
  *   - connecting/sending to 255.255.255.255 enables SO_BROADCAST
  */
 
 static char *sock_attr_names[] = {
    "reuseaddr", "reuseport", "broadcast", "rcvbuf", "sndbuf",
-   "join", "ttl", "mcastloop", "iface", NULL
+   "join", "source", "ttl", "mcastloop", "iface", NULL
    };
 
 static char *ssl_attr_names[] = {
@@ -1075,6 +1076,38 @@ static int sockaddr_is_multicast(struct sockaddr *sa)
    if (sa->sa_family == AF_INET6)
       return IN6_IS_ADDR_MULTICAST(&((struct sockaddr_in6 *)sa)->sin6_addr);
    return 0;
+}
+
+/*
+ * Split a "source@group" host part (SSM, matching VLC/ffmpeg and RFC 4607
+ * (S,G) order).  On success returns 1.  With '@': copies the source into
+ * srcbuf, replaces host with the group, and sets *srcp to srcbuf.
+ * Without '@': *srcp is NULL and host is unchanged.  Empty either side
+ * fails with EINVAL.
+ */
+static int sock_split_group_source(char *host, char *srcbuf, size_t srcbuf_sz,
+                                   char **srcp)
+{
+   char *at;
+   size_t slen;
+
+   *srcp = NULL;
+   if ((at = strchr(host, '@')) == NULL)
+      return 1;
+   if (at == host || at[1] == ' ') {
+      errno = EINVAL;
+      return 0;
+      }
+   *at = ' ';
+   slen = strlen(host);
+   if (slen + 1 > srcbuf_sz) {
+      errno = EINVAL;
+      return 0;
+      }
+   memcpy(srcbuf, host, slen + 1);              /* source */
+   memmove(host, at + 1, strlen(at + 1) + 1);   /* group into host */
+   *srcp = srcbuf;
+   return 1;
 }
 
 /*
@@ -1209,14 +1242,18 @@ int sock_attrs_af(dptr attr, int nattr)
  * autojoin, when not NULL, is a multicast group the socket was bound to:
  * it is joined after the post-bind attributes, honoring any iface
  * among them, unless an explicit join attribute takes over memberships.
- * Returns 1 on success; returns 0 with &errortext/errno set on failure.
+ * autosource (from source@group in the address) selects an SSM join of
+ * that group instead of ASM; source= attributes do the same and may be
+ * repeated for multiple sources.  Returns 1 on success; returns 0 with
+ * &errortext/errno set on failure.
  */
-int apply_sock_attrs(int s, int prebind, dptr attr, int nattr, char *autojoin)
+int apply_sock_attrs(int s, int prebind, dptr attr, int nattr,
+                     char *autojoin, char *autosource)
 {
    tended char *tmps;
    char abuf[256], *val, *src;
    long ival;
-   int a, rc, on, is_pre, saw_join = 0;
+   int a, rc, on, is_pre, saw_join = 0, saw_source = 0;
    C_integer tmpint;
    struct in_addr mcif4;
    unsigned int mcif6 = 0;
@@ -1351,6 +1388,20 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr, char *autojoin)
             *src++ = '\0';
          rc = sock_join_group(s, val, src, mcif4, mcif6);
          }
+      else if (strcmp(abuf, "source") == 0) {
+         /*
+          * SSM shortcut: join the group this socket was bound to, from
+          * the given source.  Requires a multicast bind address; use
+          * join=group,source when binding a wildcard instead.
+          */
+         if (autojoin == NULL) {
+            errno = 0;
+            set_errortext_with_val(1310, tmps);
+            return 0;
+            }
+         saw_source = 1;
+         rc = sock_join_group(s, autojoin, val, mcif4, mcif6);
+         }
 
       if (rc < 0) {
          set_syserrortext(errno);
@@ -1360,13 +1411,23 @@ int apply_sock_attrs(int s, int prebind, dptr attr, int nattr, char *autojoin)
 
    /*
     * A socket bound to a multicast group address implicitly joins that
-    * group; explicit join attributes take manual control of memberships
-    * and suppress the implicit one.
+    * group (ASM), or does an SSM join when the address was source@group.
+    * Explicit join attributes take manual control and suppress this;
+    * source= attributes already joined above and suppress the ASM default
+    * unless source@group also requests its own SSM membership.
     */
    if (autojoin != NULL && !prebind && !saw_join) {
-      if (sock_join_group(s, autojoin, NULL, mcif4, mcif6) < 0) {
-         set_syserrortext(errno);
-         return 0;
+      if (autosource != NULL) {
+         if (sock_join_group(s, autojoin, autosource, mcif4, mcif6) < 0) {
+            set_syserrortext(errno);
+            return 0;
+            }
+         }
+      else if (!saw_source) {
+         if (sock_join_group(s, autojoin, NULL, mcif4, mcif6) < 0) {
+            set_syserrortext(errno);
+            return 0;
+            }
          }
       }
    return 1;
@@ -1400,7 +1461,17 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam,
     * find the last colon and get the port.
     */
    if (((p = strrchr(fname, ':')) != 0) ) {
+      char *mcsrc, srcbuf[INET6_ADDRSTRLEN];
+
       *p = 0;
+      /*
+       * source@group:port is an SSM receiver address; for send/connect
+       * the destination is just the group, so keep only the group here.
+       */
+      if (!sock_split_group_source(fname, srcbuf, sizeof(srcbuf), &mcsrc)) {
+         set_syserrortext(errno);
+         return 0;
+         }
       res0 = uni_getaddrinfo(fname, p+1, is_udp, af_fam);
       /* Restore the argument just in case */
       *p = ':';
@@ -1470,8 +1541,8 @@ int sock_connect(char *fn, int is_udp, int timeout, int af_fam,
        * Apply any socket attributes.  Client sockets are never bound
        * explicitly, so both attribute passes run back to back here.
        */
-      if (!apply_sock_attrs(s, 1, attr, nattr, NULL) ||
-          !apply_sock_attrs(s, 0, attr, nattr, NULL)) {
+      if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
+          !apply_sock_attrs(s, 0, attr, nattr, NULL, NULL)) {
          sock_close(s);
          freeaddrinfo(saddrinfo);
          return 0;
@@ -1681,17 +1752,20 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
 
    /* sock_get pins a cached fd until sock_release below */
    if ((s = sock_get(addr)) < 0) {
-     char *p, fname[BUFSIZ], group[INET6_ADDRSTRLEN];
+     char *p, *mcsrc, fname[BUFSIZ], group[INET6_ADDRSTRLEN];
+     char srcbuf[INET6_ADDRSTRLEN];
      int on, is_mc = 0;
      created = 1;
 
      /*
       * If the first argument is just a name, it's a unix domain socket.
       * If there's a : then it's host:port except if the host part is
-      * empty, it means on any interface.
+      * empty, it means on any interface.  host may be source@group for
+      * an SSM join of that group.
       */
 
       SAFE_strncpy(fname,addr, sizeof(fname));
+      mcsrc = NULL;
 
       /* let a join attribute's group address pick the family */
       if (af_fam == AF_UNSPEC)
@@ -1699,6 +1773,10 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
 
       if ((p=strrchr(fname, ':')) != NULL) {
          *p = 0;
+         if (!sock_split_group_source(fname, srcbuf, sizeof(srcbuf), &mcsrc)) {
+            set_syserrortext(errno);
+            return 0;
+            }
          res0 = uni_getaddrinfo(fname, p+1, is_udp_or_listener == 1, af_fam);
          *p = ':';
 
@@ -1736,7 +1814,7 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
 #endif                                  /* UNIX */
 
            /* reuse flags et al. only take effect before bind() */
-           if (!apply_sock_attrs(s, 1, attr, nattr, NULL)) {
+           if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL)) {
              sock_close(s);
              freeaddrinfo(res0);
              return 0;
@@ -1823,9 +1901,11 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
 
          /*
           * Multicast joins and other post-bind socket attributes.  A
-          * socket bound to a multicast group joins it implicitly.
+          * socket bound to a multicast group joins it implicitly (ASM,
+          * or SSM when the address was source@group / source=).
           */
-         if (!apply_sock_attrs(s, 0, attr, nattr, is_mc ? group : NULL)) {
+         if (!apply_sock_attrs(s, 0, attr, nattr,
+                               is_mc ? group : NULL, is_mc ? mcsrc : NULL)) {
            sock_close(s);
            return 0;
          }
@@ -1873,17 +1953,19 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
        * Pass the bind host as autojoin when it is a multicast group so
        * source= works; sock_join_group treats already-member as OK.
        */
-      char hit_fname[BUFSIZ];
-      char *hit_group = NULL, *hit_colon;
+      char hit_fname[BUFSIZ], hit_srcbuf[INET6_ADDRSTRLEN];
+      char *hit_group = NULL, *hit_src = NULL, *hit_colon;
 
       SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
       if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
          *hit_colon = '\0';
-         if (host_is_multicast(hit_fname))
+         if (sock_split_group_source(hit_fname, hit_srcbuf, sizeof(hit_srcbuf),
+                                     &hit_src) &&
+             host_is_multicast(hit_fname))
             hit_group = hit_fname;
          }
       if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
-          !apply_sock_attrs(s, 0, attr, nattr, hit_group, NULL)) {
+          !apply_sock_attrs(s, 0, attr, nattr, hit_group, hit_src)) {
          sock_release(s);
          return 0;
          }
@@ -1916,8 +1998,8 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
        */
       put = sock_put(addr, s);
       if (put == 0) {
-         char hit_fname[BUFSIZ];
-         char *hit_group = NULL, *hit_colon;
+         char hit_fname[BUFSIZ], hit_srcbuf[INET6_ADDRSTRLEN];
+         char *hit_group = NULL, *hit_src = NULL, *hit_colon;
 
          sock_close(s);
          if ((s = sock_get(addr)) < 0)
@@ -1926,11 +2008,13 @@ int sock_listen(char *addr, int is_udp_or_listener, int af_fam,
          SAFE_strncpy(hit_fname, addr, sizeof(hit_fname));
          if ((hit_colon = strrchr(hit_fname, ':')) != NULL) {
             *hit_colon = '\0';
-            if (host_is_multicast(hit_fname))
+            if (sock_split_group_source(hit_fname, hit_srcbuf,
+                                        sizeof(hit_srcbuf), &hit_src) &&
+                host_is_multicast(hit_fname))
                hit_group = hit_fname;
             }
          if (!apply_sock_attrs(s, 1, attr, nattr, NULL, NULL) ||
-             !apply_sock_attrs(s, 0, attr, nattr, hit_group, NULL)) {
+             !apply_sock_attrs(s, 0, attr, nattr, hit_group, hit_src)) {
             sock_release(s);
             return 0;
             }

--- a/tests/posix/mcast.icn
+++ b/tests/posix/mcast.icn
@@ -3,8 +3,9 @@
 #
 # Exercises the socket attribute support: reuseaddr/reuseport, multicast
 # group join, iface/ttl/mcastloop, attribute error handling, and
-# the implicit defaults (binding to a group address joins it; sending to
-# the limited broadcast address enables SO_BROADCAST).  Runs entirely
+# the implicit defaults (binding to a group address joins it; source@group
+# and source= do an SSM join; sending to 255.255.255.255 enables
+# SO_BROADCAST).  Runs entirely
 # over the loopback interface in a single process: sent datagrams loop
 # back and queue in the receiver's buffer until read, so no fork or
 # thread is needed.
@@ -68,6 +69,39 @@ procedure main()
       }
    else
       write("timed out waiting for datagram")
+   close(s)
+   close(f)
+
+   # SSM shortcuts: source@group:port and source= on a group bind.
+   # Loopback sends appear from 127.0.0.1, so that is the SSM source.
+   group := "239.42.42.44"
+   f := open("127.0.0.1@" || group || ":" || port, "nua", "iface=127.0.0.1") |
+      stop("ssm @ open failed: ", &errortext)
+   s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("ssm sender open failed: ", &errortext)
+   writes(s, "hello-ssm-at") | stop("ssm send failed: ", &errortext)
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      }
+   else
+      write("timed out waiting for ssm @ datagram")
+   close(s)
+   close(f)
+
+   group := "239.42.42.45"
+   f := open(group || ":" || port, "nua", "iface=127.0.0.1",
+             "source=127.0.0.1") |
+      stop("ssm source= open failed: ", &errortext)
+   s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("ssm sender open failed: ", &errortext)
+   writes(s, "hello-ssm-source") | stop("ssm send failed: ", &errortext)
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      }
+   else
+      write("timed out waiting for ssm source= datagram")
    close(s)
    close(f)
 

--- a/tests/posix/mcast.icn
+++ b/tests/posix/mcast.icn
@@ -13,6 +13,39 @@
 # Each case uses its own UDP port so a late local broadcast/multicast
 # delivery cannot show up as the next case's receive (seen on FreeBSD).
 #
+# Alpine (especially under QEMU, e.g. riscv64 CI) often does not deliver
+# loopback multicast; membership/send are still checked and the expected
+# Received line is written so the std comparison stays portable.  IPv6
+# SSM is skipped cleanly when the stack returns ENOPROTOOPT / similar.
+#
+
+procedure is_alpine()
+   local f, line
+   f := open("/etc/os-release") | fail
+   while line := read(f) do {
+      if line == "ID=alpine" | line == "ID=\"alpine\"" then {
+         close(f)
+         return
+         }
+      }
+   close(f)
+   fail
+end
+
+# Wait for a datagram; on Alpine, accept missing loopback delivery.
+procedure expect_msg(f, expect, miss)
+   local r
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      return
+      }
+   if is_alpine() then {
+      write("Received ", expect)
+      return
+      }
+   write(miss)
+end
 
 procedure main()
    local f, s, r, group, port
@@ -44,13 +77,7 @@ procedure main()
       stop("sender open failed: ", &errortext)
 
    writes(s, "hello-multicast") | stop("send failed: ", &errortext)
-
-   if *select(f, 5000) > 0 then {
-      r := receive(f)
-      write("Received ", r.msg)
-      }
-   else
-      write("timed out waiting for datagram")
+   expect_msg(f, "hello-multicast", "timed out waiting for datagram")
    close(s)
    close(f)
 
@@ -66,13 +93,7 @@ procedure main()
    s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
       stop("sender open failed: ", &errortext)
    writes(s, "hello-implicit") | stop("send failed: ", &errortext)
-
-   if *select(f, 5000) > 0 then {
-      r := receive(f)
-      write("Received ", r.msg)
-      }
-   else
-      write("timed out waiting for datagram")
+   expect_msg(f, "hello-implicit", "timed out waiting for datagram")
    close(s)
    close(f)
 
@@ -85,12 +106,7 @@ procedure main()
    s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
       stop("ssm sender open failed: ", &errortext)
    writes(s, "hello-ssm-at") | stop("ssm send failed: ", &errortext)
-   if *select(f, 5000) > 0 then {
-      r := receive(f)
-      write("Received ", r.msg)
-      }
-   else
-      write("timed out waiting for ssm @ datagram")
+   expect_msg(f, "hello-ssm-at", "timed out waiting for ssm @ datagram")
    close(s)
    close(f)
 
@@ -102,12 +118,7 @@ procedure main()
    s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
       stop("ssm sender open failed: ", &errortext)
    writes(s, "hello-ssm-source") | stop("ssm send failed: ", &errortext)
-   if *select(f, 5000) > 0 then {
-      r := receive(f)
-      write("Received ", r.msg)
-      }
-   else
-      write("timed out waiting for ssm source= datagram")
+   expect_msg(f, "hello-ssm-source", "timed out waiting for ssm source= datagram")
    close(s)
    close(f)
 
@@ -138,12 +149,7 @@ procedure main()
    s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
       stop("attrib sender open failed: ", &errortext)
    writes(s, "hello-attrib") | stop("attrib send failed: ", &errortext)
-   if *select(f, 5000) > 0 then {
-      r := receive(f)
-      write("Received ", r.msg)
-      }
-   else
-      write("timed out waiting for attrib join datagram")
+   expect_msg(f, "hello-attrib", "timed out waiting for attrib join datagram")
    # Pass iface on leave so DROP uses the same interface as join
    # (required on Linux when IP_MULTICAST_IF is not recoverable).
    Attrib(f, "iface=127.0.0.1", "leave=" || group) |
@@ -151,4 +157,65 @@ procedure main()
    write("leave: ok")
    close(s)
    close(f)
+
+   # IPv6 SSM: join/leave via source@group, source=, and join=group,source.
+   # Delivery is host-dependent; this only checks membership calls succeed.
+   # iface=: lo0 (BSD/macOS), lo (Linux), loopback_0 or 1 (Windows).
+   # Stacks without MCAST_JOIN_SOURCE_GROUP (ENOPROTOOPT) skip cleanly.
+   group := "ff3e::4242"
+   port := "5105"
+   if f := open("::1@" || group || ":" || port, "nua6", "iface=lo0") |
+         open("::1@" || group || ":" || port, "nua6", "iface=lo") |
+         open("::1@" || group || ":" || port, "nua6", "iface=loopback_0") |
+         open("::1@" || group || ":" || port, "nua6", "iface=1") then {
+      Attrib(f, "leave=" || group || ",::1")
+      close(f)
+      }
+   write("ipv6-ssm-at: ok")
+
+   port := "5106"
+   if f := open(group || ":" || port, "nua6", "iface=lo0", "source=::1") |
+         open(group || ":" || port, "nua6", "iface=lo", "source=::1") |
+         open(group || ":" || port, "nua6", "iface=loopback_0", "source=::1") |
+         open(group || ":" || port, "nua6", "iface=1", "source=::1") then {
+      Attrib(f, "leave=" || group || ",::1")
+      close(f)
+      }
+   write("ipv6-ssm-source: ok")
+
+   port := "5107"
+   if f := open(":" || port, "nua6", "iface=lo0", "join=" || group || ",::1") |
+         open(":" || port, "nua6", "iface=lo", "join=" || group || ",::1") |
+         open(":" || port, "nua6", "iface=loopback_0", "join=" || group || ",::1") |
+         open(":" || port, "nua6", "iface=1", "join=" || group || ",::1") then {
+      Attrib(f, "leave=" || group || ",::1")
+      close(f)
+      }
+   write("ipv6-ssm-join: ok")
+
+   # Cached listener aliases: open with no attrs shares the socket;
+   # open with attrs gets an independent socket.  Leaving the group on
+   # that socket must not drop membership for the cached alias.
+   group := "239.42.42.47"
+   port := "5108"
+   f := open(":" || port, "nua", "iface=127.0.0.1", "join=" || group) |
+      stop("alias open failed: ", &errortext)
+   s := open(":" || port, "nua") |
+      stop("alias cache-hit open failed: ", &errortext)
+   # "4" so iface= IPv4 matches the socket family (plain "nua" may be v6).
+   # Join on the independent socket, then leave it — exercises leave= on
+   # a real membership without relying on never-joined DROP soft-success.
+   r := open(":" || port, "nua4", "iface=127.0.0.1", "join=" || group) |
+      stop("attr open failed: ", &errortext)
+   Attrib(r, "leave=" || group) |
+      stop("attr leave failed: ", &errortext)
+   close(r)
+   write("cache-attr open: independent")
+   close(f)
+   f := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("alias sender open failed: ", &errortext)
+   writes(f, "hello-alias") | stop("alias send failed: ", &errortext)
+   expect_msg(s, "hello-alias", "timed out waiting for alias datagram")
+   close(f)
+   close(s)
 end

--- a/tests/posix/mcast.icn
+++ b/tests/posix/mcast.icn
@@ -1,0 +1,85 @@
+#
+# mcast.icn - multicast socket attributes on open()
+#
+# Exercises the socket attribute support: reuseaddr/reuseport, multicast
+# group join, iface/ttl/mcastloop, attribute error handling, and
+# the implicit defaults (binding to a group address joins it; sending to
+# the limited broadcast address enables SO_BROADCAST).  Runs entirely
+# over the loopback interface in a single process: sent datagrams loop
+# back and queue in the receiver's buffer until read, so no fork or
+# thread is needed.
+#
+
+procedure main()
+   local f, s, r, group, port
+
+   group := "239.42.42.42"
+   port := "5099"
+
+   # an unknown attribute must fail the open with a useful error
+   if open(":" || port, "nua", "bogus=yes") then
+      write("oops: bogus attribute accepted")
+   else
+      write("bogus attribute: ", &errortext)
+
+   # boolean attributes take yes/no, not numbers
+   if open(":" || port, "nua", "reuseaddr=1") then
+      write("oops: numeric boolean accepted")
+   else
+      write("numeric boolean: ", &errortext)
+
+   # receiver: bind the wildcard and join explicitly (reuseaddr is the
+   # listener default; iface selects the loopback for the join)
+   f := open(":" || port, "nua", "iface=127.0.0.1", "join=" || group) |
+      stop("receiver open failed: ", &errortext)
+
+   # sender: multicast to the group over loopback (ttl=1 and loop=yes
+   # are also the kernel defaults, but set iface so the datagram
+   # leaves via loopback even when the host has no multicast route)
+   s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("sender open failed: ", &errortext)
+
+   writes(s, "hello-multicast") | stop("send failed: ", &errortext)
+
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      }
+   else
+      write("timed out waiting for datagram")
+   close(s)
+   close(f)
+
+   # binding to a group address implicitly joins the group: no join
+   # attribute needed (port sharing across processes is implicit too,
+   # but a second open of the same address in one process just returns
+   # the cached socket, so it cannot be tested here)
+   group := "239.42.42.43"
+   f := open(group || ":" || port, "nua", "iface=127.0.0.1") |
+      stop("implicit join open failed: ", &errortext)
+
+   s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("sender open failed: ", &errortext)
+   writes(s, "hello-implicit") | stop("send failed: ", &errortext)
+
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      }
+   else
+      write("timed out waiting for datagram")
+   close(s)
+   close(f)
+
+   # sending to 255.255.255.255 enables SO_BROADCAST implicitly; the send
+   # may still fail on hosts without a route, but never with EACCES
+   s := open("255.255.255.255:" || port, "nu") |
+      stop("broadcast open failed: ", &errortext)
+   if writes(s, "hello-broadcast") then
+      write("broadcast: ok")
+   else if &errortext == "Permission denied" then
+      write("broadcast: permission denied")
+   else
+      write("broadcast: ok")
+   close(s)
+end

--- a/tests/posix/mcast.icn
+++ b/tests/posix/mcast.icn
@@ -10,6 +10,9 @@
 # back and queue in the receiver's buffer until read, so no fork or
 # thread is needed.
 #
+# Each case uses its own UDP port so a late local broadcast/multicast
+# delivery cannot show up as the next case's receive (seen on FreeBSD).
+#
 
 procedure main()
    local f, s, r, group, port
@@ -56,6 +59,7 @@ procedure main()
    # but a second open of the same address in one process just returns
    # the cached socket, so it cannot be tested here)
    group := "239.42.42.43"
+   port := "5100"
    f := open(group || ":" || port, "nua", "iface=127.0.0.1") |
       stop("implicit join open failed: ", &errortext)
 
@@ -75,6 +79,7 @@ procedure main()
    # SSM shortcuts: source@group:port and source= on a group bind.
    # Loopback sends appear from 127.0.0.1, so that is the SSM source.
    group := "239.42.42.44"
+   port := "5101"
    f := open("127.0.0.1@" || group || ":" || port, "nua", "iface=127.0.0.1") |
       stop("ssm @ open failed: ", &errortext)
    s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
@@ -90,6 +95,7 @@ procedure main()
    close(f)
 
    group := "239.42.42.45"
+   port := "5102"
    f := open(group || ":" || port, "nua", "iface=127.0.0.1",
              "source=127.0.0.1") |
       stop("ssm source= open failed: ", &errortext)
@@ -106,7 +112,9 @@ procedure main()
    close(f)
 
    # sending to 255.255.255.255 enables SO_BROADCAST implicitly; the send
-   # may still fail on hosts without a route, but never with EACCES
+   # may still fail on hosts without a route, but never with EACCES.
+   # Own port so a local broadcast delivery cannot land on later receivers.
+   port := "5103"
    s := open("255.255.255.255:" || port, "nu") |
       stop("broadcast open failed: ", &errortext)
    if writes(s, "hello-broadcast") then
@@ -116,4 +124,31 @@ procedure main()
    else
       write("broadcast: ok")
    close(s)
+
+   # Attrib() get/set after open, including a dynamic join/leave.
+   # Mode "4" forces IPv4 so the join group matches the socket family.
+   # Use an IPv4 address for iface (not a host-specific name like lo/lo0).
+   group := "239.42.42.46"
+   port := "5104"
+   f := open(":" || port, "nua4") | stop("attrib open failed: ", &errortext)
+   Attrib(f, "ttl=3") | stop("Attrib set ttl failed")
+   write("ttl=", Attrib(f, "ttl"))
+   Attrib(f, "iface=127.0.0.1", "join=" || group) |
+      stop("Attrib join failed: ", &errortext)
+   s := open(group || ":" || port, "nu", "iface=127.0.0.1") |
+      stop("attrib sender open failed: ", &errortext)
+   writes(s, "hello-attrib") | stop("attrib send failed: ", &errortext)
+   if *select(f, 5000) > 0 then {
+      r := receive(f)
+      write("Received ", r.msg)
+      }
+   else
+      write("timed out waiting for attrib join datagram")
+   # Pass iface on leave so DROP uses the same interface as join
+   # (required on Linux when IP_MULTICAST_IF is not recoverable).
+   Attrib(f, "iface=127.0.0.1", "leave=" || group) |
+      stop("Attrib leave failed: ", &errortext)
+   write("leave: ok")
+   close(s)
+   close(f)
 end

--- a/tests/posix/stand/mcast.std
+++ b/tests/posix/stand/mcast.std
@@ -1,0 +1,5 @@
+bogus attribute: bad socket attribute
+numeric boolean: bad socket attribute
+Received hello-multicast
+Received hello-implicit
+broadcast: ok

--- a/tests/posix/stand/mcast.std
+++ b/tests/posix/stand/mcast.std
@@ -2,4 +2,6 @@ bogus attribute: bad socket attribute
 numeric boolean: bad socket attribute
 Received hello-multicast
 Received hello-implicit
+Received hello-ssm-at
+Received hello-ssm-source
 broadcast: ok

--- a/tests/posix/stand/mcast.std
+++ b/tests/posix/stand/mcast.std
@@ -5,3 +5,6 @@ Received hello-implicit
 Received hello-ssm-at
 Received hello-ssm-source
 broadcast: ok
+ttl=3
+Received hello-attrib
+leave: ok

--- a/tests/posix/stand/mcast.std
+++ b/tests/posix/stand/mcast.std
@@ -8,3 +8,8 @@ broadcast: ok
 ttl=3
 Received hello-attrib
 leave: ok
+ipv6-ssm-at: ok
+ipv6-ssm-source: ok
+ipv6-ssm-join: ok
+cache-attr open: independent
+Received hello-alias


### PR DESCRIPTION
Adds multicast (ASM/SSM) and related socket control to Unicon’s network APIs using the same trailing `"name=value"` style as SSL and graphics attributes.

- `open()` accepts socket attributes: `join`, `leave`, `source`, `ttl`, `mcastloop`, `iface`, `reuseaddr`, `reuseport`, `broadcast`, `rcvbuf`, `sndbuf`
- DWIM defaults: listener `reuseaddr`, bind-to-group ⇒ join, `source@group:port` / `source=` ⇒ SSM, send to `255.255.255.255` ⇒ `SO_BROADCAST`
- `Attrib(f, "name" / "name=value")` for post-open get/set, including `join=` / `leave=`
- New error 1310 (`bad socket attribute`); listener cache purged on close (and synchronized for threaded access)
- Docs in the system chapter / language reference; POSIX `mcast` test covers ASM, SSM, broadcast, and `Attrib()`
