### PR TITLE
Docupdates - correcting a number of spelling mistakes and format fixes in Unicon book

### DIFF
--- a/doc/book/admin.tex
+++ b/doc/book/admin.tex
@@ -243,7 +243,7 @@ Instead of checking to see if the list has only one element, the code
 checks to see if the value from the table is a string, and ignores
 those entries.
 
-The scan procedure has to do a little more work. Instead of initializing
+The \textt{scan} procedure has to do a little more work. Instead of initializing
 the value to a list, you can use the name of the current file; if the
 value already in the table is a string, create a list and add both the
 name from the table and the name of the current file to the list. If
@@ -547,7 +547,7 @@ procedure du(dir) \\
 end
 }
 
-Using this procedure, the program fills in the table of usages.
+Using this procedure, the program fills in the table of \testtt{usages}.
 
 \iconcode{
 \>   L := read\_db(db) \\
@@ -702,11 +702,11 @@ absent in which case 0 is \\
 
 If multiple quota lines occur for a directory, the tables must be
 updated appropriately. The semantics of the tables require varying
-approaches. The owners table writes a warning message if quota lines
+approaches. The \texttt{owners} table writes a warning message if quota lines
 with different owners for the same directory are found, but otherwise
-the owners table is unaffected by multiple entries. The actual quotas
+the \texttt{owners} table is unaffected by multiple entries. The actual \texttt{quotas}
 table allows multiple quota lines for a directory; in which case the
-quotas are added together. The daysover table retains the maximum value
+quotas are added together. The \textt{daysover} table retains the maximum value
 any quota line is overdue for a directory. 
 
 \iconcode{
@@ -1235,7 +1235,7 @@ params["inbox"], message) \\
 end
 }
 
-Since the patterns are regular expressions, we link in the IPL regexp
+Since the patterns are regular expressions, we link in the IPL \texttt{regexp}
 package for the procedure \texttt{ReFind()} that will do the pattern
 matching.
 
@@ -1257,7 +1257,7 @@ the top of the program) to call the procedure associated with each
 defined action. The function \texttt{proc()} tries to find the
 procedure with the right name; if it fails, it is an unknown action.
 The names of these procedures all have the form
-{\textquotedblleft}filterproc\_{\textquotedblright} appeneded with the
+{\textquotedblleft}filterproc\_{\textquotedblright} appended with the
 name of the action. We make sure that the procedures succeed if there
 was no error in performing the action.
 

--- a/doc/book/admin.tex
+++ b/doc/book/admin.tex
@@ -243,7 +243,7 @@ Instead of checking to see if the list has only one element, the code
 checks to see if the value from the table is a string, and ignores
 those entries.
 
-The \textt{scan} procedure has to do a little more work. Instead of initializing
+The \texttt{scan} procedure has to do a little more work. Instead of initializing
 the value to a list, you can use the name of the current file; if the
 value already in the table is a string, create a list and add both the
 name from the table and the name of the current file to the list. If
@@ -547,7 +547,7 @@ procedure du(dir) \\
 end
 }
 
-Using this procedure, the program fills in the table of \testtt{usages}.
+Using this procedure, the program fills in the table of \texttt{usages}.
 
 \iconcode{
 \>   L := read\_db(db) \\
@@ -706,7 +706,7 @@ approaches. The \texttt{owners} table writes a warning message if quota lines
 with different owners for the same directory are found, but otherwise
 the \texttt{owners} table is unaffected by multiple entries. The actual \texttt{quotas}
 table allows multiple quota lines for a directory; in which case the
-quotas are added together. The \textt{daysover} table retains the maximum value
+quotas are added together. The \texttt{daysover} table retains the maximum value
 any quota line is overdue for a directory. 
 
 \iconcode{

--- a/doc/book/advanced.tex
+++ b/doc/book/advanced.tex
@@ -453,7 +453,7 @@ end
 
 When producer resumes consumer, it passes \texttt{value}; the consumer
 passes a return code (\texttt{retval}) back. \texttt{\&source} is the
-coexpression that activated the current co-expression.
+co-expression that activated the current co-expression.
 
 {\sffamily\bfseries
 Note}

--- a/doc/book/cgi.tex
+++ b/doc/book/cgi.tex
@@ -374,12 +374,12 @@ CGI scripts under a special userid such as
 id. Some web servers run CGI scripts under a protected file system
 where the root directory "/" is not the
 same as the root directory visible to your user account, so the path to
-iconx that you normally use may be invalid in your CGI program. CGI
+\testtt{iconx} that you normally use may be invalid in your CGI program. CGI
 scripts may have a very limited PATH for security reasons, not the PATH
 you set for your user account. \ Your best bet is probably to use the
 -B Unicon compiler option to bundle the Unicon interpreter into your
 executable file; alternatively you can probably copy the virtual
-machine "iconx" into your cgi-bin directory
+machine \texttt{iconx} into your cgi-bin directory
 
 Debugging your CGI program itself may require special tricks. Because
 your CGI program is executed by a web server, its standard error output
@@ -406,7 +406,7 @@ temporary file with a \texttt{.txt} extension, and writes a nicely
 formatted document containing the user's scholarship
 application information.
 
-The code for Appform is shown in Listing 14-2. To run it you must
+The code for \texttt{Appform} is shown in Listing 14-2. To run it you must
 adapt it to your environment. As written, it prints to
 \texttt{lpr}, and sends mail to \texttt{jeffery@cs.uidaho.edu}. When running a
 CGI script it is important to realize you will run in a different

--- a/doc/book/cgi.tex
+++ b/doc/book/cgi.tex
@@ -374,7 +374,7 @@ CGI scripts under a special userid such as
 id. Some web servers run CGI scripts under a protected file system
 where the root directory "/" is not the
 same as the root directory visible to your user account, so the path to
-\testtt{iconx} that you normally use may be invalid in your CGI program. CGI
+\texttt{iconx} that you normally use may be invalid in your CGI program. CGI
 scripts may have a very limited PATH for security reasons, not the PATH
 you set for your user account. \ Your best bet is probably to use the
 -B Unicon compiler option to bundle the Unicon interpreter into your

--- a/doc/book/database.tex
+++ b/doc/book/database.tex
@@ -322,15 +322,15 @@ name or IP address, the port, and the database to connect to. For that
 triplet, you get to define a name called a DSN or data source name,
 which is the name that Unicon will pass in to \texttt{open()}. In the
 Windows dialog, this name is a text field explicitly named as a DSN,
-while in the Linux odbc.ini file, it is at the top, inside the square
+while in the Linux \texttt{odbc.ini} file, it is at the top, inside the square
 brackets.
 
 In both cases, there are a lot of additional options which are beyond
 the scope of this book.  On Windows, each ODBC driver may have its own
-custom dialogs for configuration, while on Linux the odbc.ini file is
+custom dialogs for configuration, while on Linux the \texttt{odbc.ini} file is
 more the property of the driver manager and is used to configure all
 the various drivers. As a fair warning, the details required in the
-dialogs or the exact syntax of the odbc.ini and its required entries
+dialogs or the exact syntax of the \texttt{odbc.ini} and its required entries
 for a given driver change slightly from time to time and are beyond
 the scope of this book.  Consult current ODBC documentation for the
 driver manager on your platform and the specific database to which
@@ -374,13 +374,13 @@ driver manager.
 Mode \texttt{"o"} is followed by additional string arguments to
 \texttt{open()}. The first is an optional default table name used in
 the various functions that take a table name.  Applications that send
-their own custom SQL strings via the sql() function may find that
+their own custom SQL strings via the \texttt{sql()} function may find that
 their SQL strings always specify what table they are operating on,
 rendering this optional parameter unnecessary.  The next two arguments
 are the user name and password to use in connecting to the specified
 data source. Here is an example that establishes connections to a
-database (unicondb) as user scott with password tiger, with and
-without specifying an initial table mydbtable.  Most applications
+database (unicondb) as user \texttt{scott} with password \texttt{tiger}, with and
+without specifying an initial table \texttt{mydbtable}.  Most applications
 will not need two open connections to their database, but see below
 for an example that does.
 
@@ -431,8 +431,8 @@ To walk through the rows of your current database selection, you call
 \index{fetch()!SQL}\texttt{fetch(db)}. The value returned is a
 \textit{row} that has many of the operations of a record or a table,
 namely field access and subscripting operators. For example, if
-\texttt{fetch(db)} returns a row containing columns Name, Address, and
-Phone, you can write
+\texttt{fetch(db)} returns a row containing columns \texttt{Name}, \texttt{Address}, and
+\texttt{Phone}, you can write
 
 \iconcode{
 row := fetch(db) \\

--- a/doc/book/diffs.tex
+++ b/doc/book/diffs.tex
@@ -17,7 +17,7 @@ list, \texttt{reverse()} reverses a list, and so forth.
 The keywords \texttt{\&clock}\index{\&clock} and
 \texttt{\&dateline}\index{\&dateline}
 have been extended to generate timezone information. The extensions
-may alter the behavour of Icon programs that use these keywords in a
+may alter the behavior of Icon programs that use these keywords in a
 context where failure is possible.
 
 \section{Objects}

--- a/doc/book/experimental.tex
+++ b/doc/book/experimental.tex
@@ -644,7 +644,7 @@ There is, in essence, an unfortunate trade-off between performance and
 convenience: for maximum throughput the only way is to eschew the
 \texttt{SQLite} class, use the utility procedures or the low level interface
 routines explicitly, do as much as possible in parallel and deal with
-\texttt{SQLITE\_BUSY} wherever it occcurs.  In practice, the \texttt{SQLite}
+\texttt{SQLITE\_BUSY} wherever it occurs.  In practice, the \texttt{SQLite}
 class performs tolerably well and it is only those applications that demand the
 best performance and the highest possible level of parallel access to the
 database that may feel the need to replace it. In those circumstances, it

--- a/doc/book/graphics.tex
+++ b/doc/book/graphics.tex
@@ -61,7 +61,7 @@ graphics program might look like this:
 Windows are open for both reading and writing, and support the usual
 file operations with the exceptions of \texttt{seek()} and
 \texttt{where()}. Unlike regular files, the \texttt{type()} of a
-window is "window". Like other files, windows close automatically when
+window is \texttt{"window"}. Like other files, windows close automatically when
 the program terminates, so the call to \texttt{close()} in the above
 example is optional.
 
@@ -945,12 +945,12 @@ the scene. Anything on the positive z-axis is behind the
 viewer. Finally, the up direction can be described by what direction
 is up for the person.
 
-The eye position is given by the attribute eyepos. By default this is
+The eye position is given by the attribute \texttt{eyepos}. By default this is
 set to be at the origin or (0, 0, 0). The eye direction is given by
-the attribute eyedir. By default this is set to be looking at the
+the attribute \texttt{eyedir}. By default this is set to be looking at the
 negative z-axis. The up direction can be specified by the attribute
-eyeup and by default is (0, 1, 0). The attribute eye allows the user
-to specify eyepos, eyedir, and eyeup with a single value. Changing any
+\texttt{eyeup} and by default is (0, 1, 0). The attribute \texttt{eye} allows the user
+to specify \texttt{eyepos}, \texttt{eyedir}, and \texttt{eyeup} with a single value. Changing any
 of these attributes causes the scene to redraw itself with the new eye
 specifications.
 

--- a/doc/book/gui.tex
+++ b/doc/book/gui.tex
@@ -2449,7 +2449,7 @@ communicated to the main thread (either via global variables or via Unicon's mes
 passing facilities) and mutual exclusion must be employed -- as in any concurrent program
 using shared data. The main thread cannot wait indefinitely for new results, because this
 will ``freeze'' the display if no new data is forthcoming. Instead, the main thread must
-poll for new data, probably best achieved by using the toolkit's ticker facilites.
+poll for new data, probably best achieved by using the toolkit's ticker facilities.
 
 \subsection*{Parameters}
 

--- a/doc/book/ipl.tex
+++ b/doc/book/ipl.tex
@@ -3666,8 +3666,8 @@ matrix\\
 \texttt{set\_scale(x, y) : matrix} produces a matrix for scaling\\
 \texttt{set\_trans(x, y) : matrix} produces a matrix for
 translation\\
-\texttt{set\_xshear(x) : matrix} produces a matrix for\texttt{x}shear\\
-\texttt{set\_yshear(y) : matrix} produces a matrix for y shear\\
+\texttt{set\_xshear(x) : matrix} produces a matrix for \texttt{x} shear\\
+\texttt{set\_yshear(y) : matrix} produces a matrix for \texttt{y} shear\\
 \texttt{set\_rotate(x) : matrix} produces a matrix for rotation
 
 Links: \texttt{gobject}. See also: \texttt{matrix}. (SBW, REG)

--- a/doc/book/ipl.tex
+++ b/doc/book/ipl.tex
@@ -1143,7 +1143,7 @@ Requires: co-expressions. Links: \texttt{io}, \texttt{fastfncs},
 read}mail folder and generates a sequence of records, one per message,
 failing when end-of-file is reached. Each record contains the message
 header and message text components parsed into fields. The argument x
-is either the name or the file handle. If getmail() is resumed after
+is either the name or the file handle. If \texttt{getmail()} is resumed after
 the last message is generated, it closes the mail folder and returns
 failure. If \texttt{getmail()} generates an incomplete sequence (does
 not close the folder and return failure) and is then restarted (not
@@ -1261,7 +1261,7 @@ of function names. Links: \texttt{ifncs}.
 processing. Style 1 is indented, with ] and ) at end of last item.
 Style 2 is also indented, with ] and ) on new line. Style 3 puts the
 whole image on one line. Style 4 is like style 3, with structures
-expanded breadthfirst instead of depthfirst as for other styles.
+expanded breadth-first instead of depth-first as for other styles.
 
 Structures are identified by a letter identifying the type followed by
 an integer. The tag letters are \texttt{"L"} for lists,
@@ -1483,10 +1483,10 @@ Requires: UNIX. Links: \texttt{iolib}.
 customizable sort procedure. \texttt{x} can be any Icon data type that
 supports the unary element generation (!) operator. The result is a
 sorted list of objects. The sort keys are obtained by calling
-keyproc() on each element of strucure \texttt{x} to obtain the sort
+\texttt{keyproc()} on each element of structure \texttt{x} to obtain the sort
 key for that element. If
 \texttt{keyproc} is a procedure, the first argument to each call to
-keyproc() is the element for which the key is to be computed,
+\texttt{keyproc()} is the element for which the key is to be computed,
 and the second argument is isort's argument
 \texttt{y}, passed unchanged. The \texttt{keyproc} must produce the
 extracted key. Alternatively, \texttt{keyproc} can be an integer, in
@@ -1646,17 +1646,17 @@ reversal to produce a palindrome.\\
 end conditions: 0 = omit first and last elements,\\
  \ \ \ \ 1 = omit first element, 2 = omit last element,
  3 = don't omit element.\\
-\texttt{lremvals(L, x1, x2, ...) : list} produces a copy of L with
+\texttt{lremvals(L, x1, x2, ...) : list} produces a copy of \texttt{L} with
 x1, x2, ... removed\\
-\texttt{lrepl(L,i):L} \index{replicate list}\index{replicate list}replicates L i
+\texttt{lrepl(L,i):L} \index{replicate list}\index{replicate list}replicates \texttt{L} i
 times.\\
 \texttt{lrotate(L,i):L} produces a list with the elements of L, rotated i
 positions.\\
-\texttt{lrpad(L,i,x):L} is like lextend(), but produces a new list instead of
+\texttt{lrpad(L,i,x):L} is like \texttt{lextend()}, but produces a new list instead of
 changing L.\\
-\texttt{lrtrim(L,S:set):L} produces a copy of L with elements of S trimmed on
+\texttt{lrtrim(L,S:set):L} produces a copy of \texttt{L} with elements of \texttt{S} trimmed on
  the left.\\
-\texttt{lswap(L):L} produces a copy of L with odd elements swapped with even
+\texttt{lswap(L):L} produces a copy of \texttt{L} with odd elements swapped with even
 elements.\\
 \texttt{lunique(L):L} produces a list containing only unique list elements.
 
@@ -1812,7 +1812,7 @@ sequences (lists). Suppose, for example, you wanted to
 "hell" and
 "shit" with
 "heck" and
-"shoot." You would call mapstrs as
+"shoot." You would call \texttt{mapstrs} as
 follows:\\
 \texttt{mapstrs(s, ["hell",
 "shit"],
@@ -2091,7 +2091,7 @@ every writes(outtext, outbits(!L,3)) \\
 writes(outtext, outbits(\&null,3)) \# flush buffer
 }
 
-\noindent List L may be reconstructed with \texttt{inbits()}:
+\noindent List \texttt{L} may be reconstructed with \texttt{inbits()}:
 
 \iconcode{
 intext := open("some.file.name") \\
@@ -2341,7 +2341,7 @@ An hyphen after the percent sign indicates left justification,
 otherwise right justification is used. A number of digits after the
 percent sign may specify the minimum width of the field to use, or after
 a period they specify a number of digits of precision. For example,
-\texttt{printf("\%-5.2r", x)} specifies that real number x be
+\texttt{printf("\%-5.2r", x)} specifies that real number \texttt{x} be
 formatted as a string of at least 5 characters, left justified,
 with two digits after the decimal point.
 
@@ -2351,7 +2351,7 @@ with two digits after the decimal point.
 \vspace{0.25cm}\hrule\vspace{0.1cm}{\noindent\texttt{prockind}}
 
 \texttt{prockind(p:procedure) : string?} produces a code for the kind of
-the procedure p as follows: \texttt{"p"}
+the procedure \texttt{p} as follows: \texttt{"p"}
 (declared) procedure \texttt{"f"}
 (built-in) function, \texttt{"o"} operator,
 \texttt{"c"} record
@@ -2727,8 +2727,8 @@ within \texttt{[string]} regular expressions.
 \vspace{0.25cm}\hrule\vspace{0.1cm}{\noindent\texttt{repetit}}
 
 \texttt{repetit(L:list) : integer} returns the length of the smallest
-range of values that repeat in a list. For example, if L := [1, 2, 3,
-1, 2, 3, 1, 2, 3] , \texttt{repetit(L)} returns \texttt{3}. If there is
+range of values that repeat in a list. For example, if \texttt{L := [1, 2, 3,
+1, 2, 3, 1, 2, 3]} , \texttt{repetit(L)} returns \texttt{3}. If there is
 no repetition, \texttt{repetit()} returns the length of the list. 
 
 \pagebreak
@@ -2820,7 +2820,7 @@ strings \texttt{s1} and \texttt{s2}, are also excluded from balancing.
 In addition, if \texttt{s1} is given and \texttt{s2} is null then the
 \index{comment}comment terminates at the end of string.
 
-\texttt{limatch(L:list, c:cset) : integer?} matches items in L delimited
+\texttt{limatch(L:list, c:cset) : integer?} matches items in \texttt{L} delimited
 by characters in c. Returns the last cursor position scanned to, or
 fails 
 
@@ -3666,7 +3666,7 @@ matrix\\
 \texttt{set\_scale(x, y) : matrix} produces a matrix for scaling\\
 \texttt{set\_trans(x, y) : matrix} produces a matrix for
 translation\\
-\texttt{set\_xshear(x) : matrix} produces a matrix for x shear\\
+\texttt{set\_xshear(x) : matrix} produces a matrix for\texttt{x}shear\\
 \texttt{set\_yshear(y) : matrix} produces a matrix for y shear\\
 \texttt{set\_rotate(x) : matrix} produces a matrix for rotation
 


### PR DESCRIPTION
A number of spelling mistakes have been corrected using the US language as the reference. 

A number of format corrections to bring a variety of terms into the same format.