### PR TITLE
 Add native SSH/SFTP client support via libssh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           mingw-w64-ucrt-x86_64-gcc
           mingw-w64-ucrt-x86_64-diffutils
           mingw-w64-ucrt-x86_64-openssl
+          mingw-w64-ucrt-x86_64-libssh
           mingw-w64-ucrt-x86_64-libpng
           mingw-w64-ucrt-x86_64-libjpeg-turbo
           make
@@ -136,6 +137,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+
+    - name: Install dependencies
+      run: brew install libssh
 
     - name: Configure
       run: sh configure  ${{ matrix.cfg.opt }}
@@ -234,27 +238,27 @@ jobs:
            ubuntu*|debian*)
               apt-get update -q -y
               DEBIAN_FRONTEND="noninteractive" apt-get install -q -y build-essential make autotools-dev libc6 libgcc1 libgl1-mesa-dev
-              DEBIAN_FRONTEND="noninteractive" apt-get install -q -y libssl-dev libx11-dev libjpeg-dev libpng-dev libglu1-mesa-dev libxft-dev
+              DEBIAN_FRONTEND="noninteractive" apt-get install -q -y libssl-dev libssh-dev libx11-dev libjpeg-dev libpng-dev libglu1-mesa-dev libxft-dev
               DEBIAN_FRONTEND="noninteractive" apt-get install -q -y libopenal-dev libalut-dev libogg-dev libvorbis-dev unixodbc-dev libfreetype6-dev
               ;;
            oracle*)
               dnf -y update
               dnf -y install git gcc make diffutils libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel
-              dnf -y install openssl-devel unixODBC-devel freetype-devel libXft-devel
+              dnf -y install openssl-devel libssh-devel unixODBC-devel freetype-devel libXft-devel
               ;;
            rocky*)
               dnf -y update
               dnf -y install git gcc make diffutils libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel
-              dnf -y install openssl-devel freetype-devel libXft-devel
+              dnf -y install openssl-devel libssh-devel freetype-devel libXft-devel
               ;;
            fedora*)
               dnf -y update
               dnf -y install gcc make diffutils libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel
-              dnf -y install openal-devel freealut-devel libogg-devel libvorbis-devel openssl-devel unixODBC-devel freetype-devel libXft-devel
+              dnf -y install openal-devel freealut-devel libogg-devel libvorbis-devel openssl-devel libssh-devel unixODBC-devel freetype-devel libXft-devel
               ;;
            alpine*)
               apk update
-              apk add build-base diffutils
+              apk add build-base diffutils libssh-dev
               ;;
             esac
 
@@ -417,7 +421,7 @@ jobs:
         sudo apt-get update
         # sudo apt install -q -y i686-pc-linux-gnu-gcc
         sudo apt-get install -q -y gcc-multilib g++-multilib
-        sudo apt install libssl-dev:i386
+        sudo apt install libssl-dev:i386 libssh-dev:i386
         fi
 
         if [[ "${{ matrix.cfg.name }}" = "Ubuntu arm32" ]]
@@ -491,7 +495,7 @@ jobs:
      with:
       usesh: true # default shell is csh, switch to sh
       prepare: |
-        pkg install -y -f autoconf gmake lang/gcc git
+        pkg install -y -f autoconf gmake lang/gcc git libssh
 
    - name: Configure
      shell: freebsd {0}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -45,6 +45,7 @@ jobs:
           mingw-w64-ucrt-x86_64-gcc
           mingw-w64-ucrt-x86_64-diffutils
           mingw-w64-ucrt-x86_64-openssl
+          mingw-w64-ucrt-x86_64-libssh
           mingw-w64-ucrt-x86_64-libpng
           mingw-w64-ucrt-x86_64-libjpeg-turbo
           make

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Most of these libraries are listed below for common Linux distributions.
 
 Debian/Ubuntu:
 ```
-apt install libgl1-mesa-dev libssl-dev libx11-dev libjpeg-dev libpng-dev libglu1-mesa-dev
+apt install libgl1-mesa-dev libssl-dev libssh-dev libx11-dev libjpeg-dev libpng-dev libglu1-mesa-dev
             libxft-dev libopenal-dev libalut-dev libogg-dev libvorbis-dev unixodbc-dev
 	    libfreetype6-dev
 ```
@@ -105,7 +105,7 @@ Fedora/Centos (Depending on your Centos version, you may need to replace dnf wit
 ```
 dnf install libjpeg-turbo-devel libpng-devel libX11-devel mesa-libGL-devel mesa-libGLU-devel
             freetype-devel openal-devel freealut-devel libogg-devel libvorbis-devel
-	    openssl-devel unixODBC-devel libXft-devel
+	    openssl-devel libssh-devel unixODBC-devel libXft-devel
 ```
 
 Go into the Unicon directory and run:
@@ -128,11 +128,12 @@ explicitly set the compiler as follows:
 ```
 If you want access to the graphics facilities of Unicon, you also need to download
 and install the XQuartz package from https://www.xquartz.org/.
+For native SSH/SFTP support, install libssh (for example `brew install libssh`).
 
 ### *BSD
 Install build dependencies. Make sure to use GNU `gmake` when building.
 ```
-pkg install -y -f autoconf gmake lang/gcc git
+pkg install -y -f autoconf gmake lang/gcc git libssh
 ```
 
 Configure, make, and optionally install unicon:
@@ -163,7 +164,7 @@ pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86
 - Install the optional libraries for a full build (Unicon will build without them but some features
 will be absent).
 ```
-pacman -S mingw-w64-ucrt-x86_64-openssl  mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libjpeg-turbo 
+pacman -S mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-libssh mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libjpeg-turbo 
 ```
 
 - Clone the Unicon repository:

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -326,6 +326,24 @@ fi
 ])
 
 
+AC_DEFUN([CHECK_LIBSSH],
+[
+do_arg_with([libssh])
+if test "x$with_libssh" != "xno"; then
+  # FreeBSD and Homebrew keep headers under a non-default prefix.
+  # Without -I/-L, later compiles can miss <libssh/libssh.h>.
+  if test "x$libssh_HOME" = "x"; then
+    if test -f /usr/local/include/libssh/libssh.h; then
+      libssh_HOME=/usr/local
+    elif test -f /opt/homebrew/include/libssh/libssh.h; then
+      libssh_HOME=/opt/homebrew
+    fi
+  fi
+  do_lib_check([ssh], [${libssh_HOME}], [libssh/libssh.h], [ssh_new], [HAVE_LIBSSH], [C])
+fi
+])
+
+
 AC_DEFUN([CHECK_OPENGL],
 [
 

--- a/configure
+++ b/configure
@@ -784,6 +784,7 @@ enable_concurrency
 enable_pattern
 enable_database
 enable_ssl
+enable_ssh
 enable_audio
 enable_voip
 enable_plugins
@@ -825,6 +826,7 @@ with_jvoip
 with_odbc
 with_pthread
 with_ssl
+with_libssh
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1470,6 +1472,7 @@ Optional Features:
   --disable-pattern       No pattern type support
   --disable-database      No database support
   --disable-ssl           No SSL support
+  --disable-ssh           No SSH support
   --disable-audio         No audio support
   --disable-voip          No VOIP support
   --disable-plugins       No loadfunc or plugins support
@@ -1529,6 +1532,7 @@ Optional Packages:
   --with-odbc[=DIR]       Use odbc package (DIR: custom library path)
   --with-pthread[=DIR]    Use pthread package (DIR: custom library path)
   --with-ssl[=DIR]        Use ssl package (DIR: custom library path)
+  --with-libssh[=DIR]     Use libssh package (DIR: custom library path)
 
 Some influential environment variables:
   CC          C compiler command
@@ -3659,6 +3663,14 @@ then :
   enableval=$enable_ssl; ssl=$enableval
 else $as_nop
   ssl=on
+fi
+
+# Check whether --enable-ssh was given.
+if test ${enable_ssh+y}
+then :
+  enableval=$enable_ssh; ssh=$enableval
+else $as_nop
+  ssh=on
 fi
 
 # Check whether --enable-audio was given.
@@ -6063,11 +6075,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_cxx11+y}
+if test ${ac_cv_prog_cxx_11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_cxx11=no
+  ac_cv_prog_cxx_11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -6109,11 +6121,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_cxx98+y}
+if test ${ac_cv_prog_cxx_98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_cxx98=no
+  ac_cv_prog_cxx_98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -9232,6 +9244,10 @@ if test "x$thin" = "xyes"; then
 
    if test "x$ssl" = "xon"; then
       ssl=no
+   fi
+
+   if test "x$ssh" = "xon"; then
+      ssh=no
    fi
 
    if test "x$multiprograms" = "xon"; then
@@ -17206,6 +17222,311 @@ printf "%s\n" "#define NoDatabase 1" >>confdefs.h
 
 fi
 
+if ! test "x$ssh" = "xno" ; then
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libssh is wanted" >&5
+printf %s "checking if libssh is wanted... " >&6; }
+
+# Check whether --with-libssh was given.
+if test ${with_libssh+y}
+then :
+  withval=$with_libssh; if test x$withval != xno ; then
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+      if test x$withval != xyes ; then
+         libssh_HOME="$withval"
+      fi
+    else
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+    fi
+else $as_nop
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+fi
+
+
+
+if test "x$with_libssh" != "xno"; then
+
+  # FreeBSD and Homebrew keep headers under a non-default prefix.
+  # Without -I/-L, later compiles can miss <libssh/libssh.h>.
+  if test "x$libssh_HOME" = "x"; then
+    if test -f /usr/local/include/libssh/libssh.h; then
+      libssh_HOME=/usr/local
+    elif test -f /opt/homebrew/include/libssh/libssh.h; then
+      libssh_HOME=/opt/homebrew
+    fi
+  fi
+
+if test  x${libssh_HOME} != "x"
+then
+
+	TMP_CPPFLAGS=$CPPFLAGS
+ 	TMP_LDFLAGS=$LDFLAGS
+ 	TMP_CFLAGS=$CFLAGS
+ 	TMP_LIBS=$LIBS
+
+	for part in -I${libssh_HOME}/include
+  	do
+		FOUND=
+		for itm in $CPPFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   CPPFLAGS="$CPPFLAGS $part"
+		fi
+	done
+
+  	for part in -L${libssh_HOME}/lib
+  	do
+		FOUND=
+		for itm in $LDFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   LDFLAGS="$LDFLAGS $part"
+		fi
+	done
+
+
+	cv_libthislib_h=yes
+	       for ac_header in libssh/libssh.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "libssh/libssh.h" "ac_cv_header_libssh_libssh_h" "$ac_includes_default"
+if test "x$ac_cv_header_libssh_libssh_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBSSH_LIBSSH_H 1" >>confdefs.h
+
+else $as_nop
+  cv_libthislib_h=no
+fi
+
+done
+	if test x$cv_libthislib_h == xno ;  then
+
+	CFLAGS=$TMP_CFLAGS
+	LDFLAGS=$TMP_LDFLAGS
+	CPPFLAGS=$TMP_CPPFLAGS
+ 	LIBS=$TMP_LIBS
+
+
+	TMP_CPPFLAGS=$CPPFLAGS
+ 	TMP_LDFLAGS=$LDFLAGS
+ 	TMP_CFLAGS=$CFLAGS
+ 	TMP_LIBS=$LIBS
+
+	for part in -I${libssh_HOME}
+  	do
+		FOUND=
+		for itm in $CPPFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   CPPFLAGS="$CPPFLAGS $part"
+		fi
+	done
+
+  	for part in -L${libssh_HOME}
+  	do
+		FOUND=
+		for itm in $LDFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   LDFLAGS="$LDFLAGS $part"
+		fi
+	done
+
+
+	fi
+else
+
+	TMP_CPPFLAGS=$CPPFLAGS
+ 	TMP_LDFLAGS=$LDFLAGS
+ 	TMP_CFLAGS=$CFLAGS
+ 	TMP_LIBS=$LIBS
+
+	for part in
+  	do
+		FOUND=
+		for itm in $CPPFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   CPPFLAGS="$CPPFLAGS $part"
+		fi
+	done
+
+  	for part in
+  	do
+		FOUND=
+		for itm in $LDFLAGS -a -z $FOUND
+    		do
+			if test $itm = $part
+      			then
+				FOUND=1
+      			fi
+    		done
+
+		if test -z $FOUND ; then
+	   	   LDFLAGS="$LDFLAGS $part"
+		fi
+	done
+
+
+fi
+        ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+	# If we have multiple headers, any missing one will set this to no
+	cv_libthislib_h=yes
+               for ac_header in libssh/libssh.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "libssh/libssh.h" "ac_cv_header_libssh_libssh_h" "$ac_includes_default"
+if test "x$ac_cv_header_libssh_libssh_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBSSH_LIBSSH_H 1" >>confdefs.h
+
+else $as_nop
+  cv_libthislib_h=no
+fi
+
+done
+	if test x$cv_libthislib_h != xno ;  then
+	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing ssh_new" >&5
+printf %s "checking for library containing ssh_new... " >&6; }
+if test ${ac_cv_search_ssh_new+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char ssh_new ();
+int
+main (void)
+{
+return ssh_new ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' ssh
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_ssh_new=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_ssh_new+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_ssh_new+y}
+then :
+
+else $as_nop
+  ac_cv_search_ssh_new=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_ssh_new" >&5
+printf "%s\n" "$ac_cv_search_ssh_new" >&6; }
+ac_res=$ac_cv_search_ssh_new
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+  cv_libssh=yes
+	      if test -n HAVE_LIBSSH ; then
+
+printf "%s\n" "#define HAVE_LIBSSH 1" >>confdefs.h
+
+	      fi
+
+else $as_nop
+  cv_libssh=no
+
+
+	CFLAGS=$TMP_CFLAGS
+	LDFLAGS=$TMP_LDFLAGS
+	CPPFLAGS=$TMP_CPPFLAGS
+ 	LIBS=$TMP_LIBS
+
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lib ssh in (${libssh_HOME})" >&5
+printf %s "checking for lib ssh in (${libssh_HOME})... " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+printf "%s\n" "failed" >&6; }
+
+fi
+
+        else
+
+
+	CFLAGS=$TMP_CFLAGS
+	LDFLAGS=$TMP_LDFLAGS
+	CPPFLAGS=$TMP_CPPFLAGS
+ 	LIBS=$TMP_LIBS
+
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lib ssh in (${libssh_HOME})" >&5
+printf %s "checking for lib ssh in (${libssh_HOME})... " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+printf "%s\n" "failed" >&6; }
+
+	fi
+	ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+fi
+
+fi
+
 # autoconf does this too late, so just do it now...
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
 test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
@@ -19233,6 +19554,21 @@ else
   stmp=" ! SSL"
 fi
 
+# want ssh
+if test "x$ssh" = "xyes" || test "x$ssh" = "xon" ; then
+  if test "x$cv_libssh"      = "xyes" ; then
+     sshtmp=" + SSH                : +ssh"
+  else
+     if test "x$ssh" = "xyes" ; then
+        as_fn_error $? "\"ssh requires libssh-dev or equivalent\"" "$LINENO" 5
+     fi
+     sshtmp=" - SSH                : -ssh"
+  fi
+else
+#disabled ssh
+  sshtmp=" ! SSH"
+fi
+
 revision=`./config/scripts/version.sh "revision"`
 
 san_summary=""
@@ -19276,6 +19612,7 @@ $atmp
 $vtmp
 $dtmp
 $stmp
+$sshtmp
 EOF
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,9 @@ AC_ARG_ENABLE([database],
 AC_ARG_ENABLE([ssl],
 	[AS_HELP_STRING([--disable-ssl], [No SSL support])],
 			[ssl=$enableval], [ssl=on])
+AC_ARG_ENABLE([ssh],
+	[AS_HELP_STRING([--disable-ssh], [No SSH support])],
+			[ssh=$enableval], [ssh=on])
 AC_ARG_ENABLE([audio],
 	[AS_HELP_STRING([--disable-audio], [No audio support])],
 			[audio=$enableval], [audio=on])
@@ -695,6 +698,10 @@ if test "x$thin" = "xyes"; then
       ssl=no
    fi
 
+   if test "x$ssh" = "xon"; then
+      ssh=no
+   fi
+
    if test "x$multiprograms" = "xon"; then
       multiprograms=no
    fi
@@ -927,6 +934,10 @@ if ! test "x$ssl" = "xno" ; then
    CHECK_OPENSSL()
 else
    AC_DEFINE([NoDatabase], [1], [No Database])
+fi
+
+if ! test "x$ssh" = "xno" ; then
+   CHECK_LIBSSH()
 fi
 
 # autoconf does this too late, so just do it now...
@@ -1226,6 +1237,21 @@ else
   stmp=" ! SSL"
 fi
 
+# want ssh
+if test "x$ssh" = "xyes" || test "x$ssh" = "xon" ; then
+  if test "x$cv_libssh"      = "xyes" ; then
+     sshtmp=" + SSH                : +ssh"
+  else
+     if test "x$ssh" = "xyes" ; then
+        AC_MSG_ERROR("ssh requires libssh-dev or equivalent")
+     fi
+     sshtmp=" - SSH                : -ssh"
+  fi
+else
+#disabled ssh
+  sshtmp=" ! SSH"
+fi
+
 revision=`./config/scripts/version.sh "revision"`
 
 san_summary=""
@@ -1269,6 +1295,7 @@ $atmp
 $vtmp
 $dtmp
 $stmp
+$sshtmp
 EOF
 
 

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends:
 	libgcc1,
 	libgl1-mesa-dev,
 	libssl-dev,
+	libssh-dev,
 	libx11-dev,
 	libjpeg-dev,
 	libpng-dev,

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -2989,7 +2989,8 @@ When opening an SSH session (mode \texttt{"h"}), the first argument is a
 host or \texttt{user@host}, optionally with \texttt{:port} (same form as
 socket addresses; IPv6 uses \texttt{[addr]:port}). Trailing attributes
 include \texttt{user=}, \texttt{key=}, \texttt{keypass=},
-\texttt{password=}, \texttt{hostkeyfile=}, \texttt{cmd=}, and
+\texttt{password=}, \texttt{hostkeyfile=}, \texttt{cmd=},
+\texttt{term=}/\texttt{cols=}/\texttt{rows=} (interactive PTY), and
 \texttt{channel=} (\texttt{yes}/\texttt{no}; \texttt{channel=no} is a
 transport-only session). Mode \texttt{"h-"} skips host-key verification.
 \texttt{open(s, ...)} on an existing SSH file opens another channel on

--- a/doc/book/langref.tex
+++ b/doc/book/langref.tex
@@ -1918,6 +1918,11 @@ memberships); bare names query the current value except for
 Boolean values are \texttt{yes}/\texttt{no}; numeric values are
 integers. Socket attributes do not require the Concurrent build
 feature.
+For an SSH channel file, \texttt{Attrib(c, "exitstatus")} produces the
+remote command's exit status (and fails until it has arrived),
+\texttt{Attrib(c, "stderr")} returns stderr bytes accumulated since the
+previous such call, and \texttt{Attrib(c, "eof")} produces 1 once remote
+EOF has been seen.
 For a co-expression or list, integer attribute codes from
 \texttt{threadh.icn} query or set thread inbox/outbox and channel limits
 (see Chapter~8; requires Concurrent).
@@ -2891,6 +2896,8 @@ UDP network socket\\
 IP socket (\texttt{SOCK\_RAW}; requires \texttt{proto=})\\
  \ \ \ \ \texttt{"e"\ \ \ \ } use SSL/TLS protocol to
 encrypt the network socket\\
+ \ \ \ \ \texttt{"h"\ \ \ \ } open an SSH client
+session (requires \texttt{libssh}; see Chapter~6)\\
  \ \ \ \ \texttt{"m"\ \ \ \ }connect to a
 messaging server (HTTP, HTTPS, SMTP, POP, ...)\\
  \ \ \ \ \texttt{"o"\ \ \ \ }open an
@@ -2977,6 +2984,17 @@ For 2D and 3D windows, attribute values may be specified in the
 following arguments to \texttt{open()}. \texttt{open()} fails if a
 window cannot be opened or an attribute cannot be set to a requested
 value.
+
+When opening an SSH session (mode \texttt{"h"}), the first argument is a
+host or \texttt{user@host}, optionally with \texttt{:port} (same form as
+socket addresses; IPv6 uses \texttt{[addr]:port}). Trailing attributes
+include \texttt{user=}, \texttt{key=}, \texttt{keypass=},
+\texttt{password=}, \texttt{hostkeyfile=}, \texttt{cmd=}, and
+\texttt{channel=} (\texttt{yes}/\texttt{no}; \texttt{channel=no} is a
+transport-only session). Mode \texttt{"h-"} skips host-key verification.
+\texttt{open(s, ...)} on an existing SSH file opens another channel on
+the same session; \texttt{open(s, "sftp", "path=\textit{path}", ...)}
+opens a remote file or directory over SFTP. See Chapter~6.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{opmask}
@@ -3165,7 +3183,11 @@ or fails if the conversion cannot be performed.
 to the port associated with \texttt{f}, waiting if necessary. The
 returned value is a record of type \texttt{posix\_message(addr, msg)},
 containing the address of the sender and the contents of the message
-respectively. 
+respectively. For an SSH channel file, \texttt{receive(c)} instead
+yields the next channel event in arrival order: \texttt{addr} is
+\texttt{"stdout"}, \texttt{"stderr"}, or \texttt{"exit"}, and
+\texttt{msg} holds the data (the exit status as a string for
+\texttt{"exit"}).
 
 \bigskip\hrule\vspace{0.1cm}
 \index{remove}
@@ -3174,7 +3196,8 @@ respectively.
 
 \noindent
 \index{remove file}\index{file!remove}\texttt{remove(s)} removes the
-file named \texttt{s}.
+file named \texttt{s}. \texttt{remove(s, path)} removes a remote path
+over SFTP when \texttt{s} is an SSH session file.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{rename}
@@ -3183,7 +3206,8 @@ file named \texttt{s}.
 
 \noindent
 \index{file!rename}\texttt{rename(s1,s2)} renames the file named
-\texttt{s1} to have the name \texttt{s2}.
+\texttt{s1} to have the name \texttt{s2}. \texttt{rename(s, from, to)}
+renames a remote path over SFTP when \texttt{s} is an SSH session file.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{repl}
@@ -3435,7 +3459,10 @@ integers that may be formatted with the \texttt{ctime()} and
 listing option of the UNIX \texttt{ls(1)} command. For example,
 \texttt{"-rwxrwsr-x"} represents a plain
 file with a mode of 2775 (octal). \texttt{stat(f)} fails if filename or
-path \texttt{f} does not exist.
+path \texttt{f} does not exist. \texttt{stat(c)} on an open SFTP file
+uses the remote file handle; \texttt{stat(s, path)} stats a remote path
+on SSH session \texttt{s} without opening it. Fields the SFTP server
+did not send are null rather than zero.
 
 \bigskip\hrule\vspace{0.1cm}
 \index{staticnames}
@@ -5047,6 +5074,12 @@ length\\
 1307 \ \ \ \ \ \ \ private key and certificate mismatch\\
 1308 \ \ \ \ \ \ \ unknown protocol\\
 1310 \ \ \ \ \ \ \ bad socket attribute\\
+1320 \ \ \ \ \ \ \ SSH error\\
+1321 \ \ \ \ \ \ \ bad ssh attribute\\
+1322 \ \ \ \ \ \ \ SSH authentication error\\
+1323 \ \ \ \ \ \ \ SSH host key verification error\\
+1324 \ \ \ \ \ \ \ SSH channel error\\
+1325 \ \ \ \ \ \ \ SFTP error\\
 
 \subsection*{System errors}
 

--- a/doc/book/system.tex
+++ b/doc/book/system.tex
@@ -1055,6 +1055,77 @@ procedure main() \\
 end
 }
 
+\subsection*{Secure Shell (SSH)}
+
+When Unicon is built with \texttt{libssh}, mode \texttt{"h"} opens an
+\index{SSH}SSH client session. The first argument is a host name or
+\texttt{user@host}, optionally with \texttt{:port} (the same
+\texttt{host:port} form as socket \texttt{open()}; IPv6 uses
+\texttt{[addr]:port}). Trailing
+\texttt{"\textit{name}=\textit{value}"} attributes select authentication
+and channel behavior. Connection failures fail with \texttt{\&errortext}
+set (they do not abort), matching the SSL connect path.
+
+\iconcode{
+procedure main() \\
+\>   s := open("user@router.example", "h", "key=~/.ssh/id\_rsa", \\
+\>\>\>\>"cmd=show version") {\textbar} stop(\&errortext) \\
+\>   while write(read(s)) \\
+\>   write("exit status: ", Attrib(s, "exitstatus")) \\
+\>   close(s) \\
+end
+}
+
+Attributes include \texttt{user=},
+\texttt{key=} (private key path), \texttt{keypass=} (passphrase for an
+encrypted key), \texttt{password=} (login password),
+\texttt{hostkeyfile=} (known\_hosts path), \texttt{cmd=} (remote
+command), and \texttt{channel=} (\texttt{yes}/\texttt{no}). With neither
+\texttt{key=} nor \texttt{password=}, the default identities and a
+running agent are tried. Mode \texttt{"h-"} skips host-key verification.
+Without \texttt{cmd=}, an interactive shell on a PTY is opened.
+\texttt{channel=no} opens an authenticated session with no channel
+(useful for SFTP or later \texttt{open(s, ...)} channels);
+\texttt{channel=yes} is the default. Combining \texttt{channel=no} with
+\texttt{cmd=} fails. The default port is 22 when \texttt{:port} is
+omitted.
+
+A second \texttt{open(s, ...)} on an existing SSH file opens another
+channel on the same session (no new handshake). Closing the session
+invalidates every channel derived from it.
+
+\iconcode{
+\>   s := open("user@host", "h", "key=id\_rsa") {\textbar} stop(\&errortext) \\
+\>   c1 := open(s, "cmd=uname -a") \\
+\>   c2 := open(s, "cmd=uptime")
+}
+
+Ordinary \texttt{read}/\texttt{writes} use the remote standard streams.
+\texttt{Attrib(c, "exitstatus")}, \texttt{Attrib(c, "stderr")}, and
+\texttt{Attrib(c, "eof")} report the command's exit status, stderr
+accumulated since the previous call, and whether remote EOF has arrived.
+\texttt{receive(c)} yields ordered events as
+\texttt{posix\_message} records whose \texttt{addr} is
+\texttt{"stdout"}, \texttt{"stderr"}, or \texttt{"exit"}.
+
+SFTP uses the same session. Opening with \texttt{"sftp"} and
+\texttt{path=} transfers a remote file (or lists a remote directory,
+with the same auto-detect behavior as a local directory open).
+\texttt{reads}/\texttt{writes} transfer raw bytes.
+\texttt{stat(s, path)}, \texttt{remove(s, path)}, and
+\texttt{rename(s, from, to)} extend the usual builtins with a leading
+SSH session argument.
+
+\iconcode{
+\>   s := open("user@host", "h", "key=id\_rsa", "channel=no") {\textbar} stop(\&errortext) \\
+\>   c := open(s, "sftp", "path=/tmp/out.bin", "w") {\textbar} stop(\&errortext) \\
+\>   writes(c, ReadBytes("local.bin")) \\
+\>   close(c) \\
+\>   info := stat(s, "/tmp/out.bin") \\
+\>   write("remote size: ", info.size) \\
+\>   close(s)
+}
+
 \section{Messaging Facilities}
 
 Unicon's \index{messaging}messaging facilities provide

--- a/doc/book/system.tex
+++ b/doc/book/system.tex
@@ -1080,11 +1080,16 @@ Attributes include \texttt{user=},
 \texttt{key=} (private key path), \texttt{keypass=} (passphrase for an
 encrypted key), \texttt{password=} (login password),
 \texttt{hostkeyfile=} (known\_hosts path), \texttt{cmd=} (remote
-command), and \texttt{channel=} (\texttt{yes}/\texttt{no}). With neither
+command), and \texttt{channel=} (\texttt{yes}/\texttt{no}). Interactive
+shells also accept \texttt{term=} (terminal type; default \$TERM or
+\texttt{xterm}), \texttt{cols=}, and \texttt{rows=} (PTY size; default
+from the local tty, else 80$\times$24). With neither
 \texttt{key=} nor \texttt{password=}, the default identities and a
 running agent are tried. Mode \texttt{"h-"} skips host-key verification.
 Without \texttt{cmd=}, an interactive shell on a PTY is opened.
-\texttt{channel=no} opens an authenticated session with no channel
+Use \texttt{net::ssh\_interactive(s)} (Unicon class library) to attach
+the local tty: raw mode, \texttt{select} mux with \texttt{\&input}, and
+display CRLF mapping. \texttt{channel=no} opens an authenticated session with no channel
 (useful for SFTP or later \texttt{open(s, ...)} channels);
 \texttt{channel=yes} is the default. Combining \texttt{channel=no} with
 \texttt{cmd=} fails. The default port is 22 when \texttt{:port} is

--- a/src/h/auto.in
+++ b/src/h/auto.in
@@ -206,6 +206,9 @@
 /* Define to 1 if you have the `sqlite3' library (-lsqlite3). */
 #undef HAVE_LIBSQLITE3
 
+/* Define to 1 if you have lib ssh */
+#undef HAVE_LIBSSH
+
 /* Define to 1 if you have lib ssl */
 #undef HAVE_LIBSSL
 

--- a/src/h/feature.h
+++ b/src/h/feature.h
@@ -179,6 +179,10 @@
    Feature(1, "_SSL", "secure sockets layer encryption")
 #endif                  /* HAVE_LIBSSL */
 
+#ifdef HAVE_LIBSSH
+   Feature(1, "_SSH", "secure shell")
+#endif                  /* HAVE_LIBSSH */
+
 #ifdef HAVE_VOICE
    Feature(1, "_VOIP", "Voice Over IP")
 #endif                  /* HAVE_VOICE */

--- a/src/h/grttin.h
+++ b/src/h/grttin.h
@@ -319,6 +319,24 @@ typedef int DIR;
 typedef int SSL_CTX, SSL, SSL_METHOD;
 #endif                                  /* LIBSSL */
 
+#if HAVE_LIBSSH
+typedef int ssh_session, ssh_channel, ssh_key, sftp_session, sftp_file, sftp_dir;
+typedef int sftp_attributes;
+typedef int uint32_t;
+/*
+ * rtt only needs to parse member accesses on the callbacks struct;
+ * the generated C sees the real definition from libssh/callbacks.h.
+ */
+struct ssh_channel_callbacks_struct {
+   size_t size;
+   void *userdata;
+   void *channel_data_function;
+   void *channel_eof_function;
+   void *channel_exit_status_function;
+   };
+typedef struct ssh_channel_callbacks_struct *ssh_channel_callbacks;
+#endif                                  /* HAVE_LIBSSH */
+
 #ifdef Concurrent
        typedef int pthread_key_t, sigset_t;
 #endif                                  /* Concurrent */

--- a/src/h/rmacros.h
+++ b/src/h/rmacros.h
@@ -69,6 +69,10 @@
   #define Fs_Encrypt   0200000000      /* encrypted sockets */
 #endif
 
+#if HAVE_LIBSSH
+  #define Fs_SSH       0400000000     /* ssh session/channel */
+#endif
+
 #endif                                  /* PosixFns */
 
 #ifdef ISQL

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -1181,6 +1181,7 @@ int ssh_file_write(struct SSHfile *sshf, char *s, word n);
 int ssh_getstrg(char *buf, int maxi, struct SSHfile *sshf);
 int ssh_pump(struct SSHfile *sshf, int block, int want_stdout);
 int ssh_chan_read(struct SSHfile *sshf, char *buf, int n, int block);
+int ssh_file_pending(struct b_file *fp);
 void ssh_drain_stderr(struct SSHfile *sshf, dptr d);
 struct SSHfile *create_sftp_file(struct SSHfile *sf, dptr attr, int n,
                                  int status, int *isdir);

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -1031,6 +1031,15 @@ dptr u_read                     (dptr f, int n, int fstatus, dptr d);
 void dup_fds                    (dptr d_stdin, dptr d_stdout, dptr d_stderr);
 int set_if_selectable           (struct descrip *f, fd_set *fdsp, int *n);
 void post_if_ready              (dptr ldp, dptr f, fd_set *fdsp);
+#if NT
+int win_crt_selectable          (unsigned int status);
+int win_crt_pending             (struct b_file *fp);
+struct b_list *findactivecrt    (struct b_list *lcs);
+int win_console_set_raw         (int fd, int raw);
+#endif                                  /* NT */
+#if UNIX
+int unix_tty_set_raw            (int fd, int raw);
+#endif                                  /* UNIX */
 #endif                                  /* PosixFns */
 
 #if COMPILER

--- a/src/h/rproto.h
+++ b/src/h/rproto.h
@@ -1172,6 +1172,25 @@ int set_ssl_connection_errortext(SSL *ssl, int err);
 void set_ssl_context_errortext(int err, char* errtext);
 #endif                                  /* HAVE_LIBSSL */
 
+#if HAVE_LIBSSH
+void set_ssh_errortext(ssh_session sess, int err);
+struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_verify);
+struct SSHfile *create_ssh_channel(struct SSHfile *sf, dptr spec, dptr attr, int n);
+void ssh_close_file(struct SSHfile *sshf);
+int ssh_file_write(struct SSHfile *sshf, char *s, word n);
+int ssh_getstrg(char *buf, int maxi, struct SSHfile *sshf);
+int ssh_pump(struct SSHfile *sshf, int block, int want_stdout);
+int ssh_chan_read(struct SSHfile *sshf, char *buf, int n, int block);
+void ssh_drain_stderr(struct SSHfile *sshf, dptr d);
+struct SSHfile *create_sftp_file(struct SSHfile *sf, dptr attr, int n,
+                                 int status, int *isdir);
+int ssh_sftp_readdir(struct SSHfile *sshf, char *buf, int maxi);
+int ssh_sftp_stat_rec(struct SSHfile *sf, char *path, int use_fstat,
+                      struct descrip *dp, struct b_record **rp);
+int ssh_sftp_unlink(struct SSHfile *sf, char *path);
+int ssh_sftp_rename(struct SSHfile *sf, char *from, char *to);
+#endif                                  /* HAVE_LIBSSH */
+
 #ifdef GenericBSD
 /* in common/save.c */
 int wrtexec(int ef);

--- a/src/h/rstructs.h
+++ b/src/h/rstructs.h
@@ -115,6 +115,62 @@ struct b_unicset {
    };
 #endif                          /* Unicode */
 
+#if HAVE_LIBSSH
+/*
+ * One tagged chunk of SSH channel traffic, kept in true arrival order.
+ * The libssh data/exit-status callbacks append chunks as messages are
+ * parsed off the wire -- the only way to preserve stdout/stderr
+ * ordering, since the plain channel-read API buffers the two streams
+ * separately.  Plain reads consume stdout chunks; Attrib(c,"stderr")
+ * drains stderr chunks; receive(c) pops whatever is at the head.
+ */
+#define SSH_CHUNK_STDOUT 0
+#define SSH_CHUNK_STDERR 1
+#define SSH_CHUNK_EXIT   2
+
+struct SSHchunk {
+   struct SSHchunk *next;
+   int tag;                     /* SSH_CHUNK_* */
+   int off;                     /* stdout bytes already consumed by reads */
+   int len;
+   char data[1];                /* allocated to hold len bytes */
+   };
+
+/*
+ * Per-file SSH state.  Allocated with malloc (like the Messaging MFile)
+ * so pointers to it are stable across garbage collections; freed by the
+ * close hook, never by the collector.
+ *
+ * One file opened as an SSH session owns the ssh_session; channels
+ * opened on it share that session and link themselves into the owner's
+ * children list so that closing the session can close every channel
+ * derived from it.
+ */
+struct SSHfile {
+   ssh_session sess;            /* connection (owned by the session file) */
+   ssh_channel chan;            /* NULL unless this is an exec/shell channel */
+   sftp_session sftp;           /* the session's sftp subsystem, shared by
+                                 * every sftp file/dir; created lazily and
+                                 * freed by the owner */
+   sftp_file sfile;             /* non-NULL for an open sftp regular file */
+   sftp_dir sdir;               /* non-NULL for an open sftp directory */
+   struct SSHfile *parent;      /* session owner; NULL if this is the owner */
+   struct SSHfile *children;    /* head of channel list (session owner only) */
+   struct SSHfile *next;        /* sibling link in the owner's channel list */
+   int nl_pending;              /* line reads: a '\n' was seen but not yet consumed */
+   struct SSHchunk *qhead;      /* arrival-order event queue */
+   struct SSHchunk *qtail;
+   word q_stdout;               /* unconsumed stdout bytes in the queue */
+   void *cbs;                   /* registered ssh_channel_callbacks */
+   int eof_seen;                /* remote sent EOF on the channel */
+   int exit_seen;               /* exit_status below is valid */
+   int exit_status;
+   int closed;                  /* set when cascade-invalidated by close()
+                                 * of the owning session; Icon file still
+                                 * holds this SSHfile until its own close */
+   };
+#endif                                  /* HAVE_LIBSSH */
+
 /*
  * This union was pulled out of struct b_file and made non-anonymous
  * in order to eliminate an error in some version of gcc on amd64.
@@ -142,6 +198,9 @@ union f {
 #if HAVE_LIBSSL
     SSL *ssl;
 #endif                                  /* HAVE_LIBSSL */
+#if HAVE_LIBSSH
+    struct SSHfile *sshf;
+#endif                                  /* HAVE_LIBSSH */
    int fd;        /*   other int-based file descriptor */
    };
 

--- a/src/h/sys.h
+++ b/src/h/sys.h
@@ -454,6 +454,12 @@
 
 #endif                                  /* HAVE_LIBSSL */
 
+#ifdef HAVE_LIBSSH
+#include <libssh/libssh.h>
+#include <libssh/callbacks.h>
+#include <libssh/sftp.h>
+#endif                                  /* HAVE_LIBSSH */
+
 /* On some systems we get a definition of offsetof() and on some we don't.
  * Include stddef.h just in case: guards within stddef.h should prevent double inclusion.
  */

--- a/src/iconc/ccomp.c
+++ b/src/iconc/ccomp.c
@@ -318,6 +318,10 @@ Deliberate Syntax Error
    buf = growcat(buf, &buflen, 1, " -lssl -lcrypto");
 #endif                                  /* HAVE_LIBSSL */
 
+#if HAVE_LIBSSH
+   buf = growcat(buf, &buflen, 1, " -lssh");
+#endif                                  /* HAVE_LIBSSH */
+
 #if NTGCC
    buf = growcat(buf, &buflen, 1, " -lwinmm -lwsock32 -lodbc32 -lws2_32");
 #endif                                  /* NTGCC */

--- a/src/runtime/data.r
+++ b/src/runtime/data.r
@@ -457,6 +457,15 @@ struct errtab errtab[] = {
    1310, "bad socket attribute",
 #endif                                  /* PosixFns */
 
+#ifdef HAVE_LIBSSH
+   1320, "SSH error",
+   1321, "bad ssh attribute",
+   1322, "SSH authentication error",
+   1323, "SSH host key verification error",
+   1324, "SSH channel error",
+   1325, "SFTP error",
+#endif                                  /* HAVE_LIBSSH */
+
 /*
  * End of operating-system specific code.
  */

--- a/src/runtime/errmsg.r
+++ b/src/runtime/errmsg.r
@@ -163,6 +163,32 @@ int set_ssl_connection_errortext(SSL *ssl, int err)
 }
 #endif                          /* HAVE_LIBSSL */
 
+#if HAVE_LIBSSH
+/*
+ * set &errornumber and &errortext from a libssh session error.
+ * err is one of the 132x SSH error codes from the errtab above,
+ * used as &errornumber and as the fallback message when the
+ * session has no error string of its own.
+ */
+void set_ssh_errortext(ssh_session sess, int err)
+{
+   int buflen;
+   char *buf = NULL;
+   CURTSTATE();
+
+   k_errornumber = err;
+   if (sess != NULL)
+      buf = (char *) ssh_get_error(sess);
+   if (buf == NULL || *buf == '\0') {
+      set_errortext(err);
+      return;
+   }
+   buflen = strlen(buf);
+   if ((StrLoc(k_errortext) = alcstr(buf, buflen)) != NULL)
+      StrLen(k_errortext) = buflen;
+}
+#endif                          /* HAVE_LIBSSH */
+
 /*
  * set &errno and &errortext based on a system call failure that set errno.
  * TODO: avoid allocations in most cases.

--- a/src/runtime/fmisc.r
+++ b/src/runtime/fmisc.r
@@ -3059,7 +3059,7 @@ MissingFuncV(signal)
  */
 #if defined(Concurrent) || defined(PosixFns)
 
-"Attrib(argv[]) - read/write attributes (threads, sockets, ...)"
+"Attrib(argv[]) - read/write attributes (threads, sockets, ttys, ...)"
 
 function{*} Attrib(argv[argc])
    abstract {
@@ -3069,6 +3069,7 @@ function{*} Attrib(argv[argc])
 
       /*
        * Attrib() dispatches on the type of its first argument:
+       *   - file + "tty=…": local tty/console raw/sane mode
        *   - socket file: WAttrib-style "name" / "name=value" strings
        *   - co-expression / list / integer codes: thread/channel attrs
        */
@@ -3212,6 +3213,100 @@ function{*} Attrib(argv[argc])
 #endif                                  /* HAVE_LIBSSH */
 
 #ifdef PosixFns
+      /*
+       * TTY mode on a file (&input, etc.): Attrib(f, "tty=raw") /
+       * Attrib(f, "tty=sane").  Entered only when the first attribute
+       * is a tty name so other non-socket Attrib forms are untouched.
+       */
+      if (is:file(argv[0]) &&
+          !(BlkD(argv[0], File)->status & (Fs_Socket
+#if HAVE_LIBSSH
+                                          | Fs_SSH
+#endif                                  /* HAVE_LIBSSH */
+                                          ))) {
+         tended struct descrip sbuf, ans;
+         word i;
+         int fd, status, raw, rv;
+         char *p, *end, *eq;
+         long nlen;
+
+         if (argc >= 2 && !is:null(argv[1]) &&
+             cnv:tmp_string(argv[1], sbuf)) {
+            p = StrLoc(sbuf);
+            end = p + StrLen(sbuf);
+            for (eq = p; eq < end; eq++)
+               if (*eq == '=') break;
+            nlen = (eq < end) ? (eq - p) : StrLen(sbuf);
+            if (nlen == 3 && strncmp(p, "tty", 3) == 0) {
+               status = BlkD(argv[0], File)->status;
+               if (!(status & Fs_Read) && !(status & Fs_Write))
+                  runerr(174, argv[0]);
+               /*
+                * Console &input may be tagged Fs_Window while fd.fp is
+                * still stdin; get_fd() then returns -1 on MS Windows.
+                */
+#ifdef Graphics
+               if ((status & Fs_Window) &&
+                   (BlkD(argv[0], File)->fd.fp == stdin ||
+                    BlkD(argv[0], File)->fd.fp == stdout ||
+                    BlkD(argv[0], File)->fd.fp == stderr))
+#if NT
+                  fd = _fileno(BlkD(argv[0], File)->fd.fp);
+#else                                   /* NT */
+                  fd = fileno(BlkD(argv[0], File)->fd.fp);
+#endif                                  /* NT */
+               else
+#endif                                  /* Graphics */
+                  fd = get_fd(argv[0], 0);
+               if (fd < 0)
+                  runerr(174, argv[0]);
+
+               for (i = 1; i < argc; i++) {
+                  if (is:null(argv[i]))
+                     continue;
+                  if (!cnv:tmp_string(argv[i], sbuf))
+                     runerr(109, argv[i]);
+                  p = StrLoc(sbuf);
+                  end = p + StrLen(sbuf);
+                  for (eq = p; eq < end; eq++)
+                     if (*eq == '=') break;
+                  nlen = (eq < end) ? (eq - p) : StrLen(sbuf);
+                  if (nlen != 3 || strncmp(p, "tty", 3) != 0)
+                     runerr(1310, argv[i]);
+                  if (eq >= end)
+                     runerr(1310, argv[i]); /* query not supported */
+
+                  {
+                  long vlen = end - (eq + 1);
+                  if (vlen == 3 && strncmp(eq + 1, "raw", 3) == 0)
+                     raw = 1;
+                  else if ((vlen == 4 && strncmp(eq + 1, "sane", 4) == 0) ||
+                           (vlen == 6 && strncmp(eq + 1, "cooked", 6) == 0))
+                     raw = 0;
+                  else
+                     runerr(205, argv[i]);
+                  }
+
+#if NT
+                  rv = win_console_set_raw(fd, raw);
+#elif UNIX
+                  rv = unix_tty_set_raw(fd, raw);
+#else                                   /* NT / UNIX */
+                  runerr(121, argv[0]);
+                  rv = -1;
+#endif                                  /* NT / UNIX */
+                  if (rv != 0)
+                     fail;
+                  MakeStr(eq + 1, end - (eq + 1), &ans);
+                  Protect(StrLoc(ans) = alcstr(StrLoc(ans), StrLen(ans)),
+                          runerr(0));
+                  suspend ans;
+                  }
+               fail;
+               }
+            }
+         }
+
       /*
        * Socket attributes: Attrib(f, "ttl=4") sets, Attrib(f, "ttl")
        * gets.  Same names as open() trailing attributes; join/leave add or

--- a/src/runtime/fmisc.r
+++ b/src/runtime/fmisc.r
@@ -3081,6 +3081,136 @@ function{*} Attrib(argv[argc])
 
       if (argc == 0) runerr(130, nulldesc);
 
+#if HAVE_LIBSSH
+      /*
+       * SSH channel attributes (query only):
+       *   Attrib(c, "exitstatus")  the remote command's exit status,
+       *                            or fails until it has arrived
+       *   Attrib(c, "stderr")      stderr accumulated since the last
+       *                            such call (a possibly empty string)
+       *   Attrib(c, "eof")         1 once the remote sent EOF, else 0
+       */
+      if (is:file(argv[0]) && (BlkD(argv[0],File)->status & Fs_SSH)) {
+         tended struct descrip ans;
+         struct SSHfile *sshf = BlkD(argv[0],File)->fd.sshf;
+         word i;
+#ifdef Concurrent
+         word ssh_mtx = BlkD(argv[0],File)->mutexid;
+#endif                                  /* Concurrent */
+
+         if (argc < 2)
+            runerr(130, nulldesc);
+         if (sshf == NULL)
+            runerr(174, argv[0]);
+
+         for (i = 1; i < argc; i++) {
+            tended struct descrip sbuf;
+            char *p;
+
+            if (is:null(argv[i]))
+               continue;
+            if (!cnv:tmp_string(argv[i], sbuf))
+               runerr(109, argv[i]);
+            p = StrLoc(sbuf);
+
+            if (StrLen(sbuf) == 10 && strncmp(p, "exitstatus", 10) == 0) {
+               /*
+                * Pump until the exit-status callback has fired (or the
+                * channel is done with no status).  Prefer callback state
+                * over libssh's blocking get_exit_* helpers, which are
+                * version-sensitive and unnecessary once callbacks are
+                * registered.
+                */
+               if (sshf->closed)
+                  fail;
+#ifdef Concurrent
+               MUTEX_LOCKID_CONTROLLED(ssh_mtx);
+#endif                                  /* Concurrent */
+               DEC_NARTHREADS;
+               while (!sshf->exit_seen) {
+                  int prc;
+                  if (sshf->chan == NULL || sshf->eof_seen ||
+                      ssh_channel_is_eof(sshf->chan))
+                     break;
+                  prc = ssh_pump(sshf, 1, 0);
+                  if (prc < 0) {
+                     INC_NARTHREADS_CONTROLLED;
+#ifdef Concurrent
+                     MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+                     set_ssh_errortext(sshf->sess, 1324);
+                     fail;
+                     }
+                  if (prc == 0)
+                     break;             /* EOF, still no exit status */
+                  }
+               INC_NARTHREADS_CONTROLLED;
+               if (!sshf->exit_seen) {
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+                  fail;
+                  }
+               {
+               int es = sshf->exit_status;
+#ifdef Concurrent
+               MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+               suspend C_integer es;
+               }
+               }
+            else if (StrLen(sbuf) == 6 && strncmp(p, "stderr", 6) == 0) {
+               if (sshf->closed)
+                  fail;
+#ifdef Concurrent
+               MUTEX_LOCKID_CONTROLLED(ssh_mtx);
+#endif                                  /* Concurrent */
+               DEC_NARTHREADS;
+               if (ssh_pump(sshf, 0, 0) < 0) {
+                  INC_NARTHREADS_CONTROLLED;
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+                  set_ssh_errortext(sshf->sess, 1324);
+                  fail;
+                  }
+               INC_NARTHREADS_CONTROLLED;
+               ssh_drain_stderr(sshf, &ans);
+#ifdef Concurrent
+               MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+               suspend ans;
+               }
+            else if (StrLen(sbuf) == 3 && strncmp(p, "eof", 3) == 0) {
+               int eofv;
+               if (sshf->closed)
+                  fail;
+#ifdef Concurrent
+               MUTEX_LOCKID_CONTROLLED(ssh_mtx);
+#endif                                  /* Concurrent */
+               DEC_NARTHREADS;
+               if (ssh_pump(sshf, 0, 0) < 0) {
+                  INC_NARTHREADS_CONTROLLED;
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+                  set_ssh_errortext(sshf->sess, 1324);
+                  fail;
+                  }
+               INC_NARTHREADS_CONTROLLED;
+               eofv = sshf->eof_seen ? 1 : 0;
+#ifdef Concurrent
+               MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+               suspend C_integer eofv;
+               }
+            else
+               runerr(1321, argv[i]);
+            }
+         fail;
+         }
+#endif                                  /* HAVE_LIBSSH */
+
 #ifdef PosixFns
       /*
        * Socket attributes: Attrib(f, "ttl=4") sets, Attrib(f, "ttl")

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -1940,6 +1940,60 @@ function{0,1} reads(f,i)
             }
 #endif                                  /* HAVE_LIBSSH */
          if (status & Fs_Socket) {
+#if HAVE_LIBSSH
+            /*
+             * SSH channel (not SFTP): raw byte stream via u_read.
+             * sock_getstrg() is line-oriented and blocks until '\\n', so
+             * an interactive prompt like "host$ " would hang forever
+             * with the bytes stuck inside ssh_getstrg()'s local buffer.
+             * (SFTP regular files are handled above; read() stays
+             * line-oriented via ssh_getstrg.)
+             */
+            if ((status & Fs_SSH) && BlkD(f,File)->fd.sshf != NULL &&
+                BlkD(f,File)->fd.sshf->sfile == NULL &&
+                BlkD(f,File)->fd.sshf->sdir == NULL) {
+               if (i < 0) {
+                  /* reads(f, -1): concatenate until EOF */
+                  tended struct descrip chunk;
+                  StrLen(s) = 0;
+                  StrLoc(s) = "";
+                  for (;;) {
+                     DEC_NARTHREADS;
+                     if (u_read(&f, MaxReadStr, status, &chunk) == 0) {
+                        INC_NARTHREADS_CONTROLLED;
+                        if (StrLen(s) == 0)
+                           fail;
+                        return s;
+                        }
+                     INC_NARTHREADS_CONTROLLED;
+                     Protect(reserve(Strings, StrLen(s) + StrLen(chunk)),
+                             runerr(0));
+                     if (StrLen(s) > 0 &&
+                         !InRange(strbase, StrLoc(s), strfree)) {
+                        Protect((StrLoc(s) =
+                                 alcstr(StrLoc(s), StrLen(s))), runerr(0));
+                        }
+                     if (StrLen(s) == 0)
+                        s = chunk;
+                     else {
+                        Protect(sptr = alcstr(StrLoc(chunk), StrLen(chunk)),
+                                runerr(0));
+                        StrLen(s) += StrLen(chunk);
+                        }
+                     }
+                  }
+               DEC_NARTHREADS;
+               if (u_read(&f, i, status, &s) == 0) {
+                  INC_NARTHREADS_CONTROLLED;
+                  fail;
+                  }
+               INC_NARTHREADS_CONTROLLED;
+               /* reads(f, 0): nonblocking; fail if nothing available */
+               if (i == 0 && StrLen(s) == 0)
+                  fail;
+               return s;
+               }
+#endif                                  /* HAVE_LIBSSH */
 #if HAVE_LIBSSH && defined(Concurrent)
             if (status & Fs_SSH)
                MUTEX_LOCKID_CONTROLLED(BlkD(f,File)->mutexid);
@@ -2007,7 +2061,8 @@ function{0,1} reads(f,i)
          * implemented after release: all I/O is low-level, no stdio. This
          * makes the Fs_Buff/Fs_Unbuf go away and select will work --
          * correctly. */
-        if (strcmp(StrLoc(BlkD(f,File)->fname), "pipe") != 0) {
+        if (!(status & Fs_Unbuf) &&
+            strcmp(StrLoc(BlkD(f,File)->fname), "pipe") != 0) {
             status |= Fs_Buff;
             BlkLoc(f)->File.status = status;
         }

--- a/src/runtime/fsys.r
+++ b/src/runtime/fsys.r
@@ -59,6 +59,27 @@ function{0,1} close(f)
 #endif                                  /* Messaging */
 
 #ifdef PosixFns
+#if HAVE_LIBSSH
+      /*
+       * SSH session/channel/sftp (with or without Fs_Socket): free the
+       * libssh objects.  Cascade-close of a session invalidates children.
+       */
+      if (status & Fs_SSH) {
+#ifdef Concurrent
+         MUTEX_LOCKID_CONTROLLED(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+         ssh_close_file(BlkD(f,File)->fd.sshf);
+#ifdef Concurrent
+         MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+         BlkLoc(f)->File.fd.sshf = NULL;
+         BlkLoc(f)->File.status = 0;
+         BlkLoc(f)->File.sock_gen = 0;
+         StrLoc(BlkLoc(f)->File.fname) = "closed ssh";
+         StrLen(BlkLoc(f)->File.fname) = 10;
+         return C_integer 0;
+         }
+#endif                                  /* HAVE_LIBSSH */
       if (BlkD(f,File)->status & Fs_Socket) {
 #if HAVE_LIBSSL
         if(status & Fs_Encrypt) {
@@ -274,6 +295,121 @@ function{0,1} open(fname, spec)
       tended struct descrip filename;
       }
 
+   abstract {
+      return file
+      }
+
+#if HAVE_LIBSSH
+   /*
+    * open(s, attrs...) where s is an SSH session or channel file: open
+    * a new channel on the same underlying session, reusing the
+    * transport and authentication (no new handshake).
+    */
+   if is:file(fname) then {
+      body {
+         tended struct descrip chanfname;
+         struct SSHfile *chansshf;
+         struct b_file *cfl;
+         int chanstatus;
+         int want_sftp = 0;
+         int isdir = 0;
+         word ai;
+
+         if (!(BlkD(fname,File)->status & Fs_SSH))
+            runerr(103, fname);
+         if (BlkD(fname,File)->fd.sshf == NULL)
+            runerr(103, fname);
+
+         /*
+          * An "sftp" selector (in spec or any trailing attribute)
+          * routes to the SFTP subsystem instead of a shell/exec
+          * channel.  Read/write intent comes from spec's mode chars.
+          */
+         /*
+          * Mode intent and the "sftp" selector may appear in spec or in
+          * any trailing attribute (open(s,"sftp","path=..","w")).  Scan
+          * every mode-only token (no '='); leave key=value attributes to
+          * create_sftp_file / create_ssh_channel.
+          */
+         chanstatus = Fs_SSH;
+         for (ai = -1; ai < n; ai++) {
+            word k;
+            dptr dp = (ai < 0) ? &spec : &attr[ai];
+            if (is:null(*dp) || !cnv:tmp_string(*dp, filename))
+               continue;
+            if (StrLen(filename) == 4 && strncmp(StrLoc(filename), "sftp", 4) == 0) {
+               want_sftp = 1;
+               continue;
+               }
+            for (k = 0; k < StrLen(filename); k++)
+               if (StrLoc(filename)[k] == '=')
+                  break;
+            if (k < StrLen(filename))
+               continue;                /* a key=value attribute */
+            for (k = 0; k < StrLen(filename); k++) {
+               switch (StrLoc(filename)[k]) {
+                  case 'r': case 'R': chanstatus |= Fs_Read; break;
+                  case 'w': case 'W': chanstatus |= Fs_Write; break;
+                  case 'a': case 'A': chanstatus |= Fs_Write|Fs_Append; break;
+                  case 'b': case 'B': chanstatus |= Fs_Read|Fs_Write; break;
+                  }
+               }
+            }
+         if (!(chanstatus & (Fs_Read|Fs_Write)))
+            chanstatus |= Fs_Read;      /* default to reading */
+
+         if (want_sftp) {
+#ifdef Concurrent
+            MUTEX_LOCKID_CONTROLLED(BlkD(fname,File)->mutexid);
+#endif                                  /* Concurrent */
+            chansshf = create_sftp_file(BlkD(fname,File)->fd.sshf,
+                                        attr, n, chanstatus, &isdir);
+#ifdef Concurrent
+            MUTEX_UNLOCKID(BlkD(fname,File)->mutexid);
+#endif                                  /* Concurrent */
+            if (chansshf == NULL)
+               fail;                    /* &errortext already set */
+            if (isdir)
+               chanstatus = Fs_SSH | Fs_Read | Fs_Directory;
+            else {
+               /*
+                * SFTP regular files are plain streams, not sockets:
+                * reads()/writes() transfer raw bytes (design §9.1).
+                */
+               /* chanstatus already has Fs_SSH | Fs_Read/Write */
+               }
+            }
+         else {
+#ifdef Concurrent
+            MUTEX_LOCKID_CONTROLLED(BlkD(fname,File)->mutexid);
+#endif                                  /* Concurrent */
+            chansshf = create_ssh_channel(BlkD(fname,File)->fd.sshf,
+                                          &spec, attr, n);
+#ifdef Concurrent
+            MUTEX_UNLOCKID(BlkD(fname,File)->mutexid);
+#endif                                  /* Concurrent */
+            if (chansshf == NULL)
+               fail;                    /* &errortext already set */
+            chanstatus = Fs_SSH | Fs_Socket | Fs_Read | Fs_Write;
+            }
+
+         chanfname = BlkD(fname,File)->fname;
+         Protect(cfl = alcfile(0, chanstatus, &chanfname), runerr(0));
+         cfl->fd.sshf = chansshf;
+         cfl->sock_gen = 0;
+#ifdef Concurrent
+         /*
+          * Channels on one session share the session's mutex so that
+          * the existing I/O locking serializes them; libssh sessions
+          * are not safe for uncoordinated concurrent access.
+          */
+         cfl->mutexid = BlkD(fname,File)->mutexid;
+#endif                                  /* Concurrent */
+         return file(cfl);
+         }
+      }
+#endif                                  /* HAVE_LIBSSH */
+
    /*
     * fopen and popen require a C string, but it looks terrible in
     *  error messages, so convert it to a string here and use a local
@@ -287,10 +423,6 @@ function{0,1} open(fname, spec)
     */
    if !def:tmp_string(spec, letr) then
       runerr(103, spec)
-
-   abstract {
-      return file
-      }
 
    body {
       tended char *fnamestr;
@@ -394,6 +526,12 @@ Deliberate Syntax Error
 #if HAVE_LIBSSL
                status |= Fs_Encrypt;
 #endif                                  /* HAVE_LIBSSL */
+               continue;
+            case 'h':
+            case 'H':
+#if HAVE_LIBSSH
+               status |= Fs_SSH;
+#endif                                  /* HAVE_LIBSSH */
                continue;
             case 'a':
             case 'A':
@@ -934,6 +1072,29 @@ Deliberate Syntax Error
 #if HAVE_LIBSSL
         SSL *ssl;
 #endif                                  /* HAVE_LIBSSL */
+#if HAVE_LIBSSH
+         if (status & Fs_SSH) {
+            struct SSHfile *sshf;
+            /*
+             * With a channel, Fs_Socket routes stream I/O through the
+             * existing socket dispatch points.  channel=no leaves a
+             * transport-only session (Fs_SSH alone) for later
+             * open(s, ...) / SFTP.
+             */
+            sshf = create_ssh_session(fnamestr, attr, n, do_verify);
+            if (sshf == NULL)
+               fail;                    /* &errortext already set */
+            if (sshf->chan != NULL)
+               status |= Fs_Socket | Fs_Read | Fs_Write;
+            StrLen(filename) = strlen(fnamestr);
+            StrLoc(filename) = fnamestr;
+            Protect(fl = alcfile(0, status, &filename), runerr(0));
+            fl->fd.sshf = sshf;
+            fl->sock_gen = 0;
+            return file(fl);
+            }
+         else
+#endif                                  /* HAVE_LIBSSH */
          if (status & Fs_Socket) {
             if (is_ipv4 && is_ipv6)
                af_fam = AF_UNSPEC;
@@ -1311,6 +1472,58 @@ function{0,1} read(f)
  */
 
 #ifdef PosixFns
+#if HAVE_LIBSSH
+       if ((status & Fs_SSH) && !(status & Fs_Directory)) {
+          /*
+           * Channel and SFTP files: line-oriented read via ssh_getstrg.
+           * Binary SFTP transfers should use reads().
+           */
+#ifdef Concurrent
+          MUTEX_LOCKID_CONTROLLED(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+          StrLen(s) = 0;
+          do {
+             DEC_NARTHREADS;
+             if ((slen = sock_getstrg(sbuf, MaxReadStr, &f)) == -1) {
+                INC_NARTHREADS_CONTROLLED;
+#ifdef Concurrent
+                MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+                fail;
+                }
+             INC_NARTHREADS_CONTROLLED;
+             if (slen == -3) {
+#ifdef Concurrent
+                MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+                set_ssh_errortext(BlkD(f,File)->fd.sshf->sess,
+                                  BlkD(f,File)->fd.sshf->sfile ? 1325 : 1324);
+                fail;
+                }
+             if (slen == 1 && *sbuf == '\n')
+                break;
+             rlen = slen < 0 ? (word)MaxReadStr : slen;
+
+             Protect(reserve(Strings, rlen), runerr(0));
+             if (StrLen(s) > 0 && !InRange(strbase,StrLoc(s),strfree)) {
+                Protect(reserve(Strings, StrLen(s)+rlen), runerr(0));
+                Protect((StrLoc(s) = alcstr(StrLoc(s),StrLen(s))), runerr(0));
+                }
+
+             Protect(sptr = alcstr(sbuf,rlen), runerr(0));
+             if (StrLen(s) == 0)
+                StrLoc(s) = sptr;
+             StrLen(s) += rlen;
+             if (StrLoc(s) [ StrLen(s) - 1 ] == '\n') { StrLen(s)--; break; }
+             }
+          while (slen > 0);
+
+#ifdef Concurrent
+          MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+         return s;
+          }
+#endif                                  /* HAVE_LIBSSH */
        if (status & Fs_Socket) {
           StrLen(s) = 0;
           do {
@@ -1322,7 +1535,11 @@ function{0,1} read(f)
                 }
              INC_NARTHREADS_CONTROLLED;
              if (slen == -3) {
-               /* sock_getstrg sets errornumber/text */
+#if HAVE_LIBSSH
+               if (status & Fs_SSH)
+                  set_ssh_errortext(BlkD(f,File)->fd.sshf->sess, 1324);
+#endif                                  /* HAVE_LIBSSH */
+                /* else sock_getstrg already set errornumber/text */
                 fail;
                 }
              if (slen == 1 && *sbuf == '\n')
@@ -1422,6 +1639,14 @@ function{0,1} read(f)
              char *s, *p=sbuf;
              IntVal(amperErrno) = 0;
              slen = 0;
+#if HAVE_LIBSSH
+             if (status & Fs_SSH) {
+                slen = ssh_sftp_readdir(BlkD(f,File)->fd.sshf, sbuf, MaxReadStr);
+                if (slen < 0)
+                   fail;                /* end of dir, or error with text */
+                }
+             else {
+#endif                                  /* HAVE_LIBSSH */
              DEC_NARTHREADS;
              d = readdir((DIR *)fp);
              INC_NARTHREADS_CONTROLLED;
@@ -1434,6 +1659,9 @@ function{0,1} read(f)
                 *p++ = *s++;
              if (slen == MaxReadStr)
                 slen = -2;
+#if HAVE_LIBSSH
+             }
+#endif                                  /* HAVE_LIBSSH */
           }
           else
 #endif
@@ -1652,7 +1880,70 @@ function{0,1} reads(f,i)
 
 
 #ifdef PosixFns
+#if HAVE_LIBSSH
+         if ((status & Fs_SSH) && BlkD(f,File)->fd.sshf != NULL &&
+             BlkD(f,File)->fd.sshf->sfile != NULL) {
+            /*
+             * SFTP regular file: raw byte transfer via sftp_read.
+             * Like sockets/messaging, reads(f,-1) loops until EOF.
+             */
+            int got;
+#ifdef Concurrent
+            MUTEX_LOCKID_CONTROLLED(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+            /* Casting to unsigned lets us use reads(f, -1) */
+            Maxread = (unsigned)i <= MaxReadStr ? i : MaxReadStr;
+            StrLoc(s) = NULL;
+            StrLen(s) = 0;
+            do {
+               if (bytesread > 0) {
+                  if (i >= 0 && i - bytesread <= MaxReadStr)
+                     Maxread = i - bytesread;
+                  else
+                     Maxread = MaxReadStr;
+                  }
+               DEC_NARTHREADS;
+               got = ssh_chan_read(BlkD(f,File)->fd.sshf, sbuf, Maxread, 1);
+               INC_NARTHREADS_CONTROLLED;
+               if (got < 0) {
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+                  set_ssh_errortext(BlkD(f,File)->fd.sshf->sess, 1325);
+                  fail;
+                  }
+               if (got == 0) {
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+                  if (bytesread == 0)
+                     fail;              /* EOF with nothing read */
+                  else
+                     return s;
+                  }
+               bytesread += got;
+               rlen = got;
+               Protect(reserve(Strings, StrLen(s) + rlen), runerr(0));
+               if (StrLen(s) > 0 && !InRange(strbase, StrLoc(s), strfree)) {
+                  Protect((StrLoc(s) =
+                           alcstr(StrLoc(s), StrLen(s))), runerr(0));
+                  }
+               Protect(sptr = alcstr(sbuf, rlen), runerr(0));
+               if (StrLen(s) == 0)
+                  StrLoc(s) = sptr;
+               StrLen(s) += rlen;
+               } while ((i == -1) || (bytesread < i));
+#ifdef Concurrent
+            MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+            return s;
+            }
+#endif                                  /* HAVE_LIBSSH */
          if (status & Fs_Socket) {
+#if HAVE_LIBSSH && defined(Concurrent)
+            if (status & Fs_SSH)
+               MUTEX_LOCKID_CONTROLLED(BlkD(f,File)->mutexid);
+#endif                                  /* HAVE_LIBSSH && Concurrent */
             StrLen(s) = 0;
             Maxread = (i <= MaxReadStr)? i : MaxReadStr;
             do {
@@ -1666,6 +1957,10 @@ function{0,1} reads(f,i)
                if ((slen = sock_getstrg(sbuf, Maxread, &f)) == -1) {
                     /*IntVal(amperErrno) = errno; */
                     INC_NARTHREADS_CONTROLLED;
+#if HAVE_LIBSSH && defined(Concurrent)
+                    if (status & Fs_SSH)
+                       MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* HAVE_LIBSSH && Concurrent */
                     if (bytesread == 0)
                         fail;
                     else
@@ -1673,7 +1968,15 @@ function{0,1} reads(f,i)
                 }
                 INC_NARTHREADS_CONTROLLED;
                 if (slen == -3) {
-                    /* sock_getstrg sets errortext */
+#if HAVE_LIBSSH
+                    if (status & Fs_SSH) {
+#ifdef Concurrent
+                       MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* Concurrent */
+                       set_ssh_errortext(BlkD(f,File)->fd.sshf->sess, 1324);
+                       }
+#endif                                  /* HAVE_LIBSSH */
+                    /* else sock_getstrg sets errortext */
                     fail;
                    }
 
@@ -1693,6 +1996,10 @@ function{0,1} reads(f,i)
                     StrLoc(s) = sptr;
                 StrLen(s) += rlen;
             } while ((i == -1) || (bytesread < i));
+#if HAVE_LIBSSH && defined(Concurrent)
+            if (status & Fs_SSH)
+               MUTEX_UNLOCKID(BlkD(f,File)->mutexid);
+#endif                                  /* HAVE_LIBSSH && Concurrent */
             return s;
         }
 
@@ -1733,6 +2040,18 @@ function{0,1} reads(f,i)
       if ((BlkD(f,File)->status & Fs_Directory) != 0) {
          char *sptr;
          struct dirent *de;
+#if HAVE_LIBSSH
+         if (BlkD(f,File)->status & Fs_SSH) {
+            char dbuf[MaxReadStr];
+            int dlen = ssh_sftp_readdir(BlkD(f,File)->fd.sshf, dbuf, MaxReadStr);
+            if (dlen < 0)
+               fail;                    /* end of dir, or error with text */
+            if (dlen > i)
+               dlen = i;
+            Protect(sptr = alcstr(dbuf, dlen), runerr(0));
+            return string(dlen, sptr);
+            }
+#endif                                  /* HAVE_LIBSSH */
          DEC_NARTHREADS;
          de = readdir((DIR*) fp);
          INC_NARTHREADS_CONTROLLED;
@@ -1854,16 +2173,37 @@ end
 
 "remove(s) - remove the file named s."
 
-function{0,1} remove(s)
+function{0,1} remove(s, path)
+
+   abstract {
+      return null
+      }
+
+#if HAVE_LIBSSH
+   /*
+    * remove(session, path): unlink a remote file over SFTP.  The
+    * leading-optional-file-argument idiom (like write(f, ...)); with a
+    * plain string first argument this is the ordinary local remove.
+    */
+   if is:file(s) then {
+      body {
+         tended char *rpath;
+         if (!(BlkD(s,File)->status & Fs_SSH) || BlkD(s,File)->fd.sshf == NULL)
+            runerr(103, s);
+         if (!cnv:C_string(path, rpath))
+            runerr(103, path);
+         if (ssh_sftp_unlink(BlkD(s,File)->fd.sshf, rpath) != 0)
+            fail;                       /* &errortext already set */
+         return nulldesc;
+         }
+      }
+#endif                                  /* HAVE_LIBSSH */
 
    /*
     * Make a C-style string out of s
     */
    if !cnv:C_string(s) then
       runerr(103,s)
-   abstract {
-      return null
-      }
 
    inline {
 #if !ConcurrentCOMPILER
@@ -1887,7 +2227,32 @@ end
 
 "rename(s1,s2) - rename the file named s1 to have the name s2."
 
-function{0,1} rename(s1,s2)
+function{0,1} rename(s1,s2,s3)
+
+   abstract {
+      return null
+      }
+
+#if HAVE_LIBSSH
+   /*
+    * rename(session, from, to): rename a remote file over SFTP,
+    * via the same leading-optional-session-argument idiom as remove().
+    */
+   if is:file(s1) then {
+      body {
+         tended char *rfrom, *rto;
+         if (!(BlkD(s1,File)->status & Fs_SSH) || BlkD(s1,File)->fd.sshf == NULL)
+            runerr(103, s1);
+         if (!cnv:C_string(s2, rfrom))
+            runerr(103, s2);
+         if (!cnv:C_string(s3, rto))
+            runerr(103, s3);
+         if (ssh_sftp_rename(BlkD(s1,File)->fd.sshf, rfrom, rto) != 0)
+            fail;                       /* &errortext already set */
+         return nulldesc;
+         }
+      }
+#endif                                  /* HAVE_LIBSSH */
 
    /*
     * Make C-style strings out of s1 and s2
@@ -1896,10 +2261,6 @@ function{0,1} rename(s1,s2)
       runerr(103,s1)
    if !cnv:C_string(s2) then
       runerr(103,s2)
-
-   abstract {
-      return null
-      }
 
    body {
       if (rename(s1,s2) == 0) return nulldesc;
@@ -2686,6 +3047,19 @@ end
       else
 #endif                                  /* Messaging */
 #ifdef PosixFns
+#if HAVE_LIBSSH
+      if (status & Fs_SSH) {
+         if (ssh_file_write(f.sshf, "\n", 1) < 0) {
+            MUTEX_UNLOCKID(fblk->mutexid);
+#if terminate
+            syserr("ssh write failed in stop()");
+#else
+            fail;                    /* &errortext already set */
+#endif
+          }
+         }
+      else
+#endif                                  /* HAVE_LIBSSH */
       if (status & Fs_Socket) {
          if (sock_write(f.fd, "\n", 1) < 0){
             MUTEX_UNLOCKID(fblk->mutexid);
@@ -2717,7 +3091,11 @@ end
 #endif
 
 #ifdef PosixFns
-      if (!(status & Fs_Socket)) {
+      if (!(status & (Fs_Socket
+#if HAVE_LIBSSH
+                      | Fs_SSH
+#endif
+         ))) {
 #endif                                  /* PosixFns */
 
 #if HAVE_LIBZ
@@ -2930,6 +3308,22 @@ function {1} name(x[nargs])
                         else
 #endif                                  /* Messaging */
 #ifdef PosixFns
+#if HAVE_LIBSSH
+                        if (status & Fs_SSH) {
+                           if (ssh_file_write(f.sshf, "\n", 1) < 0){
+#ifdef Concurrent
+                              if (fblk)
+                              MUTEX_UNLOCKID(fblk->mutexid);
+#endif                                  /* Concurrent */
+#if terminate
+                              syserr("ssh write failed in stop()");
+#else
+                              fail;
+#endif
+                             }
+                        }
+                        else
+#endif                                  /* HAVE_LIBSSH */
                         if (status & Fs_Socket) {
                            if (sock_write(f.fd, "\n", 1) < 0){
 #ifdef Concurrent
@@ -3045,6 +3439,19 @@ function {1} name(x[nargs])
 #endif                                  /* Messaging */
 
 #ifdef PosixFns
+#if HAVE_LIBSSH
+                     if (status & Fs_SSH) {
+                        if (ssh_file_write(f.sshf, StrLoc(t), StrLen(t)) < 0) {
+                           MUTEX_UNLOCKID(fblk->mutexid);
+#if terminate
+                           syserr("ssh write failed in stop()");
+#else
+                           fail;        /* &errortext already set */
+#endif
+                           }
+                        }
+                     else
+#endif                                  /* HAVE_LIBSSH */
                      if (status & Fs_Socket) {
 #if HAVE_LIBSSL
                         if(status & Fs_Encrypt) {

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -1929,7 +1929,7 @@ end
 
 "stat() - get file status."
 
-function{0,1} stat(f)
+function{0,1} stat(f, path)
    type_case f of {
       string: {
          abstract {
@@ -2025,6 +2025,37 @@ function{0,1} stat(f)
             if (BlkD(f,File)->status & Fs_Compress)
                fail;
 #endif                                  /* HAVE_LIBZ */
+
+#if HAVE_LIBSSH
+            if (BlkD(f,File)->status & Fs_SSH) {
+               /*
+                * stat(sshfile): sftp_fstat on an open sftp file.
+                * stat(session, path): a single sftp_stat request on a
+                * remote path, no open()+fstat round trip.
+                */
+               tended char *rpath = NULL;
+               if (BlkD(f,File)->fd.sshf == NULL)
+                  runerr(174, f);
+               if (!constr)
+                  if (!(constr = rec_structor("posix_stat")))
+                     syserr("failed to create posix record constructor");
+               nfields = (int) BlkD(*constr, Proc)->nfields;
+               Protect(rp = alcrecd(nfields, BlkLoc(*constr)), runerr(0));
+               if (!is:null(path)) {
+                  if (!cnv:C_string(path, rpath))
+                     runerr(103, path);
+                  if (!ssh_sftp_stat_rec(BlkD(f,File)->fd.sshf, rpath, 0,
+                                         &result, &rp))
+                     fail;
+                  }
+               else {
+                  if (!ssh_sftp_stat_rec(BlkD(f,File)->fd.sshf, NULL, 1,
+                                         &result, &rp))
+                     fail;
+                  }
+               return result;
+               }
+#endif                                  /* HAVE_LIBSSH */
 
             IntVal(amperErrno) = 0;
             if (BlkD(f,File)->status & Fs_Directory) {
@@ -2174,6 +2205,79 @@ function{0,1} receive(f)
 
       nfields = (int) BlkD(*constr,Proc)->nfields;
       Protect(rp = alcrecd(nfields, BlkLoc(*constr)), runerr(0));
+
+#if HAVE_LIBSSH
+      if (status & Fs_SSH) {
+         /*
+          * The next channel event in true arrival order: a
+          * posix_message whose addr is "stdout", "stderr" or "exit"
+          * and whose msg is the data (the exit status as a string).
+          * Fails once the channel is exhausted.  Hold the shared
+          * session mutex around pump/dequeue (Concurrent).
+          */
+         struct SSHfile *sshf = BlkD(f,File)->fd.sshf;
+         struct SSHchunk *ck;
+         char *tag;
+         int prc, len;
+#ifdef Concurrent
+         word ssh_mtx = BlkD(f,File)->mutexid;
+#endif                                  /* Concurrent */
+
+         if (sshf == NULL || sshf->closed)
+            fail;
+
+#ifdef Concurrent
+         MUTEX_LOCKID_CONTROLLED(ssh_mtx);
+#endif                                  /* Concurrent */
+         DEC_NARTHREADS;
+         prc = ssh_pump(sshf, 1, 0);
+         INC_NARTHREADS_CONTROLLED;
+         if (prc < 0) {
+#ifdef Concurrent
+            MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+            set_ssh_errortext(sshf->sess, 1324);
+            fail;
+            }
+         if (prc == 0) {
+#ifdef Concurrent
+            MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+            fail;                       /* exhausted */
+            }
+
+         ck = sshf->qhead;
+         sshf->qhead = ck->next;
+         if (sshf->qhead == NULL)
+            sshf->qtail = NULL;
+         if (ck->tag == SSH_CHUNK_STDOUT)
+            sshf->q_stdout -= (ck->len - ck->off);
+         switch (ck->tag) {
+            case SSH_CHUNK_STDOUT: tag = "stdout"; break;
+            case SSH_CHUNK_STDERR: tag = "stderr"; break;
+            default:               tag = "exit";   break;
+            }
+         StrLoc(rp->fields[0]) = tag;
+         StrLen(rp->fields[0]) = strlen(tag);
+         len = ck->len - ck->off;
+         Protect(StrLoc(rp->fields[1]) = alcstr(ck->data + ck->off, len),
+                 {
+#ifdef Concurrent
+                  MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+                  free(ck); runerr(0);
+                  });
+         StrLen(rp->fields[1]) = len;
+         free(ck);
+#ifdef Concurrent
+         MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
+
+         result.dword = D_Record;
+         result.vword.bptr = (union block *)rp;
+         return result;
+         }
+#endif                                  /* HAVE_LIBSSH */
 
       IntVal(amperErrno) = 0;
       if ((ret = sock_recv(BlkD(f,File)->fd.fd, &rp)) == 0) {

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -2446,6 +2446,21 @@ void post_if_ready(dptr ldp, dptr f, fd_set *fdsp)
    }
 #endif                                  /* LIBSSL */
 
+#if HAVE_LIBSSH
+   /*
+    * SSH: only report ready when stdout (or EOF) is actually available.
+    * A readable TCP fd alone is not enough — it may be protocol noise or
+    * stderr; reads() would then block forever waiting for stdout.
+    * ssh_file_pending() nonblocking-pumps first so we notice data that
+    * select() saw on the wire (or that was left in libssh buffers).
+    */
+   if (status & Fs_SSH) {
+      if (ssh_file_pending(BlkD(*f, File)))
+         c_put(ldp, f);
+      return;
+      }
+#endif                                  /* HAVE_LIBSSH */
+
    fd = get_fd(*f, Fs_Read|Fs_Socket|Fs_Messaging);
    if ((fd != -1) && FD_ISSET(fd, fdsp)) {
       /*
@@ -2618,6 +2633,47 @@ function{0,1} select(files[nargs])
                }
             }
 
+#if HAVE_LIBSSH
+         /*
+          * If any SSH file already has queued/pumpable data, do not block
+          * in select() — the TCP fd may be idle while the prompt sits in
+          * libssh buffers from open().
+          */
+         {
+         int ssh_ready = 0;
+         for (k = 0; k < nargs && !ssh_ready; k++) {
+            if ((k + 1 == nargs) && is:integer(files[k]))
+               continue;
+            if (is:file(files[k]) &&
+                (BlkD(files[k], File)->status & Fs_SSH) &&
+                ssh_file_pending(BlkD(files[k], File)))
+               ssh_ready = 1;
+            else if (is:list(files[k])) {
+               for (ep = BlkD(files[k], List)->listhead;
+                    BlkType(ep) == T_Lelem && !ssh_ready;
+                    ep = Blk(ep, Lelem)->listnext) {
+                  for (i = 0; i < Blk(ep, Lelem)->nused && !ssh_ready; i++) {
+                     j = Blk(ep, Lelem)->first + i;
+                     if (j >= ep->Lelem.nslots)
+                        j -= Blk(ep, Lelem)->nslots;
+                     f = Blk(ep, Lelem)->lslots[j];
+                     if (is:file(f) && (BlkD(f, File)->status & Fs_SSH) &&
+                         ssh_file_pending(BlkD(f, File)))
+                        ssh_ready = 1;
+                     }
+                  }
+               }
+            }
+         if (ssh_ready) {
+            tv.tv_sec = 0;
+            tv.tv_usec = 0;
+            ptv = &tv;
+            /* fall through: still set timeout branch may overwrite ptv */
+            }
+         if (ssh_ready)
+            timeout = 0;
+         }
+#endif                                  /* HAVE_LIBSSH */
 
       /* Set the tv struct */
       if (timeout < 0) {

--- a/src/runtime/fxposix.ri
+++ b/src/runtime/fxposix.ri
@@ -2410,6 +2410,18 @@ int set_if_selectable(struct descrip *f, fd_set *fdsp, int *n)
          }
       else
 #endif                                  /* PseudoPty && MSWindows */
+#if NT
+      /*
+       * CRT-backed files (&input, pipes, regular files) cannot go through
+       * Winsock select(); they are polled via findactivecrt().
+       */
+      if (win_crt_selectable(status)) {
+         if (status & Fs_Buff) return 1048;
+         BlkLoc(*f)->File.status |= Fs_Unbuf;
+         return 0;
+         }
+      else
+#endif                                  /* NT */
       if ((fd = get_fd(*f, Fs_Read|Fs_Socket|Fs_Messaging)) < 0) {
          if (fd == -2)
             return 212;
@@ -2438,6 +2450,16 @@ void post_if_ready(dptr ldp, dptr f, fd_set *fdsp)
 #endif                                  /* UNIX && PseudoPty */
                                         )) == 0)
       return;
+
+#if NT
+   /*
+    * CRT files are reported by findactivecrt(), not FD_ISSET.  Skipping
+    * here also avoids a false ready if a CRT fd number collides with a
+    * SOCKET that is set in fdsp.
+    */
+   if (win_crt_selectable(status))
+      return;
+#endif                                  /* NT */
 
 #if FIXME_HAVE_LIBSSL
    if ((status & Fs_Socket) && (status & Fs_Encrypt)) {
@@ -2532,9 +2554,15 @@ function{0,1} select(files[nargs])
       tended struct descrip d = nulldesc;
       tended struct descrip d2 = nulldesc;
       tended struct descrip d3 = nulldesc;
+#if NT
+      tended struct descrip d4 = nulldesc;
+#endif                                  /* NT */
       tended struct descrip f;
       tended struct b_list *lws = NULL;
       tended struct b_list *lps = NULL;
+#if NT
+      tended struct b_list *lcs = NULL;
+#endif                                  /* NT */
       struct hgstate state;
 
 #ifdef Graphics
@@ -2587,6 +2615,43 @@ function{0,1} select(files[nargs])
            }
          }
 #endif                                  /* Graphics */
+
+#if NT
+      /*
+       * prepass: CRT-backed files for Win32 readiness polling
+       */
+      if ((lcs = alclist(0, MinListSlots)) == NULL) runerr(307);
+      d4.dword = D_List;
+      BlkLoc(d4) = (union block *)lcs;
+      for (k = 0; k < nargs; k++) {
+         if ((k + 1 == nargs) && is:integer(files[k]))
+            continue;
+         if (is:file(files[k]) &&
+             win_crt_selectable(BlkD(files[k], File)->status))
+            c_put(&d4, files+k);
+         else if (is:list(files[k])) {
+            for (ep = BlkD(files[k], List)->listhead;
+                 BlkType(ep) == T_Lelem; ep = Blk(ep, Lelem)->listnext) {
+               for (i = 0; i < Blk(ep, Lelem)->nused; i++) {
+                  j = Blk(ep, Lelem)->first + i;
+                  if (j >= ep->Lelem.nslots)
+                     j -= ep->Lelem.nslots;
+                  f = ep->Lelem.lslots[j];
+                  if (is:file(f) && win_crt_selectable(BlkD(f, File)->status))
+                     c_put(&d4, &f);
+                  }
+               }
+            }
+         else if (is:set(files[k])) {
+            for (ep = hgfirst(BlkLoc(files[k]), &state); ep != 0;
+                 ep = hgnext(BlkLoc(files[k]), &state, ep)) {
+               f = ep->Selem.setmem;
+               if (is:file(f) && win_crt_selectable(BlkD(f, File)->status))
+                  c_put(&d4, &f);
+               }
+            }
+         }
+#endif                                  /* NT */
 
       /*
        * Unicon select() repeats until a timeout or real result.
@@ -2691,7 +2756,7 @@ function{0,1} select(files[nargs])
 #if defined(PseudoPty) && defined(MSWindows)
          /*
           * if there are any ptys, then even if we said to go forever
-          * timeout periodically to check for window events.
+          * timeout periodically to check for pty readiness.
           */
          if (lps->size > 0) {
             tv.tv_sec = 0;
@@ -2699,6 +2764,17 @@ function{0,1} select(files[nargs])
             }
          else
 #endif                                  /* PseudoPty && MSWindows */
+#if NT
+         /*
+          * CRT files (&input, etc.): poll periodically; Winsock cannot
+          * wait on them.
+          */
+         if (lcs->size > 0) {
+            tv.tv_sec = 0;
+            tv.tv_usec = 50000;
+            }
+         else
+#endif                                  /* NT */
             ptv = 0;
          }
       else {
@@ -2723,6 +2799,14 @@ function{0,1} select(files[nargs])
          }
 #endif                                  /* PseudoPty && MSWindows */
 #endif                                  /* Graphics */
+#if NT
+      if ((lp == NULL) && (lcs->size > 0) &&
+          ((lp = findactivecrt(lcs)) != NULL)) {
+         d.dword = D_List;
+         BlkLoc(d) = (union block *) lp;
+         tv.tv_sec = tv.tv_usec = 0;
+         }
+#endif                                  /* NT */
 
       if (n) {
         DEC_NARTHREADS;
@@ -2759,9 +2843,23 @@ function{0,1} select(files[nargs])
             }
 #endif                                  /* PseudoPty */
 #endif                                  /* Graphics */
+#if NT
+         if ((lp == NULL) && (lcs->size > 0) &&
+             ((lp = findactivecrt(lcs)) != NULL)) {
+            d.dword = D_List;
+            BlkLoc(d) = (union block *) lp;
+            }
+#endif                                  /* NT */
          }
       else if (ptv && (ptv->tv_sec || ptv->tv_usec)) {
          idelay(ptv->tv_sec * 1000 + ptv->tv_usec / 1000);
+#if NT
+         if ((lp == NULL) && (lcs->size > 0) &&
+             ((lp = findactivecrt(lcs)) != NULL)) {
+            d.dword = D_List;
+            BlkLoc(d) = (union block *) lp;
+            }
+#endif                                  /* NT */
          }
 
       if (lp == NULL) {

--- a/src/runtime/rmisc.r
+++ b/src/runtime/rmisc.r
@@ -2603,7 +2603,12 @@ int getimage(dptr dp1, dptr dp2)
             else {
 #endif                                  /* Graphics */
 #ifdef PosixFns
-               if (BlkD(source,File)->status & Fs_Socket) {
+               if ((BlkD(source,File)->status & Fs_Socket)
+#if HAVE_LIBSSH
+                   /* fd.fd is not a socket descriptor for SSH files */
+                   && !(BlkD(source,File)->status & Fs_SSH)
+#endif                                  /* HAVE_LIBSSH */
+                   ) {
                    s = namebuf;
                    len = sock_name(BlkLoc(source)->File.fd.fd,
                                  StrLoc(BlkLoc(source)->File.fname),

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -313,6 +313,43 @@ int get_fd(struct descrip file, unsigned int errmask)
    return fileno(BlkD(file,File)->fd.fp);
 }
 
+#if HAVE_LIBSSH
+/*
+ * ssh_file_pending() - 1 if an SSH file already has stdout (or EOF)
+ * waiting.  Used by select() so we do not hang when libssh buffered
+ * the banner/prompt during open().  Only stdout matters here: stream
+ * reads() do not consume stderr/exit queue chunks, so a nonempty
+ * qhead alone must not make select() claim the file is readable.
+ */
+int ssh_file_pending(struct b_file *fp)
+{
+   struct SSHfile *sshf;
+
+   if (fp == NULL || !(fp->status & Fs_SSH))
+      return 0;
+   sshf = fp->fd.sshf;
+   if (sshf == NULL || sshf->closed)
+      return 0;
+#ifdef Concurrent
+   MUTEX_LOCKID_CONTROLLED(fp->mutexid);
+#endif                                  /* Concurrent */
+   if (sshf->nl_pending || sshf->q_stdout > 0) {
+#ifdef Concurrent
+      MUTEX_UNLOCKID(fp->mutexid);
+#endif                                  /* Concurrent */
+      return 1;
+      }
+   if (sshf->chan != NULL || sshf->sfile != NULL)
+      ssh_pump(sshf, 0, 1);             /* want stdout for reads()/select */
+   {
+   int ready = (sshf->nl_pending || sshf->q_stdout > 0 || sshf->eof_seen);
+#ifdef Concurrent
+   MUTEX_UNLOCKID(fp->mutexid);
+#endif                                  /* Concurrent */
+   return ready;
+   }
+}
+#endif                                  /* HAVE_LIBSSH */
 
 int get_uid(char *name)
 {
@@ -3751,6 +3788,10 @@ SSL_CTX * create_ssl_context(dptr attr, int n, int type ) {
 
 #if HAVE_LIBSSH
 
+#if !NT
+#passthru #include <sys/ioctl.h>
+#endif                                  /* !NT */
+
 /*
  * Authentication attributes are tried in the order they appear in the
  * open() call, not in a hardcoded priority order.
@@ -4027,6 +4068,43 @@ void ssh_drain_stderr(struct SSHfile *sshf, dptr d)
 }
 
 /*
+ * ssh_request_interactive_pty() - remote PTY with TERM + window size.
+ * Without a real size, ls(1) and friends fall back to one column.
+ * term NULL => $TERM or "xterm"; cols/rows <= 0 => local TIOCGWINSZ
+ * (or 80x24).
+ */
+static int ssh_request_interactive_pty(ssh_channel chan, const char *term,
+                                       int cols, int rows)
+{
+   const char *t = term;
+#if !NT
+   struct winsize ws;
+#endif                                  /* !NT */
+
+   if (t == NULL || *t == '\0') {
+      t = getenv("TERM");
+      if (t == NULL || *t == '\0')
+         t = "xterm";
+      }
+   if (cols <= 0 || rows <= 0) {
+#if !NT
+      if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) == 0 ||
+          ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0) {
+         if (cols <= 0 && ws.ws_col > 0)
+            cols = ws.ws_col;
+         if (rows <= 0 && ws.ws_row > 0)
+            rows = ws.ws_row;
+         }
+#endif                                  /* !NT */
+      if (cols <= 0)
+         cols = 80;
+      if (rows <= 0)
+         rows = 24;
+      }
+   return ssh_channel_request_pty_size(chan, t, cols, rows);
+}
+
+/*
  * create_ssh_session() - establish an authenticated SSH connection,
  * optionally with a channel on it, returning a malloc'd SSHfile.
  * Follows the same attribute-parsing shape as create_ssl_context():
@@ -4050,6 +4128,7 @@ struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_veri
    tended char *tmps, *val;
    tended char *key=NULL, *password=NULL, *keypass=NULL;
    tended char *hostkeyfile=NULL, *cmd=NULL, *userattr=NULL;
+   tended char *term=NULL;
    char namebuf[512];
    char *user, *host, *at, *colon, *rbrack;
    int auth_order[2];
@@ -4059,6 +4138,7 @@ struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_veri
    ssh_channel chan = NULL;
    C_integer timeout = 0;
    C_integer port = 0;
+   C_integer pty_cols = 0, pty_rows = 0;
    int a, authed, err;
    int want_channel = 1;                /* channel=yes by default */
 
@@ -4172,6 +4252,12 @@ struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_veri
          hostkeyfile = val;
       else if (strcmp(tmps, "cmd") == 0)
          cmd = val;
+      else if (strcmp(tmps, "term") == 0)
+         term = val;
+      else if (strcmp(tmps, "cols") == 0)
+         pty_cols = atol(val);
+      else if (strcmp(tmps, "rows") == 0)
+         pty_rows = atol(val);
       else if (strcmp(tmps, "channel") == 0) {
          want_channel = sock_attr_bool(val);
          if (want_channel < 0) {
@@ -4292,7 +4378,8 @@ struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_veri
             goto ssh_fail;
          }
       else {
-         if (ssh_channel_request_pty(chan) != SSH_OK)
+         if (ssh_request_interactive_pty(chan, term,
+                                         (int)pty_cols, (int)pty_rows) != SSH_OK)
             goto ssh_fail;
          if (ssh_channel_request_shell(chan) != SSH_OK)
             goto ssh_fail;
@@ -4514,10 +4601,12 @@ struct SSHfile *create_ssh_channel(struct SSHfile *sf, dptr spec, dptr attr, int
 {
    tended char *tmps, *val;
    tended char *cmd = NULL;
+   tended char *term = NULL;
    struct SSHfile *owner, *sshf;
    ssh_channel chan = NULL;
    dptr dp;
    int a;
+   C_integer pty_cols = 0, pty_rows = 0;
 
    /* resolve to the session owner: opening on a channel opens a sibling */
    owner = (sf->parent != NULL) ? sf->parent : sf;
@@ -4554,6 +4643,12 @@ struct SSHfile *create_ssh_channel(struct SSHfile *sf, dptr spec, dptr attr, int
          }
       if (strcmp(tmps, "cmd") == 0)
          cmd = val;
+      else if (strcmp(tmps, "term") == 0)
+         term = val;
+      else if (strcmp(tmps, "cols") == 0)
+         pty_cols = atol(val);
+      else if (strcmp(tmps, "rows") == 0)
+         pty_rows = atol(val);
       else {
          set_errortext_with_val(1321, tmps);
          return NULL;
@@ -4580,7 +4675,8 @@ struct SSHfile *create_ssh_channel(struct SSHfile *sf, dptr spec, dptr attr, int
          goto chan_fail;
       }
    else {
-      if (ssh_channel_request_pty(chan) != SSH_OK)
+      if (ssh_request_interactive_pty(chan, term,
+                                      (int)pty_cols, (int)pty_rows) != SSH_OK)
          goto chan_fail;
       if (ssh_channel_request_shell(chan) != SSH_OK)
          goto chan_fail;

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -3916,7 +3916,11 @@ int ssh_pump(struct SSHfile *sshf, int block, int want_stdout)
 /*
  * ssh_chan_read() - read up to n stdout bytes out of the queue,
  * pumping the wire as needed.  Returns the byte count, 0 at EOF,
- * -1 on error with &errortext set.
+ * -1 on error (caller sets &errortext after INC_NARTHREADS).
+ *
+ * Under Concurrent, the caller must hold the shared session mutex
+ * (b_file.mutexid) around this call: the same lock used by
+ * receive()/Attrib() and by writers on sibling channels.
  */
 int ssh_chan_read(struct SSHfile *sshf, char *buf, int n, int block)
 {
@@ -3979,6 +3983,9 @@ int ssh_chan_read(struct SSHfile *sshf, char *buf, int n, int block)
  * their concatenation (possibly empty) as an Icon string in *d.
  * This is a live, incremental accessor: each call returns only the
  * bytes accumulated since the previous one.
+ *
+ * Under Concurrent, the caller must hold the shared session mutex
+ * (same rule as ssh_chan_read).
  */
 void ssh_drain_stderr(struct SSHfile *sshf, dptr d)
 {
@@ -5517,8 +5524,19 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
    else {
       /* Read as much as we can without blocking, in chunks of 1536 bytes */
       long bufsize = 1536, total = 0, i = 0;
+#if HAVE_LIBSSH && defined(Concurrent)
+      word ssh_mtx = 0;
+      int ssh_have_mtx = 0;
+#endif                                  /* HAVE_LIBSSH && Concurrent */
       StrLoc(*d) = strfree;
       StrLen(*d) = 0;
+#if HAVE_LIBSSH && defined(Concurrent)
+      if (fstatus & Fs_SSH) {
+         ssh_mtx = BlkD(*f,File)->mutexid;
+         MUTEX_LOCKID_CONTROLLED(ssh_mtx);
+         ssh_have_mtx = 1;
+         }
+#endif                                  /* HAVE_LIBSSH && Concurrent */
       for(;;) {
          int srv, kk=0;
          fd_set readset;
@@ -5529,12 +5547,17 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
              * select() on the session fd cannot see data already
              * decrypted and queued inside libssh; pump the channel.
              * SFTP files have no channel queue -- just try a read.
+             * The shared session mutex (above) covers pump + dequeue.
              */
             struct SSHfile *sshf = BlkD(*f,File)->fd.sshf;
             if (sshf == NULL || sshf->closed ||
                 (sshf->chan == NULL && sshf->sfile == NULL &&
                  sshf->q_stdout == 0)) {
                set_errortext(1324);
+#if defined(Concurrent)
+               if (ssh_have_mtx)
+                  MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
                return 0;
                }
             if (sshf->sfile != NULL) {
@@ -5547,13 +5570,22 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
                INC_NARTHREADS_CONTROLLED;
                if (prc == -1) {
                   set_ssh_errortext(sshf->sess, 1324);
+#if defined(Concurrent)
+                  if (ssh_have_mtx)
+                     MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
                   return 0;
                   }
                if (prc == 2)
                   break;                /* nothing more is available */
                if (prc == 0) {          /* EOF */
-                  if (StrLen(*d) == 0)
+                  if (StrLen(*d) == 0) {
+#if defined(Concurrent)
+                     if (ssh_have_mtx)
+                        MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
                      return 0;
+                     }
                   break;
                   }
                }
@@ -5612,6 +5644,10 @@ tryagain:
                   set_ssh_errortext(sshf->sess, sshf->sfile ? 1325 : 1324);
                   strtotal += bufsize;
                   strfree = StrLoc(*d);
+#if defined(Concurrent)
+                  if (ssh_have_mtx)
+                     MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* Concurrent */
                   return 0;
                   }
                }
@@ -5687,6 +5723,10 @@ tryagain:
          }
          i++;
       }
+#if HAVE_LIBSSH && defined(Concurrent)
+      if (ssh_have_mtx)
+         MUTEX_UNLOCKID(ssh_mtx);
+#endif                                  /* HAVE_LIBSSH && Concurrent */
    }
    return d;
 }

--- a/src/runtime/rposix.r
+++ b/src/runtime/rposix.r
@@ -289,6 +289,15 @@ int get_fd(struct descrip file, unsigned int errmask)
 #define fileno _fileno
 #endif                                  /* NT */
 
+#if HAVE_LIBSSH
+   if (status & Fs_SSH) {
+      struct SSHfile *sshf = BlkD(file,File)->fd.sshf;
+      if (sshf == NULL || sshf->closed || sshf->sess == NULL)
+         return -1;
+      return ssh_get_fd(sshf->sess);
+      }
+#endif                                  /* HAVE_LIBSSH */
+
    if (status & Fs_Socket) {
 #if HAVE_LIBSSL
       if(status & Fs_Encrypt)
@@ -1474,19 +1483,6 @@ static int sock_join_group(int s, char *grp, char *src,
       }
    errno = EINVAL;
    return -1;
-}
-
-/* True if host is a dotted/numeric multicast address (not a name). */
-static int host_is_multicast(char *host)
-{
-   struct in_addr a4;
-   struct in6_addr a6;
-
-   if (inet_pton(AF_INET, host, &a4) == 1)
-      return IN_MULTICAST(ntohl(a4.s_addr));
-   if (inet_pton(AF_INET6, host, &a6) == 1)
-      return IN6_IS_ADDR_MULTICAST(&a6);
-   return 0;
 }
 
 /*
@@ -3753,6 +3749,1185 @@ SSL_CTX * create_ssl_context(dptr attr, int n, int type ) {
 }
 #endif                                  /* LIBSSL */
 
+#if HAVE_LIBSSH
+
+/*
+ * Authentication attributes are tried in the order they appear in the
+ * open() call, not in a hardcoded priority order.
+ */
+#define SSH_AUTH_ATTR_KEY      1
+#define SSH_AUTH_ATTR_PASSWORD 2
+
+/*
+ * Channel event queue.  Data and exit-status callbacks append tagged
+ * chunks as messages are parsed off the wire, preserving the exact
+ * stdout/stderr arrival order (ssh_channel_read()'s own buffers keep
+ * the two streams apart and lose it).  Everything here is malloc'd:
+ * callbacks can fire inside blocking libssh calls made while the
+ * thread is unregistered (DEC_NARTHREADS), where Icon allocation is
+ * not allowed.
+ */
+static void ssh_enqueue(struct SSHfile *sshf, int tag, char *data, int len)
+{
+   struct SSHchunk *ck;
+
+   ck = malloc(sizeof(struct SSHchunk) + len);
+   if (ck == NULL)
+      syserr("out of memory for ssh channel data");
+   ck->next = NULL;
+   ck->tag = tag;
+   ck->off = 0;
+   ck->len = len;
+   if (len > 0)
+      memcpy(ck->data, data, len);
+   if (sshf->qtail != NULL)
+      sshf->qtail->next = ck;
+   else
+      sshf->qhead = ck;
+   sshf->qtail = ck;
+   if (tag == SSH_CHUNK_STDOUT)
+      sshf->q_stdout += len;
+}
+
+static int ssh_chan_data_cb(ssh_session session, ssh_channel channel,
+                            void *data, uint32_t len, int is_stderr,
+                            void *userdata)
+{
+   struct SSHfile *sshf = (struct SSHfile *)userdata;
+
+   if (len == 0)
+      return 0;
+   ssh_enqueue(sshf, is_stderr ? SSH_CHUNK_STDERR : SSH_CHUNK_STDOUT,
+               (char *)data, (int)len);
+   return (int)len;             /* consumed: keep it out of libssh's buffer */
+}
+
+static void ssh_chan_eof_cb(ssh_session session, ssh_channel channel,
+                            void *userdata)
+{
+   ((struct SSHfile *)userdata)->eof_seen = 1;
+}
+
+static void ssh_chan_exit_cb(ssh_session session, ssh_channel channel,
+                             int exit_status, void *userdata)
+{
+   struct SSHfile *sshf = (struct SSHfile *)userdata;
+   char buf[32];
+
+   sshf->exit_status = exit_status;
+   sshf->exit_seen = 1;
+   snprintf(buf, sizeof(buf), "%d", exit_status);
+   ssh_enqueue(sshf, SSH_CHUNK_EXIT, buf, (int)strlen(buf));
+}
+
+/*
+ * ssh_clear_file_state() - free queued chunks and the callbacks
+ * struct, leaving the SSHfile itself allocated (still owned by a
+ * b_file until that file is closed).
+ */
+static void ssh_clear_file_state(struct SSHfile *sshf)
+{
+   struct SSHchunk *ck, *nextck;
+
+   for (ck = sshf->qhead; ck != NULL; ck = nextck) {
+      nextck = ck->next;
+      free(ck);
+      }
+   sshf->qhead = sshf->qtail = NULL;
+   sshf->q_stdout = 0;
+   if (sshf->cbs != NULL) {
+      free(sshf->cbs);
+      sshf->cbs = NULL;
+      }
+}
+
+/*
+ * ssh_free_file_state() - clear a file's queued state and free the
+ * SSHfile struct itself.
+ */
+static void ssh_free_file_state(struct SSHfile *sshf)
+{
+   ssh_clear_file_state(sshf);
+   free(sshf);
+}
+
+/*
+ * ssh_chan_register_callbacks() - route a channel's traffic through
+ * the arrival-order queue.  Must happen before the channel is opened
+ * so no early data can land in libssh's own buffers instead.
+ */
+static int ssh_chan_register_callbacks(struct SSHfile *sshf, ssh_channel chan)
+{
+   ssh_channel_callbacks cb;
+
+   cb = malloc(sizeof(struct ssh_channel_callbacks_struct));
+   if (cb == NULL)
+      return -1;
+   memset(cb, 0, sizeof(struct ssh_channel_callbacks_struct));
+   ssh_callbacks_init(cb);
+   cb->userdata = sshf;
+   cb->channel_data_function = ssh_chan_data_cb;
+   cb->channel_eof_function = ssh_chan_eof_cb;
+   cb->channel_exit_status_function = ssh_chan_exit_cb;
+   if (ssh_set_channel_callbacks(chan, cb) != SSH_OK) {
+      free(cb);
+      return -1;
+      }
+   sshf->cbs = cb;
+   return 0;
+}
+
+/*
+ * ssh_pump() - let libssh process incoming packets so the channel
+ * callbacks can run.  Returns 1 once the queue has what the caller
+ * wants (a stdout chunk when want_stdout, else any chunk), 0 at EOF
+ * with nothing wanted queued, 2 when nonblocking and nothing has
+ * arrived yet, -1 on error (does NOT set &errortext -- callers that
+ * run under DEC_NARTHREADS must call set_ssh_errortext only after
+ * re-registering the thread).
+ */
+int ssh_pump(struct SSHfile *sshf, int block, int want_stdout)
+{
+   int rc;
+
+   if (sshf == NULL || sshf->closed)
+      return -1;
+
+   for (;;) {
+      if (want_stdout ? (sshf->q_stdout > 0) : (sshf->qhead != NULL))
+         return 1;
+      if (sshf->chan == NULL || sshf->eof_seen ||
+          ssh_channel_is_eof(sshf->chan))
+         return 0;
+      rc = ssh_channel_poll_timeout(sshf->chan, block ? 100 : 0, 0);
+      if (rc == SSH_ERROR)
+         return -1;
+      if (!block) {
+         if (want_stdout ? (sshf->q_stdout > 0) : (sshf->qhead != NULL))
+            return 1;
+         if (sshf->eof_seen || rc == SSH_EOF ||
+             ssh_channel_is_eof(sshf->chan))
+            return 0;
+         return 2;
+         }
+      }
+}
+
+/*
+ * ssh_chan_read() - read up to n stdout bytes out of the queue,
+ * pumping the wire as needed.  Returns the byte count, 0 at EOF,
+ * -1 on error with &errortext set.
+ */
+int ssh_chan_read(struct SSHfile *sshf, char *buf, int n, int block)
+{
+   struct SSHchunk *ck, *prev, *nextck;
+   int copied = 0, take, rc;
+
+   if (sshf == NULL || sshf->closed)
+      return -1;
+
+   if (sshf->sfile != NULL) {
+      /*
+       * SFTP regular file: raw sftp_read.  Caller is responsible for
+       * DEC_NARTHREADS around this (same as other blocking SSH I/O).
+       */
+      rc = sftp_read(sshf->sfile, buf, n);
+      if (rc < 0)
+         return -1;                     /* caller sets &errortext after INC */
+      return rc;                        /* 0 == EOF */
+      }
+
+   if (sshf->q_stdout == 0) {
+      rc = ssh_pump(sshf, block, 1);
+      if (rc == -1)
+         return -1;
+      if (rc != 1)
+         return 0;                      /* EOF (or nothing yet, nonblocking) */
+      }
+   prev = NULL;
+   ck = sshf->qhead;
+   while (ck != NULL && copied < n) {
+      nextck = ck->next;
+      if (ck->tag != SSH_CHUNK_STDOUT) {
+         prev = ck;
+         ck = nextck;
+         continue;
+         }
+      take = ck->len - ck->off;
+      if (take > n - copied)
+         take = n - copied;
+      memcpy(buf + copied, ck->data + ck->off, take);
+      ck->off += take;
+      copied += take;
+      sshf->q_stdout -= take;
+      if (ck->off == ck->len) {
+         if (prev != NULL)
+            prev->next = nextck;
+         else
+            sshf->qhead = nextck;
+         if (sshf->qtail == ck)
+            sshf->qtail = prev;
+         free(ck);
+         }
+      ck = nextck;
+      }
+   return copied;
+}
+
+/*
+ * ssh_drain_stderr() - remove every queued stderr chunk, producing
+ * their concatenation (possibly empty) as an Icon string in *d.
+ * This is a live, incremental accessor: each call returns only the
+ * bytes accumulated since the previous one.
+ */
+void ssh_drain_stderr(struct SSHfile *sshf, dptr d)
+{
+   struct SSHchunk *ck, *prev, *nextck;
+   word total = 0;
+   char *p;
+
+   for (ck = sshf->qhead; ck != NULL; ck = ck->next)
+      if (ck->tag == SSH_CHUNK_STDERR)
+         total += ck->len;
+
+   StrLen(*d) = total;
+   if (total == 0) {
+      StrLoc(*d) = "";
+      return;
+      }
+   Protect(StrLoc(*d) = alcstr(NULL, total), fatalerr(0,NULL));
+
+   p = StrLoc(*d);
+   prev = NULL;
+   ck = sshf->qhead;
+   while (ck != NULL) {
+      nextck = ck->next;
+      if (ck->tag == SSH_CHUNK_STDERR) {
+         memcpy(p, ck->data, ck->len);
+         p += ck->len;
+         if (prev != NULL)
+            prev->next = nextck;
+         else
+            sshf->qhead = nextck;
+         if (sshf->qtail == ck)
+            sshf->qtail = prev;
+         free(ck);
+         }
+      else
+         prev = ck;
+      ck = nextck;
+      }
+}
+
+/*
+ * create_ssh_session() - establish an authenticated SSH connection,
+ * optionally with a channel on it, returning a malloc'd SSHfile.
+ * Follows the same attribute-parsing shape as create_ssl_context():
+ * trailing open() arguments are "key=value" strings (a leading integer
+ * is a connect timeout in milliseconds, as for plain sockets).
+ *
+ * The first open() argument is "host", "user@host", or either with
+ * ":port" (same host:port shape as socket open(); IPv6 uses
+ * "[addr]:port").  With a cmd= attribute the channel is a one-shot
+ * exec channel with clean command boundaries; otherwise an interactive
+ * shell on a pty is requested.  channel=no opens a transport-only
+ * session (no channel); use a later open(s, ...) for exec/shell/SFTP.
+ * channel=yes is the default.  Passing do_verify = 0 (the '-' mode
+ * char) skips host-key verification.
+ *
+ * On failure sets &errortext and returns NULL, so open() can fail
+ * rather than raise a runtime error, matching the SSL connect path.
+ */
+struct SSHfile *create_ssh_session(char *fnamestr, dptr attr, int n, int do_verify)
+{
+   tended char *tmps, *val;
+   tended char *key=NULL, *password=NULL, *keypass=NULL;
+   tended char *hostkeyfile=NULL, *cmd=NULL, *userattr=NULL;
+   char namebuf[512];
+   char *user, *host, *at, *colon, *rbrack;
+   int auth_order[2];
+   int nauth = 0;
+   struct SSHfile *sshf;
+   ssh_session sess = NULL;
+   ssh_channel chan = NULL;
+   C_integer timeout = 0;
+   C_integer port = 0;
+   int a, authed, err;
+   int want_channel = 1;                /* channel=yes by default */
+
+   /*
+    * Split "user@host[:port]" (or "[ipv6]:port") into storage that
+    * cannot move if the attribute parsing below triggers a GC.  Port
+    * uses the same host:port form as socket open(), not a port= attr.
+    */
+   if (strlen(fnamestr) >= sizeof(namebuf)) {
+      set_errortext(1320);
+      return NULL;
+      }
+   strncpy(namebuf, fnamestr, sizeof(namebuf)-1);
+   namebuf[sizeof(namebuf)-1] = '\0';
+   user = NULL;
+   host = namebuf;
+   at = strchr(namebuf, '@');
+   if (at != NULL) {
+      *at = '\0';
+      user = namebuf;
+      host = at + 1;
+      }
+   if (*host == '\0') {
+      set_errortext_with_val(1320, fnamestr);
+      return NULL;
+      }
+   /*
+    * Optional :port.  Bracketed IPv6: "[addr]:port".  Otherwise take
+    * host:port only when there is a single colon, so a bare IPv6
+    * literal is not misparsed (same rule as socket open()).
+    */
+   if (host[0] == '[') {
+      rbrack = strchr(host + 1, ']');
+      if (rbrack == NULL || (rbrack[1] != '\0' && rbrack[1] != ':')) {
+         set_errortext_with_val(1320, fnamestr);
+         return NULL;
+         }
+      *rbrack = '\0';
+      host++;                           /* skip '[' */
+      if (*host == '\0') {
+         set_errortext_with_val(1320, fnamestr);
+         return NULL;
+         }
+      if (rbrack[1] == ':') {
+         port = atol(rbrack + 2);
+         if (port <= 0 || port > 65535) {
+            set_errortext_with_val(1320, fnamestr);
+            return NULL;
+            }
+         }
+      }
+   else {
+      colon = strrchr(host, ':');
+      if (colon != NULL && strchr(host, ':') == colon && colon[1] != '\0') {
+         *colon = '\0';
+         port = atol(colon + 1);
+         if (port <= 0 || port > 65535 || *host == '\0') {
+            set_errortext_with_val(1320, fnamestr);
+            return NULL;
+            }
+         }
+      }
+
+   /*
+    * Check the attributes, create_ssl_context() style.
+    */
+   for (a=0; a<n; a++) {
+      if (is:null(attr[a])) {
+         attr[a] = emptystr;
+         continue;
+         }
+      if (a==0 && cnv:C_integer(attr[a], timeout))
+         continue;
+      if (!cnv:C_string(attr[a], tmps)) {
+         set_errortext(1321);
+         return NULL;
+         }
+      if (strlen(tmps) < 3 || tmps[0] == '=' || tmps[strlen(tmps)-1] == '=') {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      /*
+       * Split a private copy at the '=' sign; cnv:C_string can return
+       * the caller's own string storage, which must not be mutated.
+       */
+      Protect(tmps = alcstr(tmps, (word)strlen(tmps)+1), fatalerr(0,NULL));
+      val = strchr(tmps, '=');
+      if (val == NULL) {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      *val = '\0';
+      val++;
+      if (strlen(val) == 0) {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      if (strcmp(tmps, "user") == 0)
+         userattr = val;
+      else if (strcmp(tmps, "key") == 0) {
+         key = val;
+         if (nauth < 2) auth_order[nauth++] = SSH_AUTH_ATTR_KEY;
+         }
+      else if (strcmp(tmps, "password") == 0) {
+         password = val;
+         if (nauth < 2) auth_order[nauth++] = SSH_AUTH_ATTR_PASSWORD;
+         }
+      else if (strcmp(tmps, "keypass") == 0)
+         keypass = val;
+      else if (strcmp(tmps, "hostkeyfile") == 0)
+         hostkeyfile = val;
+      else if (strcmp(tmps, "cmd") == 0)
+         cmd = val;
+      else if (strcmp(tmps, "channel") == 0) {
+         want_channel = sock_attr_bool(val);
+         if (want_channel < 0) {
+            set_errortext_with_val(1321, tmps);
+            return NULL;
+            }
+         }
+      else {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      }
+
+   /* an explicit user@host wins over a user= attribute */
+   if (user == NULL && userattr != NULL)
+      user = userattr;
+
+   /* channel=no with cmd= is contradictory */
+   if (!want_channel && cmd != NULL) {
+      set_errortext_with_val(1321, "channel");
+      return NULL;
+      }
+
+   sess = ssh_new();
+   if (sess == NULL) {
+      set_errortext(1320);
+      return NULL;
+      }
+   ssh_options_set(sess, SSH_OPTIONS_HOST, host);
+   if (user != NULL)
+      ssh_options_set(sess, SSH_OPTIONS_USER, user);
+   if (port != 0) {
+      unsigned int p = (unsigned int)port;
+      ssh_options_set(sess, SSH_OPTIONS_PORT, &p);
+      }
+   if (timeout > 0) {
+      long sec = timeout / 1000;
+      long usec = (timeout % 1000) * 1000;
+      ssh_options_set(sess, SSH_OPTIONS_TIMEOUT, &sec);
+      ssh_options_set(sess, SSH_OPTIONS_TIMEOUT_USEC, &usec);
+      }
+   if (hostkeyfile != NULL)
+      ssh_options_set(sess, SSH_OPTIONS_KNOWNHOSTS, hostkeyfile);
+
+   sshf = malloc(sizeof(struct SSHfile));
+   if (sshf == NULL) {
+      ssh_free(sess);
+      set_errortext(1320);
+      return NULL;
+      }
+   memset(sshf, 0, sizeof(struct SSHfile));
+
+   /*
+    * The network phase: no Icon allocation may happen between
+    * DEC_NARTHREADS and INC_NARTHREADS_CONTROLLED, so error text is
+    * only produced at the ssh_fail label after re-registering.
+    */
+   err = 1320;
+   DEC_NARTHREADS;
+
+   if (ssh_connect(sess) != SSH_OK)
+      goto ssh_fail;
+
+   if (do_verify) {
+      if (ssh_session_is_known_server(sess) != SSH_KNOWN_HOSTS_OK) {
+         err = 1323;
+         goto ssh_fail;
+         }
+      }
+
+   /*
+    * Authenticate: attributes in call order; with neither key= nor
+    * password= fall back to the default identities (~/.ssh keys or a
+    * running agent).
+    */
+   authed = 0;
+   if (nauth == 0) {
+      if (ssh_userauth_publickey_auto(sess, NULL, keypass) == SSH_AUTH_SUCCESS)
+         authed = 1;
+      }
+   for (a = 0; a < nauth && !authed; a++) {
+      if (auth_order[a] == SSH_AUTH_ATTR_KEY) {
+         ssh_key privkey = NULL;
+         if (ssh_pki_import_privkey_file(key, keypass, NULL, NULL,
+                                         &privkey) == SSH_OK) {
+            if (ssh_userauth_publickey(sess, NULL, privkey) == SSH_AUTH_SUCCESS)
+               authed = 1;
+            ssh_key_free(privkey);
+            }
+         }
+      else {
+         if (ssh_userauth_password(sess, NULL, password) == SSH_AUTH_SUCCESS)
+            authed = 1;
+         }
+      }
+   if (!authed) {
+      err = 1322;
+      goto ssh_fail;
+      }
+
+   /*
+    * Open a channel unless channel=no (transport-only session for
+    * later open(s, ...) / SFTP).  With a channel: exec when cmd= was
+    * given, otherwise an interactive shell on a pty.  Callbacks are
+    * set before the open so no early data bypasses the event queue.
+    */
+   if (want_channel) {
+      err = 1324;
+      chan = ssh_channel_new(sess);
+      if (chan == NULL)
+         goto ssh_fail;
+      if (ssh_chan_register_callbacks(sshf, chan) < 0)
+         goto ssh_fail;
+      if (ssh_channel_open_session(chan) != SSH_OK)
+         goto ssh_fail;
+      if (cmd != NULL) {
+         if (ssh_channel_request_exec(chan, cmd) != SSH_OK)
+            goto ssh_fail;
+         }
+      else {
+         if (ssh_channel_request_pty(chan) != SSH_OK)
+            goto ssh_fail;
+         if (ssh_channel_request_shell(chan) != SSH_OK)
+            goto ssh_fail;
+         }
+      }
+
+   INC_NARTHREADS_CONTROLLED;
+
+   sshf->sess = sess;
+   sshf->chan = chan;                   /* NULL when channel=no */
+   return sshf;
+
+ssh_fail:
+   INC_NARTHREADS_CONTROLLED;
+   set_ssh_errortext(sess, err);
+   if (chan != NULL)
+      ssh_channel_free(chan);
+   ssh_disconnect(sess);
+   ssh_free(sess);
+   ssh_free_file_state(sshf);
+   return NULL;
+}
+
+/*
+ * ssh_close_file() - close-hook cleanup for an SSH file.
+ *
+ * Closing a channel closes/frees just that channel and unlinks it from
+ * its session's list.  Closing the session file cascade-closes every
+ * remaining channel (their SSHfile structs are only freed when their
+ * own file is closed, but they are unusable from here on) and then
+ * tears down the connection.
+ */
+void ssh_close_file(struct SSHfile *sshf)
+{
+   struct SSHfile *ch, *nextch, **pp;
+
+   if (sshf == NULL)
+      return;
+
+   if (sshf->sfile != NULL) {
+      sftp_close(sshf->sfile);
+      sshf->sfile = NULL;
+      }
+   if (sshf->sdir != NULL) {
+      sftp_closedir(sshf->sdir);
+      sshf->sdir = NULL;
+      }
+
+   if (sshf->chan != NULL) {
+      ssh_channel_send_eof(sshf->chan);
+      ssh_channel_close(sshf->chan);
+      ssh_channel_free(sshf->chan);
+      sshf->chan = NULL;
+      }
+
+   if (sshf->parent != NULL) {
+      /* a channel: unlink from its session owner */
+      for (pp = &sshf->parent->children; *pp != NULL; pp = &(*pp)->next)
+         if (*pp == sshf) {
+            *pp = sshf->next;
+            break;
+            }
+      }
+   else if (sshf->sess != NULL) {
+      /*
+       * Session owner: invalidate every remaining channel.  Icon-level
+       * b_file handles stay alive until their own close(), but the
+       * closed flag and cleared queue make them unusable immediately
+       * (no dangling libssh objects, no readable leftovers).
+       */
+      for (ch = sshf->children; ch != NULL; ch = nextch) {
+         nextch = ch->next;
+         if (ch->sfile != NULL) {
+            sftp_close(ch->sfile);
+            ch->sfile = NULL;
+            }
+         if (ch->sdir != NULL) {
+            sftp_closedir(ch->sdir);
+            ch->sdir = NULL;
+            }
+         if (ch->chan != NULL) {
+            ssh_channel_send_eof(ch->chan);
+            ssh_channel_close(ch->chan);
+            ssh_channel_free(ch->chan);
+            ch->chan = NULL;
+            }
+         ch->sftp = NULL;               /* owned here, freed below */
+         ch->sess = NULL;
+         ch->parent = NULL;
+         ch->next = NULL;
+         ch->closed = 1;
+         ssh_clear_file_state(ch);
+         }
+      sshf->children = NULL;
+      if (sshf->sftp != NULL) {
+         sftp_free(sshf->sftp);
+         sshf->sftp = NULL;
+         }
+      ssh_disconnect(sshf->sess);
+      ssh_free(sshf->sess);
+      sshf->sess = NULL;
+      }
+
+   ssh_free_file_state(sshf);
+}
+
+/*
+ * ssh_file_write() - write all n bytes to an SSH channel or SFTP file.
+ * Retries short writes.  Returns n on success, or -1 with &errortext set.
+ */
+int ssh_file_write(struct SSHfile *sshf, char *s, word n)
+{
+   word total = 0;
+   int rc;
+
+   if (sshf == NULL || sshf->closed) {
+      set_errortext(1324);
+      return -1;
+      }
+   if (n == 0)
+      return 0;
+   if (sshf->sfile != NULL) {
+      DEC_NARTHREADS;
+      while (total < n) {
+         rc = sftp_write(sshf->sfile, s + total, (size_t)(n - total));
+         if (rc < 0) {
+            INC_NARTHREADS_CONTROLLED;
+            set_ssh_errortext(sshf->sess, 1325);
+            return -1;
+            }
+         if (rc == 0) {
+            INC_NARTHREADS_CONTROLLED;
+            set_ssh_errortext(sshf->sess, 1325);
+            return -1;
+            }
+         total += rc;
+         }
+      INC_NARTHREADS_CONTROLLED;
+      return (int)n;
+      }
+   if (sshf->chan == NULL) {
+      set_errortext(1324);
+      return -1;
+      }
+   DEC_NARTHREADS;
+   while (total < n) {
+      rc = ssh_channel_write(sshf->chan, s + total, (uint32_t)(n - total));
+      if (rc == SSH_ERROR) {
+         INC_NARTHREADS_CONTROLLED;
+         set_ssh_errortext(sshf->sess, 1324);
+         return -1;
+         }
+      if (rc == 0) {
+         INC_NARTHREADS_CONTROLLED;
+         set_ssh_errortext(sshf->sess, 1324);
+         return -1;
+         }
+      total += rc;
+      }
+   INC_NARTHREADS_CONTROLLED;
+   return (int)n;
+}
+
+/*
+ * ssh_getstrg() - sock_getstrg() equivalent for SSH channels: read a
+ * line of at most maxi characters into buf.  Returns the length not
+ * counting the newline, -1 on EOF, -3 on error.  Like sock_getstrg(),
+ * the newline is delivered separately as a one-character read; libssh
+ * has no MSG_PEEK, so a seen-but-unconsumed newline is remembered in
+ * nl_pending instead of being left in a kernel buffer.
+ */
+int ssh_getstrg(char *buf, int maxi, struct SSHfile *sshf)
+{
+   int i = 0, n;
+   char c;
+
+   /*
+    * Called under DEC_NARTHREADS.  On error return -3 without setting
+    * &errortext (alcstr is unsafe here); the caller re-registers and
+    * then calls set_ssh_errortext.
+    */
+   if (sshf == NULL || sshf->closed ||
+       (sshf->chan == NULL && sshf->sfile == NULL && sshf->q_stdout == 0))
+      return -3;
+   if (sshf->nl_pending) {
+      sshf->nl_pending = 0;
+      buf[0] = '\n';
+      return 1;
+      }
+   while (i < maxi) {
+      n = ssh_chan_read(sshf, &c, 1, 1);
+      if (n == 0)                       /* EOF */
+         return (i > 0) ? i : -1;
+      if (n < 0)                        /* error; caller sets &errortext */
+         return -3;
+      if (c == '\n') {
+         if (i == 0) {
+            buf[0] = '\n';
+            return 1;
+            }
+         sshf->nl_pending = 1;
+         return i;
+         }
+      buf[i++] = c;
+      }
+   return i;
+}
+
+/*
+ * create_ssh_channel() - open another channel on an existing session,
+ * reusing the transport and authentication.  spec is open()'s second
+ * argument, treated as the first attribute when given: with cmd= the
+ * channel is a one-shot exec channel, otherwise an interactive shell
+ * on a pty.  The new SSHfile is linked into the session owner's
+ * children list so that closing the session closes it too.
+ * On failure sets &errortext and returns NULL.
+ */
+struct SSHfile *create_ssh_channel(struct SSHfile *sf, dptr spec, dptr attr, int n)
+{
+   tended char *tmps, *val;
+   tended char *cmd = NULL;
+   struct SSHfile *owner, *sshf;
+   ssh_channel chan = NULL;
+   dptr dp;
+   int a;
+
+   /* resolve to the session owner: opening on a channel opens a sibling */
+   owner = (sf->parent != NULL) ? sf->parent : sf;
+   if (owner->sess == NULL) {
+      set_errortext(1324);
+      return NULL;
+      }
+
+   for (a = -1; a < n; a++) {
+      dp = (a < 0) ? spec : &attr[a];
+      if (is:null(*dp)) {
+         *dp = emptystr;
+         continue;
+         }
+      if (!cnv:C_string(*dp, tmps)) {
+         set_errortext(1321);
+         return NULL;
+         }
+      if (strlen(tmps) < 3 || tmps[0] == '=' || tmps[strlen(tmps)-1] == '=') {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      Protect(tmps = alcstr(tmps, (word)strlen(tmps)+1), fatalerr(0,NULL));
+      val = strchr(tmps, '=');
+      if (val == NULL) {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      *val = '\0';
+      val++;
+      if (strlen(val) == 0) {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      if (strcmp(tmps, "cmd") == 0)
+         cmd = val;
+      else {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      }
+
+   sshf = malloc(sizeof(struct SSHfile));
+   if (sshf == NULL) {
+      set_errortext(1324);
+      return NULL;
+      }
+   memset(sshf, 0, sizeof(struct SSHfile));
+
+   DEC_NARTHREADS;
+   chan = ssh_channel_new(owner->sess);
+   if (chan == NULL)
+      goto chan_fail;
+   if (ssh_chan_register_callbacks(sshf, chan) < 0)
+      goto chan_fail;
+   if (ssh_channel_open_session(chan) != SSH_OK)
+      goto chan_fail;
+   if (cmd != NULL) {
+      if (ssh_channel_request_exec(chan, cmd) != SSH_OK)
+         goto chan_fail;
+      }
+   else {
+      if (ssh_channel_request_pty(chan) != SSH_OK)
+         goto chan_fail;
+      if (ssh_channel_request_shell(chan) != SSH_OK)
+         goto chan_fail;
+      }
+   INC_NARTHREADS_CONTROLLED;
+
+   sshf->sess = owner->sess;
+   sshf->chan = chan;
+   sshf->parent = owner;
+   sshf->next = owner->children;
+   owner->children = sshf;
+   return sshf;
+
+chan_fail:
+   INC_NARTHREADS_CONTROLLED;
+   set_ssh_errortext(owner->sess, 1324);
+   if (chan != NULL)
+      ssh_channel_free(chan);
+   ssh_free_file_state(sshf);
+   return NULL;
+}
+
+/*
+ * ssh_owner_sftp() - lazily create (once) the session's shared sftp
+ * subsystem, returning it or NULL with &errortext set.
+ */
+static sftp_session ssh_owner_sftp(struct SSHfile *owner)
+{
+   sftp_session sftp;
+
+   if (owner->sftp != NULL)
+      return owner->sftp;
+   sftp = sftp_new(owner->sess);
+   if (sftp == NULL) {
+      set_ssh_errortext(owner->sess, 1325);
+      return NULL;
+      }
+   if (sftp_init(sftp) != SSH_OK) {
+      set_ssh_errortext(owner->sess, 1325);
+      sftp_free(sftp);
+      return NULL;
+      }
+   owner->sftp = sftp;
+   return sftp;
+}
+
+/*
+ * create_sftp_file() - open a remote path over SFTP on an existing
+ * session.  Recognizes attributes path= (required), and the same r/w/a
+ * intent already parsed into status.  If the path is a directory, opens
+ * it for listing and sets *isdir; otherwise opens a regular file.  On
+ * failure sets &errortext and returns NULL.
+ */
+struct SSHfile *create_sftp_file(struct SSHfile *sf, dptr attr, int n,
+                                 int status, int *isdir)
+{
+   tended char *tmps, *val, *path = NULL;
+   struct SSHfile *owner, *sshf;
+   sftp_session sftp;
+   sftp_attributes at;
+   int a, accesstype;
+
+   *isdir = 0;
+   owner = (sf->parent != NULL) ? sf->parent : sf;
+   if (owner->sess == NULL) {
+      set_errortext(1324);
+      return NULL;
+      }
+
+   for (a = 0; a < n; a++) {
+      if (is:null(attr[a])) {
+         attr[a] = emptystr;
+         continue;
+         }
+      if (!cnv:C_string(attr[a], tmps)) {
+         set_errortext(1321);
+         return NULL;
+         }
+      if (strcmp(tmps, "sftp") == 0)   /* the mode selector itself */
+         continue;
+      /*
+       * Mode-only tokens ("w", "r", "a", "b", ...) carry no '=' and are
+       * handled by the caller's mode scan; skip them here.
+       */
+      if (strchr(tmps, '=') == NULL)
+         continue;
+      if (tmps[0] == '=' || tmps[strlen(tmps)-1] == '=') {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      Protect(tmps = alcstr(tmps, (word)strlen(tmps)+1), fatalerr(0,NULL));
+      val = strchr(tmps, '=');
+      *val = '\0';
+      val++;
+      if (strlen(val) == 0) {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      if (strcmp(tmps, "path") == 0)
+         path = val;
+      else {
+         set_errortext_with_val(1321, tmps);
+         return NULL;
+         }
+      }
+   if (path == NULL) {
+      set_errortext(1325);
+      return NULL;
+      }
+
+   sftp = ssh_owner_sftp(owner);
+   if (sftp == NULL)
+      return NULL;                      /* &errortext already set */
+
+   sshf = malloc(sizeof(struct SSHfile));
+   if (sshf == NULL) {
+      set_errortext(1325);
+      return NULL;
+      }
+   memset(sshf, 0, sizeof(struct SSHfile));
+   sshf->sess = owner->sess;
+   sshf->sftp = sftp;
+   sshf->parent = owner;
+
+   DEC_NARTHREADS;
+   at = sftp_stat(sftp, path);
+   if (at != NULL && at->type == SSH_FILEXFER_TYPE_DIRECTORY) {
+      sftp_attributes_free(at);
+      sshf->sdir = sftp_opendir(sftp, path);
+      INC_NARTHREADS_CONTROLLED;
+      if (sshf->sdir == NULL) {
+         set_ssh_errortext(owner->sess, 1325);
+         free(sshf);
+         return NULL;
+         }
+      *isdir = 1;
+      }
+   else {
+      if (at != NULL)
+         sftp_attributes_free(at);
+      if (status & Fs_Append)
+         accesstype = O_WRONLY | O_CREAT | O_APPEND;
+      else if ((status & Fs_Write) && (status & Fs_Read))
+         accesstype = O_RDWR | O_CREAT;
+      else if (status & Fs_Write)
+         accesstype = O_WRONLY | O_CREAT | O_TRUNC;
+      else
+         accesstype = O_RDONLY;
+      sshf->sfile = sftp_open(sftp, path, accesstype, 0644);
+      INC_NARTHREADS_CONTROLLED;
+      if (sshf->sfile == NULL) {
+         set_ssh_errortext(owner->sess, 1325);
+         free(sshf);
+         return NULL;
+         }
+      }
+
+   sshf->next = owner->children;
+   owner->children = sshf;
+   return sshf;
+}
+
+/*
+ * ssh_sftp_readdir() - copy the next directory entry name into buf,
+ * returning its length, or -1 at end of directory / on error (with
+ * &errortext set only on a real error).
+ */
+int ssh_sftp_readdir(struct SSHfile *sshf, char *buf, int maxi)
+{
+   sftp_attributes at;
+   int len;
+
+   if (sshf->sdir == NULL) {
+      set_errortext(1325);
+      return -1;
+      }
+   DEC_NARTHREADS;
+   at = sftp_readdir(sshf->sftp, sshf->sdir);
+   INC_NARTHREADS_CONTROLLED;
+   if (at == NULL) {
+      if (!sftp_dir_eof(sshf->sdir))
+         set_ssh_errortext(sshf->sess, 1325);
+      return -1;
+      }
+   len = (at->name != NULL) ? (int)strlen(at->name) : 0;
+   if (len > maxi)
+      len = maxi;
+   if (len > 0)
+      memcpy(buf, at->name, len);
+   sftp_attributes_free(at);
+   return len;
+}
+
+/*
+ * sftp2rec() - populate a posix_stat record from SFTP attributes.
+ * Fields the server did not send (SFTP attribute coverage is
+ * protocol-version dependent) are left null rather than reported as
+ * zero, so callers can tell "absent" from "genuinely zero".
+ */
+static void sftp2rec(sftp_attributes at, struct descrip *dp,
+                     struct b_record **rp)
+{
+   int i;
+   char mode[12];
+
+   dp->dword = D_Record;
+   dp->vword.bptr = (union block *)(*rp);
+
+   for (i = 0; i < 14; i++)
+      (*rp)->fields[i] = nulldesc;
+
+   /* size (field 7) */
+   if (at->flags & SSH_FILEXFER_ATTR_SIZE) {
+      (*rp)->fields[7].dword = D_Integer;
+      IntVal((*rp)->fields[7]) = (word)at->size;
+      }
+   /* uid/gid (fields 4,5) */
+   if (at->flags & SSH_FILEXFER_ATTR_UIDGID) {
+      if (at->owner != NULL) {
+         Protect(StrLoc((*rp)->fields[4]) = alcstr(at->owner, strlen(at->owner)),
+                 fatalerr(0,NULL));
+         StrLen((*rp)->fields[4]) = strlen(at->owner);
+         }
+      else {
+         char b[32];
+         snprintf(b, sizeof(b), "%lu", (unsigned long)at->uid);
+         Protect(StrLoc((*rp)->fields[4]) = alcstr(b, strlen(b)), fatalerr(0,NULL));
+         StrLen((*rp)->fields[4]) = strlen(b);
+         }
+      if (at->group != NULL) {
+         Protect(StrLoc((*rp)->fields[5]) = alcstr(at->group, strlen(at->group)),
+                 fatalerr(0,NULL));
+         StrLen((*rp)->fields[5]) = strlen(at->group);
+         }
+      else {
+         char b[32];
+         snprintf(b, sizeof(b), "%lu", (unsigned long)at->gid);
+         Protect(StrLoc((*rp)->fields[5]) = alcstr(b, strlen(b)), fatalerr(0,NULL));
+         StrLen((*rp)->fields[5]) = strlen(b);
+         }
+      }
+   /* times (fields 8,9,10): SFTP carries atime/mtime; no ctime */
+   if (at->flags & SSH_FILEXFER_ATTR_ACMODTIME) {
+      (*rp)->fields[8].dword = D_Integer;
+      IntVal((*rp)->fields[8]) = (word)at->atime;
+      (*rp)->fields[9].dword = D_Integer;
+      IntVal((*rp)->fields[9]) = (word)at->mtime;
+      }
+   /* permissions -> mode string (field 2) */
+   if (at->flags & SSH_FILEXFER_ATTR_PERMISSIONS) {
+      uint32_t m = at->permissions;
+      strcpy(mode, "----------");
+      switch (at->type) {
+         case SSH_FILEXFER_TYPE_DIRECTORY: mode[0] = 'd'; break;
+         case SSH_FILEXFER_TYPE_SYMLINK:   mode[0] = 'l'; break;
+         case SSH_FILEXFER_TYPE_SPECIAL:   mode[0] = 'c'; break;
+         default: break;
+         }
+      if (m & 0400) mode[1] = 'r';
+      if (m & 0200) mode[2] = 'w';
+      if (m & 0100) mode[3] = 'x';
+      if (m & 040)  mode[4] = 'r';
+      if (m & 020)  mode[5] = 'w';
+      if (m & 010)  mode[6] = 'x';
+      if (m & 04)   mode[7] = 'r';
+      if (m & 02)   mode[8] = 'w';
+      if (m & 01)   mode[9] = 'x';
+      Protect(StrLoc((*rp)->fields[2]) = alcstr(mode, 10), fatalerr(0,NULL));
+      StrLen((*rp)->fields[2]) = 10;
+      }
+}
+
+/*
+ * ssh_sftp_stat_rec() - stat a remote path (use_fstat==0, path given)
+ * or an already-open sftp file (use_fstat==1, sf is the file), filling
+ * a freshly allocated posix_stat record.  Returns 1 on success, 0 on
+ * failure with &errortext set.
+ */
+int ssh_sftp_stat_rec(struct SSHfile *sf, char *path, int use_fstat,
+                      struct descrip *dp, struct b_record **rp)
+{
+   struct SSHfile *owner;
+   sftp_session sftp;
+   sftp_attributes at;
+
+   owner = (sf->parent != NULL) ? sf->parent : sf;
+   if (use_fstat) {
+      if (sf->sfile == NULL) {
+         set_errortext(1325);
+         return 0;
+         }
+      sftp = sf->sftp;
+      DEC_NARTHREADS;
+      at = sftp_fstat(sf->sfile);
+      INC_NARTHREADS_CONTROLLED;
+      }
+   else {
+      sftp = ssh_owner_sftp(owner);
+      if (sftp == NULL)
+         return 0;
+      DEC_NARTHREADS;
+      at = sftp_stat(sftp, path);
+      INC_NARTHREADS_CONTROLLED;
+      }
+   if (at == NULL) {
+      set_ssh_errortext(owner->sess, 1325);
+      return 0;
+      }
+   sftp2rec(at, dp, rp);
+   sftp_attributes_free(at);
+   return 1;
+}
+
+/*
+ * ssh_sftp_unlink() / ssh_sftp_rename() - metadata verbs, returning 0
+ * on success or -1 with &errortext set.
+ */
+int ssh_sftp_unlink(struct SSHfile *sf, char *path)
+{
+   struct SSHfile *owner = (sf->parent != NULL) ? sf->parent : sf;
+   sftp_session sftp = ssh_owner_sftp(owner);
+   int rc;
+
+   if (sftp == NULL)
+      return -1;
+   DEC_NARTHREADS;
+   rc = sftp_unlink(sftp, path);
+   INC_NARTHREADS_CONTROLLED;
+   if (rc != SSH_OK) {
+      set_ssh_errortext(owner->sess, 1325);
+      return -1;
+      }
+   return 0;
+}
+
+int ssh_sftp_rename(struct SSHfile *sf, char *from, char *to)
+{
+   struct SSHfile *owner = (sf->parent != NULL) ? sf->parent : sf;
+   sftp_session sftp = ssh_owner_sftp(owner);
+   int rc;
+
+   if (sftp == NULL)
+      return -1;
+   DEC_NARTHREADS;
+   rc = sftp_rename(sftp, from, to);
+   INC_NARTHREADS_CONTROLLED;
+   if (rc != SSH_OK) {
+      set_ssh_errortext(owner->sess, 1325);
+      return -1;
+      }
+   return 0;
+}
+#endif                                  /* HAVE_LIBSSH */
+
 
 #if !NT
 dptr make_pwd(struct passwd *pw, dptr result)
@@ -4281,6 +5456,36 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
       /* Allocate n bytes of char space */
       StrLoc(*d) = alcstr(NULL, n);
       StrLen(*d) = 0;
+#if HAVE_LIBSSH
+      if (fstatus & Fs_SSH) {
+         struct SSHfile *sshf = BlkD(*f,File)->fd.sshf;
+#ifdef Concurrent
+         MUTEX_LOCKID_CONTROLLED(BlkD(*f,File)->mutexid);
+#endif                                  /* Concurrent */
+         if (sshf == NULL || sshf->closed ||
+             (sshf->chan == NULL && sshf->sfile == NULL &&
+              sshf->q_stdout == 0)) {
+            set_errortext(1324);
+            tally = -1;
+            }
+         else if (sshf->nl_pending) {
+            sshf->nl_pending = 0;
+            *StrLoc(*d) = '\n';
+            tally = 1;
+            }
+         else {
+            DEC_NARTHREADS;
+            tally = ssh_chan_read(sshf, StrLoc(*d), n, 1);
+            INC_NARTHREADS_CONTROLLED;
+            if (tally < 0)
+               set_ssh_errortext(sshf->sess, sshf->sfile ? 1325 : 1324);
+            }
+#ifdef Concurrent
+         MUTEX_UNLOCKID(BlkD(*f,File)->mutexid);
+#endif                                  /* Concurrent */
+         }
+      else
+#endif                                  /* HAVE_LIBSSH */
       if (fstatus & Fs_Socket) {
 #if HAVE_LIBSSL
         if (fstatus & Fs_Encrypt) {
@@ -4318,6 +5523,43 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
          int srv, kk=0;
          fd_set readset;
          struct timeval tv;
+#if HAVE_LIBSSH
+         if (fstatus & Fs_SSH) {
+            /*
+             * select() on the session fd cannot see data already
+             * decrypted and queued inside libssh; pump the channel.
+             * SFTP files have no channel queue -- just try a read.
+             */
+            struct SSHfile *sshf = BlkD(*f,File)->fd.sshf;
+            if (sshf == NULL || sshf->closed ||
+                (sshf->chan == NULL && sshf->sfile == NULL &&
+                 sshf->q_stdout == 0)) {
+               set_errortext(1324);
+               return 0;
+               }
+            if (sshf->sfile != NULL) {
+               /* fall through to the read below */
+               }
+            else if (!sshf->nl_pending && sshf->q_stdout == 0) {
+               int prc;
+               DEC_NARTHREADS;
+               prc = ssh_pump(sshf, 0, 1);
+               INC_NARTHREADS_CONTROLLED;
+               if (prc == -1) {
+                  set_ssh_errortext(sshf->sess, 1324);
+                  return 0;
+                  }
+               if (prc == 2)
+                  break;                /* nothing more is available */
+               if (prc == 0) {          /* EOF */
+                  if (StrLen(*d) == 0)
+                     return 0;
+                  break;
+                  }
+               }
+            }
+         else {
+#endif                                  /* HAVE_LIBSSH */
          FD_ZERO(&readset);
          FD_SET(fd, &readset);
          tv.tv_sec = tv.tv_usec = 0;
@@ -4329,6 +5571,9 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
             set_syserrortext(errno);
             return 0;
             }
+#if HAVE_LIBSSH
+         }
+#endif                                  /* HAVE_LIBSSH */
 
          /* Something is available: allocate another chunk */
          if (i == 0)
@@ -4350,6 +5595,29 @@ dptr u_read(dptr f, int n, int fstatus, dptr d)
          }
 tryagain:
 
+#if HAVE_LIBSSH
+         if (fstatus & Fs_SSH) {
+            struct SSHfile *sshf = BlkD(*f,File)->fd.sshf;
+            if (sshf->nl_pending) {
+               sshf->nl_pending = 0;
+               *(StrLoc(*d) + i*bufsize) = '\n';
+               tally = 1;
+               }
+            else {
+               DEC_NARTHREADS;
+               tally = ssh_chan_read(sshf, StrLoc(*d) + i*bufsize,
+                                     bufsize, 0);
+               INC_NARTHREADS_CONTROLLED;
+               if (tally < 0) {
+                  set_ssh_errortext(sshf->sess, sshf->sfile ? 1325 : 1324);
+                  strtotal += bufsize;
+                  strfree = StrLoc(*d);
+                  return 0;
+                  }
+               }
+            }
+         else
+#endif                                  /* HAVE_LIBSSH */
          if (fstatus & Fs_Socket) {
 #if HAVE_LIBSSL
            if (fstatus & Fs_Encrypt) {

--- a/src/runtime/rsys.r
+++ b/src/runtime/rsys.r
@@ -2168,3 +2168,219 @@ int mswinsystem(char *s)
       return rv;
 }
 #endif                                  /* MSWindows */
+
+#if NT && defined(PosixFns)
+/*
+ * Winsock select() only accepts SOCKETs.  CRT-backed files (&input,
+ * pipes, regular files) are waited on separately via WaitFor /
+ * PeekNamedPipe, matching the Win32 PTY select path.
+ */
+int win_crt_selectable(unsigned int status)
+{
+   if (!(status & Fs_Read))
+      return 0;
+   if (status & (Fs_Socket | Fs_Directory
+#ifdef Messaging
+                 | Fs_Messaging
+#endif                                  /* Messaging */
+#ifdef Graphics
+                 | Fs_Window
+#endif                                  /* Graphics */
+#ifdef PseudoPty
+                 | Fs_Pty
+#endif                                  /* PseudoPty */
+#ifdef Dbm
+                 | Fs_Dbm
+#endif                                  /* Dbm */
+#ifdef ISQL
+                 | Fs_ODBC
+#endif                                  /* ISQL */
+#if HAVE_LIBSSH
+                 | Fs_SSH
+#endif                                  /* HAVE_LIBSSH */
+#if HAVE_LIBZ
+                 | Fs_Compress
+#endif                                  /* HAVE_LIBZ */
+#ifdef HAVE_VOICE
+                 | Fs_Voice
+#endif                                  /* HAVE_VOICE */
+                 ))
+      return 0;
+   return 1;
+}
+
+/*
+ * Non-zero if a CRT-backed file has input ready (or EOF).
+ */
+int win_crt_pending(struct b_file *fp)
+{
+   HANDLE h;
+   DWORD n, ftype;
+   FILE *f;
+
+   if (fp == NULL || !(fp->status & Fs_Read))
+      return 0;
+   f = fp->fd.fp;
+   if (f == NULL)
+      return 0;
+   if (feof(f))
+      return 1;
+   h = (HANDLE)_get_osfhandle(_fileno(f));
+   if (h == INVALID_HANDLE_VALUE || h == (HANDLE)-1)
+      return 0;
+   ftype = GetFileType(h);
+   if (ftype == FILE_TYPE_DISK)
+      return 1;                         /* regular file: always readable */
+   if (ftype == FILE_TYPE_PIPE) {
+      if (PeekNamedPipe(h, NULL, 0, NULL, &n, NULL))
+         return n > 0;
+      return 1;                         /* broken/closed pipe => EOF ready */
+      }
+   /* console or other character device */
+   return WaitForSingleObject(h, 0) == WAIT_OBJECT_0;
+}
+
+/*
+ * Return a list of CRT files from lcs that are ready, or NULL.
+ */
+struct b_list *findactivecrt(struct b_list *lcs)
+{
+   word i, j;
+   tended union block *ep;
+   tended struct descrip d;
+
+   if (lcs == NULL || lcs->size == 0)
+      return NULL;
+   d = nulldesc;
+   ep = (union block *)(lcs->listhead);
+   for ( ; BlkType(ep) == T_Lelem; ep = ep->Lelem.listnext) {
+      for (i = 0; i < ep->Lelem.nused; i++) {
+         struct b_file *fp;
+         int status;
+         j = ep->Lelem.first + i;
+         if (j >= ep->Lelem.nslots)
+            j -= ep->Lelem.nslots;
+         if (!is:file(ep->Lelem.lslots[j]))
+            continue;
+         status = BlkD(ep->Lelem.lslots[j], File)->status;
+         if (!win_crt_selectable(status))
+            continue;
+         fp = BlkD(ep->Lelem.lslots[j], File);
+         if (win_crt_pending(fp)) {
+            if (is:null(d)) {
+               BlkLoc(d) = (union block *)alclist(0, MinListSlots);
+               d.dword = D_List;
+               }
+            c_put(&d, &(ep->Lelem.lslots[j]));
+            }
+         }
+      }
+   if (is:null(d))
+      return NULL;
+   return (struct b_list *)BlkLoc(d);
+}
+
+/*
+ * Put console fd into raw (or restored sane) input mode for Attrib(f,"tty=").
+ * Returns 0 on success, -1 if fd is not a console or the call fails.
+ */
+int win_console_set_raw(int fd, int raw)
+{
+   static DWORD saved_in = 0, saved_out = 0;
+   static int have_saved = 0;
+   static int saved_fd = -1;
+   HANDLE hin, hout;
+   DWORD mode;
+
+   if (fd < 0)
+      return -1;
+   hin = (HANDLE)_get_osfhandle(fd);
+   if (hin == NULL || hin == INVALID_HANDLE_VALUE || hin == (HANDLE)-1)
+      return -1;
+   hout = GetStdHandle(STD_OUTPUT_HANDLE);
+   if (raw) {
+      if (!GetConsoleMode(hin, &mode))
+         return -1;
+      if (!have_saved || saved_fd != fd) {
+         saved_in = mode;
+         saved_out = 0;
+         if (hout != NULL && hout != INVALID_HANDLE_VALUE &&
+             GetConsoleMode(hout, &mode))
+            saved_out = mode;
+         have_saved = 1;
+         saved_fd = fd;
+         }
+      mode = saved_in;
+      mode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+      if (!SetConsoleMode(hin, mode))
+         return -1;
+      if (hout != NULL && hout != INVALID_HANDLE_VALUE &&
+          GetConsoleMode(hout, &mode)) {
+         mode |= ENABLE_PROCESSED_OUTPUT;
+#ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+         mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+#endif
+         SetConsoleMode(hout, mode);
+         }
+      return 0;
+      }
+   if (!have_saved || saved_fd != fd)
+      return 0;
+   if (!SetConsoleMode(hin, saved_in))
+      return -1;
+   if (hout != NULL && hout != INVALID_HANDLE_VALUE && saved_out != 0)
+      SetConsoleMode(hout, saved_out);
+   have_saved = 0;
+   saved_fd = -1;
+   return 0;
+}
+#endif                                  /* NT && PosixFns */
+
+#if UNIX && defined(PosixFns)
+/*
+ * Save/restore termios on fd for Attrib(f, "tty=raw"|"tty=sane").
+ * "sane" restores the mode saved at the last "raw" on that fd, or
+ * applies cooked defaults if nothing was saved.
+ */
+int unix_tty_set_raw(int fd, int raw)
+{
+   static struct termios saved;
+   static int have_saved = 0;
+   static int saved_fd = -1;
+   struct termios tty;
+
+   if (fd < 0 || !isatty(fd))
+      return -1;
+   if (raw) {
+      if (tcgetattr(fd, &tty) < 0)
+         return -1;
+      if (!have_saved || saved_fd != fd) {
+         saved = tty;
+         have_saved = 1;
+         saved_fd = fd;
+         }
+      tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHOK | ECHONL | ISIG | IEXTEN);
+      tty.c_iflag &= ~(IXON | IXOFF | ICRNL | INLCR | IGNCR);
+      tty.c_oflag &= ~(OPOST);
+      tty.c_cc[VMIN] = 1;
+      tty.c_cc[VTIME] = 0;
+      return tcsetattr(fd, TCSANOW, &tty) < 0 ? -1 : 0;
+      }
+   if (have_saved && saved_fd == fd) {
+      if (tcsetattr(fd, TCSANOW, &saved) < 0)
+         return -1;
+      have_saved = 0;
+      saved_fd = -1;
+      return 0;
+      }
+   if (tcgetattr(fd, &tty) < 0)
+      return -1;
+   tty.c_lflag |= (ICANON | ECHO | ISIG);
+   tty.c_iflag |= ICRNL;
+   tty.c_oflag |= OPOST;
+#ifdef ONLCR
+   tty.c_oflag |= ONLCR;
+#endif                                  /* ONLCR */
+   return tcsetattr(fd, TCSANOW, &tty) < 0 ? -1 : 0;
+}
+#endif                                  /* UNIX && PosixFns */

--- a/src/runtime/rsys.r
+++ b/src/runtime/rsys.r
@@ -17,6 +17,11 @@ int sock_getstrg(register char *buf, int maxi, dptr file)
    int r = 0, i=0;
    char *stmp=NULL;
 
+#if HAVE_LIBSSH
+   if (BlkD(*file, File)->status & Fs_SSH)
+      return ssh_getstrg(buf, maxi, BlkD(*file, File)->fd.sshf);
+#endif                                  /* HAVE_LIBSSH */
+
 #if HAVE_LIBSSL
    if (BlkD(*file, File)->status & Fs_Encrypt) {
      r = SSL_peek(BlkD(*file, File)->fd.ssl, buf, maxi);

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -34,6 +34,7 @@ IGNORE=
 #               All use fork(); same blocker unless rewritten without fork.
 #   uxsocket    Unix-domain sockets + fork; AF_UNIX differs on Windows (and fork).
 #   rusage      getrusage() stubbed on NT (fail); needs a Windows implementation or skip.
+#   select-io is enabled on Windows: CRT &input / files use findactivecrt().
 #
 WINSKIP=pty_uni tcp wait fork fdup filepair kill pipe-select select udp uxsocket rusage
 

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -14,6 +14,10 @@ ifeq ($(findstring multiple programs,$(UCFEAT)),)
 SKIP += pty_uni
 endif
 endif
+# ssh needs libssh (the "secure shell" feature); skip when built without it.
+ifeq ($(findstring secure shell,$(UCFEAT)),)
+SKIP += ssh
+endif
 endif
 
 TARGETS=$(patsubst %.icn,%,$(wildcard *.icn))

--- a/tests/posix/icont.lst
+++ b/tests/posix/icont.lst
@@ -27,6 +27,7 @@ pipe-select
 kill
 
 select
+select-io
 spawn
 
 umask

--- a/tests/posix/pipe-select.icn
+++ b/tests/posix/pipe-select.icn
@@ -1,4 +1,5 @@
-# select() + reads() on a pipe only (not &input — would raise error 1048).
+# select() + reads() on a pipe (writer in a child).
+# For select(&input) / Buff-Unbuf mixing, see select-io.icn.
 $include "posix.icn"
 
 procedure main()
@@ -14,8 +15,6 @@ procedure main()
       # parent: reader
       close(L[2])
       while 1 do {
-         # Only select on the pipe: select(&input,...) triggers run-time error 1048
-         # (buffered console read cannot mix with select on &input).
          while *(L := select(L[1], 1000)) = 0 do
             delay(10)
          (&errno = 0) | stop("Select failed: ", sys_errstr(&errno))

--- a/tests/posix/select-io.icn
+++ b/tests/posix/select-io.icn
@@ -1,0 +1,50 @@
+#
+# select-io.icn - select() / reads() mixing for interactive-style I/O
+#
+# Covers the primitives ussh relies on:
+#   1. Timed select(&input) must not raise 1048 (even with nothing ready).
+#   2. select → reads → select on a regular file must keep working: after
+#      select() marks a file Fs_Unbuf, reads() must not stick Fs_Buff on it
+#      (that used to make the next select() raise 1048).
+#   3. Byte-sized reads() across that loop (not only whole-line read()).
+#
+# No stty here: automated runs are not on a controlling tty, and leaving
+# the terminal raw on failure is worse than skipping that check.
+#
+
+procedure main()
+   local f, L, path, data, i
+
+   #
+   # Timed select on &input: must succeed without 1048.  Do not
+   # reads(&input) — that would consume the test harness's stdin.
+   # List size is not checked: a closed/redirected stdin is often
+   # reported ready (EOF), so *L may be 0 or 1 depending on the runner.
+   #
+   L := select(&input, 50) |
+      stop("select(&input) failed: ", image(&errornumber), " ", &errortext)
+   write("input-select: ok")
+
+   #
+   # Regular file: always readable to select(2).  Three select/reads
+   # rounds must all succeed without 1048.
+   #
+   path := "local/select-io.dat"
+   f := open(path, "w") | stop("cannot create ", path)
+   writes(f, "abcdef")
+   close(f)
+
+   f := open(path) | stop("cannot open ", path)
+   every i := 1 to 3 do {
+      L := select(f, 1000) |
+         stop("select(file) #", i, " failed: ", image(&errornumber),
+              " ", &errortext)
+      (*L > 0) | stop("select(file) #", i, " returned empty")
+      data := reads(f, 2) | stop("reads(file) #", i, " failed")
+      write("file-chunk-", i, ": ", image(data))
+      }
+   close(f)
+   remove(path)
+
+   write("select-io done")
+end

--- a/tests/posix/ssh.icn
+++ b/tests/posix/ssh.icn
@@ -1,0 +1,127 @@
+# Native SSH client support (open() mode "h", libssh-backed).
+#
+# This test is deterministic and needs no SSH server for its default run:
+# it checks the _SSH feature is present and that the error paths fail
+# cleanly with &errortext set.  A full round-trip against a real server
+# is exercised only when UNICON_SSH_TESTHOST is set (host or user@host);
+# see the header of live_test() for the other UNICON_SSH_* variables.
+
+procedure main()
+   write("feature _SSH: ", if &features == "secure shell" then "yes" else "no")
+
+   # A bad attribute must fail (not abort) with &errortext set.
+   f := open("nobody@127.0.0.1", "h", "bogus=1")
+   write("bad-attribute open fails: ", failed_with_text(f))
+
+   # channel= must be yes/no; other values are bad attributes.
+   f := open("nobody@127.0.0.1", "h", "channel=maybe")
+   write("bad-channel open fails: ", failed_with_text(f))
+
+   # channel=no with cmd= is contradictory.
+   f := open("nobody@127.0.0.1", "h", "channel=no", "cmd=true")
+   write("channel=no+cmd open fails: ", failed_with_text(f))
+
+   # Connecting to a closed local port must fail with &errortext set.
+   f := open("nobody@127.0.0.1:1", "h", "cmd=true")
+   write("connect-refused open fails: ", failed_with_text(f))
+
+   live_test()
+   write("ssh test done")
+end
+
+# Report "yes" when open() failed (produced &null) and left a &errortext.
+procedure failed_with_text(f)
+   if /f & (*&errortext > 0) then return "yes"
+   if \f then close(f)
+   return "no"
+end
+
+# Build open() argv for addr (host or user@host[:port]).
+# Mode is "h-" when no known_hosts file is provided.
+procedure ssh_opts(addr, attrs[])
+   local opts, key, kh, a
+   opts := [addr, "h"]
+   every a := !attrs do put(opts, a)
+   if key := getenv("UNICON_SSH_TESTKEY") then put(opts, "key=" || key)
+   if kh := getenv("UNICON_SSH_KNOWNHOSTS") then put(opts, "hostkeyfile=" || kh)
+   else opts[2] := "h-"
+   return opts
+end
+
+# Append :port from UNICON_SSH_TESTPORT when set (host should not already
+# include a port in that case).
+procedure ssh_addr(host)
+   local p
+   p := getenv("UNICON_SSH_TESTPORT") | {
+      return host
+      }
+   return host || ":" || p
+end
+
+# Live round-trip, only when UNICON_SSH_TESTHOST is set:
+#   UNICON_SSH_TESTHOST   host or user@host (optionally with :port)
+#   UNICON_SSH_TESTPORT   appended as :port when set (libssh default 22)
+#   UNICON_SSH_TESTKEY    private key path (else default identities/agent)
+#   UNICON_SSH_KNOWNHOSTS known_hosts path (else host-key check is skipped)
+#   UNICON_SSH_SFTPPATH   remote directory for SFTP checks (optional)
+procedure live_test()
+   local host, addr, opts, s, line, got, c, info, remote
+
+   host := getenv("UNICON_SSH_TESTHOST") | {
+      write("live round-trip: skipped (set UNICON_SSH_TESTHOST)")
+      return
+      }
+   addr := ssh_addr(host)
+
+   opts := ssh_opts(addr, "cmd=echo unicon_ssh_ok")
+   s := open ! opts | {
+      write("live round-trip: open failed: ", &errortext)
+      return
+      }
+   got := ""
+   while line := read(s) do got ||:= line
+   write("live round-trip: ", if find("unicon_ssh_ok", got) then "pass" else "fail")
+   write("live exit status: ", Attrib(s, "exitstatus"))
+   close(s)
+
+   # Second connection: receive() ordering + stderr/exit events
+   opts := ssh_opts(addr, "cmd=echo out1; echo err1 1>&2; echo out2; exit 3")
+   s := open ! opts | {
+      write("live receive: open failed: ", &errortext)
+      return
+      }
+   got := ""
+   while m := receive(s) do
+      got ||:= m.addr || "=" || trim(m.msg, '\n') || ";"
+   write("live receive: ", if find("stdout=", got) & find("exit=", got)
+      then "pass" else "fail")
+   close(s)
+
+   # Optional SFTP checks when a remote writable directory is provided
+   remote := getenv("UNICON_SSH_SFTPPATH") | {
+      write("live sftp: skipped (set UNICON_SSH_SFTPPATH)")
+      return
+      }
+   opts := ssh_opts(addr, "channel=no")
+   s := open ! opts | {
+      write("live sftp: open failed: ", &errortext)
+      return
+      }
+   c := open(s, "sftp", "path=" || remote || "/unicon_ssh_bin.bin", "w") |
+        stop("live sftp write-open failed: ", &errortext)
+   writes(c, "\x00\x01\x02\n\xff") | stop("live sftp writes failed: ", &errortext)
+   close(c)
+   c := open(s, "sftp", "path=" || remote || "/unicon_ssh_bin.bin") |
+        stop("live sftp read-open failed: ", &errortext)
+   got := reads(c, 5) | stop("live sftp reads failed: ", &errortext)
+   close(c)
+   write("live sftp binary: ",
+      if got == "\x00\x01\x02\n\xff" then "pass" else "fail")
+   info := stat(s, remote || "/unicon_ssh_bin.bin") |
+           stop("live sftp stat failed: ", &errortext)
+   write("live sftp stat size: ", if info.size = 5 then "pass" else "fail")
+   remove(s, remote || "/unicon_ssh_bin.bin") |
+      stop("live sftp remove failed: ", &errortext)
+   write("live sftp remove: pass")
+   close(s)
+end

--- a/tests/posix/ssh.icn
+++ b/tests/posix/ssh.icn
@@ -65,7 +65,7 @@ end
 #   UNICON_SSH_KNOWNHOSTS known_hosts path (else host-key check is skipped)
 #   UNICON_SSH_SFTPPATH   remote directory for SFTP checks (optional)
 procedure live_test()
-   local host, addr, opts, s, line, got, c, info, remote
+   local host, addr, opts, s, line, got, c, info, remote, L, chunk
 
    host := getenv("UNICON_SSH_TESTHOST") | {
       write("live round-trip: skipped (set UNICON_SSH_TESTHOST)")
@@ -95,6 +95,30 @@ procedure live_test()
       got ||:= m.addr || "=" || trim(m.msg, '\n') || ";"
    write("live receive: ", if find("stdout=", got) & find("exit=", got)
       then "pass" else "fail")
+   close(s)
+
+   #
+   # Partial line via reads(): interactive prompts have no trailing
+   # newline.  reads() on an SSH channel must return those bytes without
+   # blocking for '\\n' (the old sock_getstrg path hung here).
+   #
+   opts := ssh_opts(addr, "cmd=printf 'partial_ssh_line'")
+   s := open ! opts | {
+      write("live partial-reads: open failed: ", &errortext)
+      return
+      }
+   # Drain with a short select bound so a hang fails the suite instead
+   # of wedging CI.  5s is generous for a local/LAN printf.
+   got := ""
+   every 1 to 50 do {
+      L := select(s, 100) | break
+      if *L = 0 then next
+      chunk := reads(s, 64) | break
+      got ||:= chunk
+      if find("partial_ssh_line", got) then break
+      }
+   write("live partial-reads: ",
+      if find("partial_ssh_line", got) then "pass" else "fail")
    close(s)
 
    # Optional SFTP checks when a remote writable directory is provided

--- a/tests/posix/stand/select-io.std
+++ b/tests/posix/stand/select-io.std
@@ -1,0 +1,5 @@
+input-select: ok
+file-chunk-1: "ab"
+file-chunk-2: "cd"
+file-chunk-3: "ef"
+select-io done

--- a/tests/posix/stand/ssh.std
+++ b/tests/posix/stand/ssh.std
@@ -1,0 +1,7 @@
+feature _SSH: yes
+bad-attribute open fails: yes
+bad-channel open fails: yes
+channel=no+cmd open fails: yes
+connect-refused open fails: yes
+live round-trip: skipped (set UNICON_SSH_TESTHOST)
+ssh test done

--- a/uni/lib/Makefile
+++ b/uni/lib/Makefile
@@ -11,7 +11,7 @@ UFILES=gui.u file_dlg.u db.u \
  fcn_util.u group.u httpclient.u json.u langprocs.u listener.u \
  mailbox.u mailmisc.u mapbytes.u message.u messagehandler.u method.u \
  money.u msg.u multipart.u multiparthandler.u netclient.u noophandler.u object.u \
- packetspec.u icmp.u igmp.u \
+ packetspec.u icmp.u igmp.u ssh.u \
  popclient.u predicat.u process.u pushback.u qsort.u quotedprintablehandler.u \
  rfc822parser.u runnable.u args.u blockread.u notifier.u \
  selectiveclasscoding.u sem.u setfields.u shm.u smtpclient.u scan_util.u \

--- a/uni/lib/ssh.icn
+++ b/uni/lib/ssh.icn
@@ -1,0 +1,98 @@
+#<p>
+# Interactive SSH console helper for a channel opened with
+# <tt>open(host, "h", ...)</tt> (no <tt>cmd=</tt>).
+#</p>
+#<p>
+# Puts the local tty in raw mode, muxes <tt>&amp;input</tt> with the
+# remote channel via <tt>select()</tt>, and maps lone LF to CRLF when
+# copying remote output to the local terminal (needed because
+# raw mode disables ONLCR / local newline mapping).  Restores the tty
+# before returning.  Does not close <tt>s</tt> — the caller owns the file.
+#</p>
+#<p>
+# Example:
+#</p>
+#<pre>
+#  s := open("user@host", "h", "key=...") | stop(&errortext)
+#  ssh_interactive(s)
+#  close(s)
+#</pre>
+#<p>
+# For a custom loop (logging, key remapping, …), open the session
+# yourself and drive <tt>select</tt>/<tt>reads</tt>/<tt>writes</tt>;
+# keep channel I/O byte-faithful and only apply display CRLF when
+# writing to a raw local tty.
+#</p>
+#<p>
+# <b>Author:</b> Jafar Al-Gharaibeh
+#</p>
+
+package net
+
+#<p>
+# Save/restore helpers via <tt>Attrib(&amp;input, "tty=…")</tt>
+# (termios on Unix, console modes on Windows).  Failures are ignored
+# when stdin is not a tty (e.g. automated runs).
+#</p>
+procedure ssh_tty_raw()
+   Attrib(&input, "tty=sane") | &null   # undo a prior crashed client
+   Attrib(&input, "tty=raw") | &null
+end
+
+procedure ssh_tty_sane()
+   Attrib(&input, "tty=sane") | &null
+end
+
+#<p>
+# Write <tt>s</tt> to <tt>&amp;output</tt>, inserting CR before each lone LF.
+#</p>
+procedure ssh_raw_writes(s)
+   local out, i, c, prev
+   out := ""
+   prev := ""
+   every i := 1 to *s do {
+      c := s[i]
+      if c == "\n" & prev ~== "\r" then
+         out ||:= "\r\n"
+      else
+         out ||:= c
+      prev := c
+      }
+   writes(&output, out)
+end
+
+#<p>
+# Run an interactive SSH shell session on channel file <tt>s</tt>.
+# Returns after remote EOF or local stdin EOF.  Fails if a write to
+# the channel fails (tty is still restored).
+# <[param s SSH channel file from open(..., "h")]>
+#</p>
+procedure ssh_interactive(s)
+   local L, f, data
+
+   ssh_tty_raw()
+   while L := select(s, &input) do {
+      every f := !L do {
+         if f === &input then {
+            data := reads(&input, 1) | {
+               ssh_tty_sane()
+               return
+               }
+            writes(s, data) | {
+               ssh_tty_sane()
+               fail
+               }
+            }
+         else {
+            data := reads(s, 4096) | {
+               ssh_tty_sane()
+               writes(&errout, "\r\n[remote closed]\r\n")
+               return
+               }
+            ssh_raw_writes(data)
+            }
+         }
+      }
+   ssh_tty_sane()
+   return
+end

--- a/uni/progs/Makefile
+++ b/uni/progs/Makefile
@@ -4,7 +4,7 @@ include $(UNICON_TOP_BUILDDIR)/Makedefs.uni
 
 BINPROGS=ie uprof  umake 
 PROGS= idxGen uget splitmail csv genAcc heap_demo mapStrings rpn \
-	uping uigmp $(BINPROGS)
+	uping uigmp ussh $(BINPROGS)
 
 all: $(PROGS)
 	$(CP) $(BINPROGS) ../../bin
@@ -50,6 +50,9 @@ uping: uping.icn
 
 uigmp: uigmp.icn
 	$(UNICON) $(UFLAGS) uigmp
+
+ussh: ussh.icn
+	$(UNICON) $(UFLAGS) ussh
 
 clean Clean:
 	@$(RM) $(PROGS) *.exe uniclass.pag uniclass.dir uniclass.db

--- a/uni/progs/ussh.icn
+++ b/uni/progs/ussh.icn
@@ -1,0 +1,92 @@
+#
+# ussh.icn - native SSH client demo (libssh / open() mode "h")
+#
+# Build:  unicon ussh
+# Run:    ./ussh user@host                 # interactive shell
+#         ./ussh user@host uname -a        # run a remote command
+#         ./ussh -n user@host uptime       # skip known_hosts check
+#         ./ussh -i ~/.ssh/id_ed25519 user@host
+#
+# Needs a Unicon build with the "secure shell" feature (&features).
+# Interactive mode uses net::ssh_interactive() (works on Unix and
+# Windows console iconx: select(&input) + Attrib(&input, "tty=…")).
+#
+
+import net
+link options
+
+procedure usage()
+   stop("Usage: ", &progname, " [-n] [-i key] [-p password] user@host [command...]\n",
+        "  -n            skip host-key verification (open mode \"h-\")\n",
+        "  -i key        private key path (default: agent / ~/.ssh identities)\n",
+        "  -p password   login password (prefer keys; visible in process list)\n",
+        "  -h            show this help\n",
+        "  user@host     optional :port, or [ipv6]:port\n",
+        "  command...    if present, run remotely and print output; else shell")
+end
+
+#
+# Expand a leading ~/ using HOME (libssh does not do this for key=).
+#
+procedure expand_path(p)
+   local home
+   p := ::string(p)
+   if p[1] == "~" & (*p = 1 | p[2] == "/") then {
+      home := getenv("HOME") | fail
+      if *p = 1 then
+         return home
+      return home || p[2:0]
+      }
+   return p
+end
+
+procedure main(argv)
+   local opts, host, cmd, mode, key, attrs, s, m, i
+
+   opts := options(argv, "ni:p:h")
+   if \opts["h"] then
+      usage()
+
+   host := argv[1] | usage()
+   cmd := &null
+   if *argv >= 2 then {
+      cmd := argv[2]
+      every i := 3 to *argv do
+         cmd ||:= " " || argv[i]
+      }
+
+   (&features == "secure shell") |
+      stop("this Unicon build has no SSH support (need libssh at configure time)")
+
+   mode := if /opts["n"] then "h" else "h-"
+   attrs := [host, mode]
+   if key := \opts["i"] then
+      put(attrs, "key=" || (expand_path(key) | stop("bad -i path")))
+   if \opts["p"] then
+      put(attrs, "password=" || opts["p"])
+   if \cmd then
+      put(attrs, "cmd=" || cmd)
+
+   write(&errout, "Connecting to ", host, " ...")
+   s := open ! attrs | stop("open failed: ", &errortext)
+   write(&errout, "connected.")
+
+   if \cmd then {
+      #
+      # One-shot remote command: preserve stdout/stderr order via receive().
+      #
+      while m := receive(s) do {
+         if m.addr == "stdout" then
+            writes(&output, m.msg)
+         else if m.addr == "stderr" then
+            writes(&errout, m.msg)
+         else if m.addr == "exit" then
+            write(&errout, "[exit ", trim(m.msg), "]")
+         }
+      close(s)
+      return
+      }
+
+   ssh_interactive(s) | stop("session write failed: ", &errortext)
+   close(s)
+end


### PR DESCRIPTION
Add `open(..., "h")` for SSH sessions (`user@host[:port]`, auth attrs, `channel=yes/no`), multi-channel and SFTP on the same connection, ordered `receive()` / Attrib events, `configure/--disable-ssh` plumbing, docs, and posix tests.