### PR TITLE
Update tests/unicon/Makefile

### DIFF
--- a/tests/unicon/Makefile
+++ b/tests/unicon/Makefile
@@ -22,6 +22,6 @@ include ../Makefile.test
 
 # Precompiled package for import testing (list_test, FxPtTest).
 tester.u: data/tester.icn
-	@$(UC) -s -u -c $^
+	cd data; ../$(UC) -s -u -c tester.icn
 
 list_test FxPtTest: | tester.u


### PR DESCRIPTION
The Makefile doesn't properly compile the tester.icn file in the data directory.

The Makefile is updated to do this correctly.

This fixes the two failed tests 